### PR TITLE
feat(core::props::Props): add function "get_ref"

### DIFF
--- a/src/core/props/mod.rs
+++ b/src/core/props/mod.rs
@@ -36,7 +36,9 @@ pub struct Props {
 }
 
 impl Props {
-    /// Get, if any, the attribute associated to the selector
+    /// Get, if any, the attribute associated to the selector.
+    ///
+    /// This function clones the returned value.
     pub fn get(&self, query: Attribute) -> Option<AttrValue> {
         self.attrs.get(&query).cloned()
     }
@@ -45,6 +47,11 @@ impl Props {
     /// or return the fallback value `default`
     pub fn get_or(&self, query: Attribute, default: AttrValue) -> AttrValue {
         self.get(query).unwrap_or(default)
+    }
+
+    /// Get, if any, the attribute associated to the selector by reference.
+    pub fn get_ref(&self, query: Attribute) -> Option<&AttrValue> {
+        self.attrs.get(&query)
     }
 
     /// Set a new attribute into Properties
@@ -301,6 +308,37 @@ mod test {
     use pretty_assertions::assert_eq;
 
     use super::*;
+
+    #[test]
+    fn should_set_get_props() {
+        let mut props = Props::default();
+        assert_eq!(props.get(Attribute::Alignment), None);
+        assert_eq!(
+            props.get_or(
+                Attribute::Alignment,
+                AttrValue::Alignment(Alignment::Center)
+            ),
+            AttrValue::Alignment(Alignment::Center)
+        );
+        assert_eq!(props.get_ref(Attribute::Alignment), None);
+
+        props.set(Attribute::Alignment, AttrValue::Alignment(Alignment::Left));
+        assert_eq!(
+            props.get(Attribute::Alignment),
+            Some(AttrValue::Alignment(Alignment::Left))
+        );
+        assert_eq!(
+            props.get_or(
+                Attribute::Alignment,
+                AttrValue::Alignment(Alignment::Center)
+            ),
+            AttrValue::Alignment(Alignment::Left)
+        );
+        assert_eq!(
+            props.get_ref(Attribute::Alignment),
+            Some(&AttrValue::Alignment(Alignment::Left))
+        );
+    }
 
     #[test]
     fn unwrapping_should_unwrap() {


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

No Issue

## Description

This PR adds a `get_ref` function to `Props` to get the searched attribute by reference instead of always cloning like `get` does.
Also add tests for all `set` and `get` function of `Props`.

I did not include a `get_ref_or` function as it is simple enough to just chain `props.get_ref(query).unwrap_or(default)`.

Personally, i would recommend to maybe remove the original `get` function in a major version and replace it with `get_ref`, this way it is up to the user when to clone the returned value.
If it should be removed, i would recommend to put a `#[deprecated]` on `get` before it being removed.

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

---

This change would for example allow another clone at [stdlib#TextSpan](https://github.com/veeso/tui-realm-stdlib/blob/913b0807586e1c426f0363870e633a2bee3c3958/src/components/span.rs#L75) to be removed.
And likely other places too.