### PR TITLE
Update ratatui dependency to version 0.26

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "^1", features = ["derive"], optional = true }
 termion = { version = "^2", optional = true }
 thiserror = "^1.0.0"
 tui = { version = "0.19", default-features = false, optional = true }
-ratatui = { version = "0.23", default-features = false, optional = true }
+ratatui = { version = "0.26", default-features = false, optional = true }
 tuirealm_derive = { version = "^1.0.0", optional = true }
 
 [dev-dependencies]

--- a/src/adapter/crossterm/mod.rs
+++ b/src/adapter/crossterm/mod.rs
@@ -20,7 +20,7 @@ use crate::tui::{Frame as TuiFrame, Terminal as TuiTerminal};
 // -- Frame
 
 /// Frame represents the Frame where the view will be displayed in
-pub type Frame<'a> = TuiFrame<'a, CrosstermBackend<Stdout>>;
+pub type Frame<'a> = TuiFrame<'a>;
 
 /// Terminal must be used to interact with the terminal in tui applications
 pub type Terminal = TuiTerminal<CrosstermBackend<Stdout>>;

--- a/src/adapter/crossterm/mod.rs
+++ b/src/adapter/crossterm/mod.rs
@@ -20,7 +20,11 @@ use crate::tui::{Frame as TuiFrame, Terminal as TuiTerminal};
 // -- Frame
 
 /// Frame represents the Frame where the view will be displayed in
+#[cfg(feature = "ratatui")]
 pub type Frame<'a> = TuiFrame<'a>;
+
+#[cfg(feature = "tui")]
+pub type Frame<'a> = TuiFrame<'a, CrosstermBackend<Stdout>>;
 
 /// Terminal must be used to interact with the terminal in tui applications
 pub type Terminal = TuiTerminal<CrosstermBackend<Stdout>>;

--- a/src/adapter/termion/mod.rs
+++ b/src/adapter/termion/mod.rs
@@ -23,6 +23,10 @@ use crate::tui::{Frame as TuiFrame, Terminal as TuiTerminal};
 // -- Frame
 
 /// Frame represents the Frame where the view will be displayed in
+#[cfg(feature = "ratatui")]
+pub type Frame<'a> = TuiFrame<'a>;
+
+#[cfg(feature = "tui")]
 pub type Frame<'a> =
     TuiFrame<'a, TermionBackend<MouseTerminal<AlternateScreen<RawTerminal<Stdout>>>>>;
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -13,7 +13,6 @@ pub mod subscription;
 mod view;
 
 // -- export
-pub use command::Cmd;
 pub use component::{Component, MockComponent};
 pub use state::{State, StateValue};
 // -- internal


### PR DESCRIPTION
# 68 - Update ratatui dependency to version 0.26

Fixes #68

## Description

Updated ratatui dependency

## List here your changes

- Updated Cargo.toml to point to ratatui 0.26
- I made also removed the generic argument in `src/adapter/crossterm/mod.rs` since `Frame` now takes none:

```output
error[E0107]: struct takes 0 generic arguments but 1 generic argument was supplied
  --> src/adapter/crossterm/mod.rs:23:22
   |
23 | pub type Frame<'a> = TuiFrame<'a, CrosstermBackend<Stdout>>;
   |                      ^^^^^^^^     ------------------------ help: remove this generic argument
   |                      |
   |                      expected 0 generic arguments
   |
note: struct defined here, with 0 generic parameters
  --> /Users/andy/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ratatui-0.26.1/src/terminal/frame.rs:14:12
   |
14 | pub struct Frame<'a> {
   |            ^^^^^
```

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [ ] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [ ] I increased or maintained the code coverage for the project, compared to the previous commit
