### PR TITLE
Fixed Input cursor when dealing with UTF8 charcters

### DIFF
--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -156,7 +156,7 @@ fn init_view() -> View {
             input::InputPropsBuilder::default()
                 .with_borders(Borders::ALL, BorderType::Rounded, Color::LightYellow)
                 .with_foreground(Color::LightYellow)
-                .with_input(InputType::Password)
+                .with_input(InputType::Text)
                 .with_label(String::from("Type in your password"))
                 .build(),
         )),

--- a/src/components/input.rs
+++ b/src/components/input.rs
@@ -495,6 +495,42 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     #[test]
+    fn test_components_input_states() {
+        let mut states: OwnStates = OwnStates::default();
+        states.append('a', InputType::Text, Some(3));
+        assert_eq!(states.input, vec!['a']);
+        states.append('b', InputType::Text, Some(3));
+        assert_eq!(states.input, vec!['a', 'b']);
+        states.append('c', InputType::Text, Some(3));
+        assert_eq!(states.input, vec!['a', 'b', 'c']);
+        // Reached length
+        states.append('d', InputType::Text, Some(3));
+        assert_eq!(states.input, vec!['a', 'b', 'c']);
+        // Push char to numbers
+        states.append('d', InputType::Number, None);
+        assert_eq!(states.input, vec!['a', 'b', 'c']);
+        // move cursor
+        // decr cursor
+        states.decr_cursor();
+        assert_eq!(states.cursor, 2);
+        states.cursor = 1;
+        states.decr_cursor();
+        assert_eq!(states.cursor, 0);
+        states.decr_cursor();
+        assert_eq!(states.cursor, 0);
+        // Incr
+        states.incr_cursor();
+        assert_eq!(states.cursor, 1);
+        states.incr_cursor();
+        assert_eq!(states.cursor, 2);
+        states.incr_cursor();
+        assert_eq!(states.cursor, 3);
+        // Render value
+        assert_eq!(states.render_value(InputType::Text).as_str(), "abc");
+        assert_eq!(states.render_value(InputType::Password).as_str(), "***");
+    }
+
+    #[test]
     fn test_components_input_text() {
         // Instantiate Input with value
         let mut component: Input = Input::new(

--- a/src/components/utils.rs
+++ b/src/components/utils.rs
@@ -135,6 +135,14 @@ pub fn get_block<'a>(props: &BordersProps, title: &Option<String>, focus: bool) 
     }
 }
 
+/// ### calc_utf8_cursor_position
+///
+/// Calculate the UTF8 compliant position for the cursor given the characters preceeding the cursor position.
+/// Use this function to calculate cursor position whenever you want to handle UTF8 texts with cursors
+pub fn calc_utf8_cursor_position(chars: &[char]) -> u16 {
+    chars.iter().collect::<String>().width() as u16
+}
+
 #[cfg(test)]
 mod test {
 
@@ -213,5 +221,20 @@ mod test {
         };
         get_block(&props, &Some(String::from("title")), true);
         get_block(&props, &None, false);
+    }
+
+    #[test]
+    fn test_components_utils_calc_utf8_cursor_position() {
+        let chars: Vec<char> = vec!['v', 'e', 'e', 's', 'o'];
+        // Entire
+        assert_eq!(calc_utf8_cursor_position(chars.as_slice()), 5);
+        assert_eq!(calc_utf8_cursor_position(&chars[0..3]), 3);
+        // With special characters
+        let chars: Vec<char> = vec!['я', ' ', 'х', 'о', 'ч', 'у', ' ', 'с', 'п', 'а', 'т', 'ь'];
+        assert_eq!(calc_utf8_cursor_position(&chars[0..6]), 6);
+        let chars: Vec<char> = vec!['H', 'i', '😄'];
+        assert_eq!(calc_utf8_cursor_position(chars.as_slice()), 4);
+        let chars: Vec<char> = vec!['我', '之', '😄'];
+        assert_eq!(calc_utf8_cursor_position(chars.as_slice()), 6);
     }
 }


### PR DESCRIPTION
# Issue 5 - Issue when input chinese characters

Fixes #5 

## Description

The issue was caused by the fact that the x of the cursor for input was calculated using the lenght of the input string, but some characters (such as emojis), uses two characters on terminals; so unicode length must be used.

- Get cursor X using unicode_width characters iterating over input chars

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [ ] I increased or maintained the code coverage for the project, compared to the previous commit
