### PR TITLE
40 bug tricky problem about focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - [Changelog](#changelog)
+  - [1.7.1](#171)
   - [1.7.0](#170)
   - [1.6.0](#160)
   - [1.5.0](#150)
@@ -29,6 +30,12 @@
   - [0.1.0](#010)
 
 ---
+
+## 1.7.1
+
+Released on 03/08/2022
+
+- Fixed [issue 40](https://github.com/veeso/tui-realm/issues/40)
 
 ## 1.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 Released on 03/08/2022
 
 - Fixed [issue 40](https://github.com/veeso/tui-realm/issues/40)
+- Updated `crossterm` to `0.24`
 
 ## 1.7.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuirealm"
-version = "1.7.0"
+version = "1.7.1"
 authors = ["Christian Visintin"]
 edition = "2021"
 categories = ["command-line-utilities"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/veeso/tui-realm"
 
 [dependencies]
 bitflags = "^1.3"
-crossterm = { version = "^0.23", optional = true }
+crossterm = { version = "^0.24", optional = true }
 lazy-regex = "^2.3.0"
 serde = { version = "^1", features = [ "derive" ], optional = true }
 termion = { version = "^1.5", optional = true }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 </p>
 
 <p align="center">Developed by <a href="https://veeso.github.io/" target="_blank">@veeso</a></p>
-<p align="center">Current version: 1.7.0 (23/06/2022)</p>
+<p align="center">Current version: 1.7.1 (02/08/2022)</p>
 
 <p align="center">
   <a href="https://opensource.org/licenses/MIT"

--- a/src/core/props/input_type.rs
+++ b/src/core/props/input_type.rs
@@ -81,11 +81,13 @@ impl InputType {
             Self::Color => Self::char_valid_for_color(input, c),
             Self::Email => Self::char_valid_for_email(input, c),
             Self::Number => {
-                c.is_digit(10) || (['+', '-'].contains(&c) && input.is_empty()) || c == '.'
+                c.is_ascii_digit() || (['+', '-'].contains(&c) && input.is_empty()) || c == '.'
             }
             Self::Telephone => Self::char_valid_for_phone(input, c),
-            Self::SignedInteger => c.is_digit(10) || (['+', '-'].contains(&c) && input.is_empty()),
-            Self::UnsignedInteger => c.is_digit(10),
+            Self::SignedInteger => {
+                c.is_ascii_digit() || (['+', '-'].contains(&c) && input.is_empty())
+            }
+            Self::UnsignedInteger => c.is_ascii_digit(),
             Self::Password(_) | Self::Text => true,
             Self::Custom(_, char_valid) | Self::CustomPassword(_, _, char_valid) => {
                 char_valid(input, c)
@@ -120,19 +122,19 @@ impl InputType {
 
     fn char_valid_for_phone(input: &str, c: char) -> bool {
         // Must be digit, or + (but at the begin) or space/- but not empty
-        c.is_digit(10)
+        c.is_ascii_digit()
             || (c == '+' && input.is_empty())
             || ([' ', '-'].contains(&c) && !input.is_empty())
     }
 
     fn char_valid_for_color(input: &str, c: char) -> bool {
         (c.is_alphanumeric() && !input.starts_with('#'))
-            || (input.starts_with('#') && c.is_digit(16))
+            || (input.starts_with('#') && c.is_ascii_hexdigit())
             || c == ' '
             || (c == '#' && input.is_empty())
             || (c == ',' && input.starts_with("rgb"))
             || (c == '(' && input.starts_with("rgb") && !input.contains('('))
-            || (c.is_digit(10) && input.starts_with("rgb"))
+            || (c.is_ascii_digit() && input.starts_with("rgb"))
             || (c == ')' && input.len() >= 15 && !input.contains(')')) // rgb(xxx,xxx,xxx)
     }
 }


### PR DESCRIPTION
# ISSUE 40 - tricky problem about focus

Fixes #40 

## Description

- Added `View::remount()` to keep components in focus stack when remounting.

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
