### PR TITLE
Tui 0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,45 @@
 
 Released on ??
 
-- Compatibility with tui `0.16` and crossterm `0.20`
-- Added `title` to `Props`
-- `BlockTitle` type in `Props`
+- ❗ Compatibility with tui `0.16` and crossterm `0.20` ❗
+  - You can now set the block title alignment
+    - Added `title` to `Props`
+    - `BlockTitle` type in `Props`, which is made up of `text` and `alignment`. Use this instead of setting title in `own` map
+  - 🔴 A really bad new in `Msg` matching 😭
+
+      in crossterm `0.20` to solve an issue they removed the `#[derive(Eq, PartialEq)]` from `KeyEvent`.
+      This has now caused an issue when matching against `OnKey` events:
+
+      ```txt
+      error: to use a constant of type `KeyEvent` in a pattern, `KeyEvent` must be annotated with `#[derive(PartialEq, Eq)]`
+      ```
+
+      To solve this issue you must from now on use a guard match to match keys:
+
+      ```rust
+      fn update(model: &mut Model, view: &mut View, msg: Option<(String, Msg)>) -> Option<(String, Msg)> {
+          let ref_msg: Option<(&str, &Msg)> = msg.as_ref().map(|(s, msg)| (s.as_str(), msg));
+          match ref_msg {
+              None => None, // Exit after None
+              Some(msg) => match msg {
+                  (COMPONENT_COUNTER1, key) if key == &MSG_KEY_TAB => {
+                      view.active(COMPONENT_COUNTER2);
+                      None
+                  }
+                  (COMPONENT_COUNTER2, key) if key == &MSG_KEY_TAB => {
+                      view.active(COMPONENT_COUNTER1);
+                      None
+                  }
+                  (_, key) if key == &MSG_KEY_ESC => {
+                      // Quit on esc
+                      model.quit();
+                      None
+                  }
+                  _ => None,
+              },
+          }
+      }
+      ```
 
 ## 0.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - [Changelog](#changelog)
+  - [0.6.0](#060)
   - [0.5.1](#051)
   - [0.5.0](#050)
   - [0.4.3](#043)
@@ -15,6 +16,14 @@
   - [0.1.0](#010)
 
 ---
+
+## 0.6.0
+
+Released on ??
+
+- Compatibility with tui `0.16` and crossterm `0.20`
+- Added `title` to `Props`
+- `BlockTitle` type in `Props`
 
 ## 0.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ## 0.6.0
 
-Released on ??
+Released on 03/08/2021
 
 - ❗ Compatibility with tui `0.16` and crossterm `0.20` ❗
   - You can now set the block title alignment

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuirealm"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Christian Visintin"]
 edition = "2018"
 categories = ["command-line-utilities"]
@@ -14,8 +14,8 @@ readme = "README.md"
 repository = "https://github.com/veeso/tui-realm"
 
 [dependencies]
-tui = { version = "0.15.0", default-features = false, features = ["crossterm"] }
-crossterm = { version = "0.19" }
+tui = { version = "0.16.0", default-features = false, features = ["crossterm"] }
+crossterm = { version = "0.20" }
 
 [dev-dependencies]
 pretty_assertions = "0.7.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuirealm"
-version = "0.5.2"
+version = "0.6.0"
 authors = ["Christian Visintin"]
 edition = "2018"
 categories = ["command-line-utilities"]

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
   <img src="docs/images/tui-realm.svg" width="256" height="256" />
 </p>
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-teal.svg)](https://opensource.org/licenses/MIT) [![Stars](https://img.shields.io/github/stars/veeso/tui-realm.svg)](https://github.com/veeso/tui-realm) [![Downloads](https://img.shields.io/crates/d/tuirealm.svg)](https://crates.io/crates/tuirealm) [![Crates.io](https://img.shields.io/badge/crates.io-v0.5.1-orange.svg)](https://crates.io/crates/tuirealm) [![Docs](https://docs.rs/tuirealm/badge.svg)](https://docs.rs/tuirealm)  
+[![License: MIT](https://img.shields.io/badge/License-MIT-teal.svg)](https://opensource.org/licenses/MIT) [![Stars](https://img.shields.io/github/stars/veeso/tui-realm.svg)](https://github.com/veeso/tui-realm) [![Downloads](https://img.shields.io/crates/d/tuirealm.svg)](https://crates.io/crates/tuirealm) [![Crates.io](https://img.shields.io/badge/crates.io-v0.6.0-orange.svg)](https://crates.io/crates/tuirealm) [![Docs](https://docs.rs/tuirealm/badge.svg)](https://docs.rs/tuirealm)  
 
 [![Build](https://github.com/veeso/tui-realm/workflows/Linux/badge.svg)](https://github.com/veeso/tui-realm/actions) [![Build](https://github.com/veeso/tui-realm/workflows/MacOS/badge.svg)](https://github.com/veeso/tui-realm/actions) [![Build](https://github.com/veeso/tui-realm/workflows/Windows/badge.svg)](https://github.com/veeso/tui-realm/actions) [![Coverage Status](https://coveralls.io/repos/github/veeso/tui-realm/badge.svg?branch=main)](https://coveralls.io/github/veeso/tui-realm?branch=main)
 
 Developed by Christian Visintin  
-Current version: 0.5.1 (31/07/2021)
+Current version: 0.6.0 (31/07/2021)
 
 ---
 
@@ -51,13 +51,13 @@ Tui-realm also comes with a standard library of components, which can be added t
 ### Add tui-realm to your Cargo.toml 🦀
 
 ```toml
-tuirealm = "0.5.1"
+tuirealm = "0.6.0"
 ```
 
 Since this library requires `crossterm` too, you'll also need to add it to your Cargo.toml
 
 ```toml
-crossterm = "0.19.0"
+crossterm = "0.20.0"
 ```
 
 You don't need tui as dependency, since you can access to tui via `tuirealm::tui::*`

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Build](https://github.com/veeso/tui-realm/workflows/Linux/badge.svg)](https://github.com/veeso/tui-realm/actions) [![Build](https://github.com/veeso/tui-realm/workflows/MacOS/badge.svg)](https://github.com/veeso/tui-realm/actions) [![Build](https://github.com/veeso/tui-realm/workflows/Windows/badge.svg)](https://github.com/veeso/tui-realm/actions) [![Coverage Status](https://coveralls.io/repos/github/veeso/tui-realm/badge.svg?branch=main)](https://coveralls.io/github/veeso/tui-realm?branch=main)
 
 Developed by Christian Visintin  
-Current version: 0.6.0 (31/07/2021)
+Current version: 0.6.0 (03/08/2021)
 
 ---
 
@@ -57,7 +57,7 @@ tuirealm = "0.6.0"
 Since this library requires `crossterm` too, you'll also need to add it to your Cargo.toml
 
 ```toml
-crossterm = "0.20.0"
+crossterm = "0.20"
 ```
 
 You don't need tui as dependency, since you can access to tui via `tuirealm::tui::*`

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -268,7 +268,7 @@ I will implement everything in a single file in this case and I will reproduce s
                         let msg = self.view.update(COMPONENT_LABEL, props);
                         self.update(msg)
                     }
-                    (_, &MSG_KEY_ESC) => {
+                    (_, key) if key == &MSG_KEY_ESC => {
                         // Quit on esc
                         self.quit();
                         None

--- a/docs/new-components.md
+++ b/docs/new-components.md
@@ -269,8 +269,14 @@ pub enum PropValue {
     F64(f64),
     F32(f32),
     Str(String),
-    Color(Color),
+    // -- tui props
+    Alignment(Alignment),
+    Dataset(Dataset),
     InputType(InputType),
+    Shape(Shape),
+    Style(Style),
+    Table(Table),
+    TextSpan(TextSpan),
 }
 ```
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -157,15 +157,15 @@ fn update(model: &mut Model, view: &mut View, msg: Option<(String, Msg)>) -> Opt
     match ref_msg {
         None => None, // Exit after None
         Some(msg) => match msg {
-            (COMPONENT_COUNTER1, &MSG_KEY_TAB) => {
+            (COMPONENT_COUNTER1, key) if key == &MSG_KEY_TAB => {
                 view.active(COMPONENT_COUNTER2);
                 None
             }
-            (COMPONENT_COUNTER2, &MSG_KEY_TAB) => {
+            (COMPONENT_COUNTER2, key) if key == &MSG_KEY_TAB => {
                 view.active(COMPONENT_COUNTER1);
                 None
             }
-            (_, &MSG_KEY_ESC) => {
+            (_, key) if key == &MSG_KEY_ESC => {
                 // Quit on esc
                 model.quit();
                 None

--- a/examples/utils/keymap.rs
+++ b/examples/utils/keymap.rs
@@ -27,7 +27,7 @@
  */
 extern crate crossterm;
 extern crate tuirealm;
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use tuirealm::event::{KeyCode, KeyEvent, KeyModifiers};
 use tuirealm::Msg;
 
 // -- keys

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //! ### Adding `tui-realm` as dependency
 //!
 //! ```toml
-//! tuirealm = "0.5.1"
+//! tuirealm = "0.6.0"
 //! ```
 //!
 //! ## Examples

--- a/src/props/builder.rs
+++ b/src/props/builder.rs
@@ -28,7 +28,7 @@
  * SOFTWARE.
  */
 use super::borders::{BorderType, Borders};
-use super::{PropPayload, Props};
+use super::{Alignment, BlockTitle, PropPayload, Props};
 
 use tui::style::{Color, Modifier};
 
@@ -136,6 +136,16 @@ impl GenericPropsBuilder {
             props.borders.borders = borders;
             props.borders.variant = variant;
             props.borders.color = color;
+        }
+        self
+    }
+
+    /// ### with_title
+    ///
+    /// Set title to element
+    pub fn with_title<S: AsRef<str>>(&mut self, text: S, alignment: Alignment) -> &mut Self {
+        if let Some(props) = self.props.as_mut() {
+            props.title = Some(BlockTitle::new(text, alignment));
         }
         self
     }
@@ -254,6 +264,7 @@ mod test {
             .rapid_blink()
             .slow_blink()
             .with_custom_color("arrows", Color::Red)
+            .with_title("Omar", Alignment::Center)
             .with_value(
                 "input",
                 PropPayload::One(PropValue::Str(String::from("Hello"))),
@@ -263,6 +274,8 @@ mod test {
         assert_eq!(props.borders.borders, Borders::BOTTOM);
         assert_eq!(props.borders.color, Color::White);
         assert_eq!(props.borders.variant, BorderType::Plain);
+        assert_eq!(props.title.as_ref().unwrap().text(), "Omar");
+        assert_eq!(props.title.as_ref().unwrap().alignment(), Alignment::Center);
         assert!(props.modifiers.intersects(Modifier::BOLD));
         assert!(props.modifiers.intersects(Modifier::ITALIC));
         assert!(props.modifiers.intersects(Modifier::UNDERLINED));

--- a/src/props/mod.rs
+++ b/src/props/mod.rs
@@ -35,12 +35,14 @@ pub mod borders;
 pub mod builder;
 pub mod dataset;
 pub mod texts;
+pub mod title;
 
 // Exports
 pub use borders::{Borders, BordersProps};
 pub use builder::{GenericPropsBuilder, PropsBuilder};
 pub use dataset::Dataset;
 pub use texts::{Table, TableBuilder, TextSpan};
+pub use title::BlockTitle;
 pub use tui::layout::Alignment;
 
 // -- Props
@@ -51,10 +53,11 @@ pub use tui::layout::Alignment;
 #[derive(Clone)]
 pub struct Props {
     // Values
-    pub visible: bool,         // Is the element visible ON CREATE?
-    pub foreground: Color,     // Foreground color
-    pub background: Color,     // Background color
-    pub borders: BordersProps, // Borders
+    pub visible: bool,             // Is the element visible ON CREATE?
+    pub foreground: Color,         // Foreground color
+    pub background: Color,         // Background color
+    pub borders: BordersProps,     // Borders
+    pub title: Option<BlockTitle>, // Block title
     pub modifiers: Modifier,
     pub palette: HashMap<&'static str, Color>, // Use palette to store extra colors
     pub own: HashMap<&'static str, PropPayload>, // Own properties (extra)
@@ -68,6 +71,7 @@ impl Default for Props {
             foreground: Color::Reset,
             background: Color::Reset,
             borders: BordersProps::default(),
+            title: None,
             modifiers: Modifier::empty(),
             palette: HashMap::new(),
             own: HashMap::new(),
@@ -503,6 +507,7 @@ mod tests {
         assert_eq!(props.borders.borders, Borders::ALL);
         assert_eq!(props.borders.color, Color::Reset);
         assert_eq!(props.borders.variant, BorderType::Plain);
+        assert_eq!(props.title.is_none(), true);
         assert_eq!(props.modifiers, Modifier::empty());
         assert_eq!(props.palette.len(), 0);
         assert_eq!(props.own.len(), 0);

--- a/src/props/title.rs
+++ b/src/props/title.rs
@@ -1,0 +1,75 @@
+//! ## Title
+//!
+//! `title` is the module which defines properties for block title
+
+/**
+ * MIT License
+ *
+ * tui-realm - Copyright (C) 2021 Christian Visintin
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+use super::Alignment;
+
+/// ## BlockTitle
+///
+/// Title properties for block containing the component
+#[derive(Clone)]
+pub struct BlockTitle {
+    text: String,
+    alignment: Alignment,
+}
+
+impl BlockTitle {
+    pub fn new<S: AsRef<str>>(text: S, alignment: Alignment) -> Self {
+        Self {
+            text: text.as_ref().to_string(),
+            alignment,
+        }
+    }
+
+    /// ### text
+    ///
+    /// get text alignment
+    pub fn text(&self) -> &str {
+        self.text.as_str()
+    }
+
+    /// ### alignment
+    ///
+    /// get block alignment
+    pub fn alignment(&self) -> Alignment {
+        self.alignment
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_props_title() {
+        let title: BlockTitle = BlockTitle::new("Omar", Alignment::Center);
+        assert_eq!(title.text(), "Omar");
+        assert_eq!(title.alignment, Alignment::Center); // not dropped
+        assert_eq!(title.alignment, Alignment::Center); // not dropped
+    }
+}


### PR DESCRIPTION
## 0.6.0

- ❗ Compatibility with tui `0.16` and crossterm `0.20` ❗
  - You can now set the block title alignment
    - Added `title` to `Props`
    - `BlockTitle` type in `Props`, which is made up of `text` and `alignment`. Use this instead of setting title in `own` map
  - 🔴 A really bad new in `Msg` matching 😭

      in crossterm `0.20` to solve an issue they removed the `#[derive(Eq, PartialEq)]` from `KeyEvent`.
      This has now caused an issue when matching against `OnKey` events:

      ```txt
      error: to use a constant of type `KeyEvent` in a pattern, `KeyEvent` must be annotated with `#[derive(PartialEq, Eq)]`
      ```

      To solve this issue you must from now on use a guard match to match keys:

      ```rust
      fn update(model: &mut Model, view: &mut View, msg: Option<(String, Msg)>) -> Option<(String, Msg)> {
          let ref_msg: Option<(&str, &Msg)> = msg.as_ref().map(|(s, msg)| (s.as_str(), msg));
          match ref_msg {
              None => None, // Exit after None
              Some(msg) => match msg {
                  (COMPONENT_COUNTER1, key) if key == &MSG_KEY_TAB => {
                      view.active(COMPONENT_COUNTER2);
                      None
                  }
                  (COMPONENT_COUNTER2, key) if key == &MSG_KEY_TAB => {
                      view.active(COMPONENT_COUNTER1);
                      None
                  }
                  (_, key) if key == &MSG_KEY_ESC => {
                      // Quit on esc
                      model.quit();
                      None
                  }
                  _ => None,
              },
          }
      }
      ```
