### PR TITLE
async ports

### DIFF
--- a/.github/workflows/crossterm-windows.yml
+++ b/.github/workflows/crossterm-windows.yml
@@ -14,13 +14,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          override: true
           components: rustfmt, clippy
       - name: Test
-        run: cargo test --no-fail-fast --lib --no-default-features --features derive,serialize,crossterm
+        run: cargo test --no-fail-fast --lib --no-default-features --features derive,serialize,crossterm,async-ports
       - name: Examples
         run: cargo build --all-targets --examples
       - name: Format
         run: cargo fmt --all -- --check
       - name: Clippy
-        run: cargo clippy --lib --no-default-features --features derive,serialize,crossterm -- -Dwarnings
+        run: cargo clippy --lib --no-default-features --features derive,serialize,crossterm,async-ports -- -Dwarnings

--- a/.github/workflows/ratatui_crossterm.yml
+++ b/.github/workflows/ratatui_crossterm.yml
@@ -14,13 +14,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          override: true
           components: rustfmt, clippy
       - name: Test
-        run: cargo test --no-fail-fast --lib --features derive,serialize,crossterm --no-default-features
+        run: cargo test --no-fail-fast --lib --features derive,serialize,crossterm,async-ports --no-default-features
       - name: Examples
         run: cargo build --all-targets --examples
       - name: Format
         run: cargo fmt --all -- --check
       - name: Clippy
-        run: cargo clippy --lib --features derive,serialize,crossterm --no-default-features -- -Dwarnings
+        run: cargo clippy --lib --features derive,serialize,crossterm,async-ports --no-default-features -- -Dwarnings

--- a/.github/workflows/ratatui_termion.yml
+++ b/.github/workflows/ratatui_termion.yml
@@ -16,10 +16,10 @@ jobs:
           toolchain: stable
           components: rustfmt, clippy
       - name: Test
-        run: cargo test --no-fail-fast --lib --no-default-features --features derive,serialize,termion
+        run: cargo test --no-fail-fast --lib --no-default-features --features derive,serialize,termion,async-ports
       - name: Examples
         run: cargo build --all-targets --no-default-features --features derive,serialize,termion --examples
       - name: Format
         run: cargo fmt --all -- --check
       - name: Clippy
-        run: cargo clippy --lib --no-default-features --features derive,serialize,termion -- -Dwarnings
+        run: cargo clippy --lib --no-default-features --features derive,serialize,termion,async-ports -- -Dwarnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@
 
 Released on 17/05/2025
 
-- [Issue 94](https://github.com/veeso/tui-realm/issues/94): Added support for **Async Ports**. It is now possible to create async ports by implementing the `PollAsync` trait and then by passing the `tokio::rt::Handl` to the `EventListenerCfg::port` method.
+- [Issue 94](https://github.com/veeso/tui-realm/issues/94): Added support for **Async Ports**. It is now possible to create async ports by implementing the `PollAsync` trait and then by passing the `tokio::rt::Handle` to the `EventListenerCfg::port` method.
 
     ```rust
     let handle = Arc::new(tokio::rt::Handle::current());

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - [Changelog](#changelog)
+  - [2.3.0](#230)
   - [2.2.0](#220)
   - [2.1.0](#210)
   - [2.0.3](#203)
@@ -40,6 +41,40 @@
   - [0.1.0](#010)
 
 ---
+
+## 2.3.0
+
+Released on 17/05/2025
+
+- [Issue 94](https://github.com/veeso/tui-realm/issues/94): Added support for **Async Ports**. It is now possible to create async ports by implementing the `PollAsync` trait and then by passing the `tokio::rt::Handl` to the `EventListenerCfg::port` method.
+
+    ```rust
+    let handle = Arc::new(tokio::rt::Handle::current());
+
+    let event_listener = EventListenerCfg::default()
+        .crossterm_input_listener(Duration::from_millis(10), 3)
+        .add_async_port(
+            Box::new(AsyncPort::new()),
+            Duration::from_millis(1000),
+            1,
+            &handle,
+        );
+
+    #[tuirealm::async_trait]
+    impl PollAsync<UserEvent> for AsyncPort {
+        async fn poll(&self) -> ListenerResult<Option<Event<UserEvent>>> {
+            let result = self.write_file().await;
+
+            Ok(Some(Event::User(UserEvent::WroteFile(result))))
+        }
+    }
+    ```
+
+    ⚠️ `PollAsync` takes a `&self` reference, and not a `&mut self` reference as `Poll` does; this is because it is not possible to have mutable references with async in this case. Also consider that `UserEvent` must be `Send` and `Sync` if you want to use it in an async context.
+
+    ‼️ **PollAsync** is featured behind the `async-ports` feature.
+
+    ❗ You can find an example of this at `examples/async_ports.rs`.
 
 ## 2.2.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tuirealm"
-version = "2.2.0"
-authors = ["Christian Visintin"]
+version = "2.3.0"
+authors = ["Christian Visintin <christian.visintin@veeso.dev>"]
 edition = "2024"
 rust-version = "1.85.1"
 categories = ["command-line-utilities"]
@@ -15,6 +15,7 @@ readme = "README.md"
 repository = "https://github.com/veeso/tui-realm"
 
 [dependencies]
+async-trait = { version = "0.1", optional = true }
 bitflags = "2"
 crossterm = { version = "0.29", optional = true }
 lazy-regex = "3"
@@ -22,19 +23,29 @@ ratatui = { version = "0.29", default-features = false }
 serde = { version = "1", features = ["derive"], optional = true }
 termion = { version = "^4", optional = true }
 thiserror = "2"
+tokio = { version = "1", features = [
+  "rt",
+], default-features = false, optional = true }
 tuirealm_derive = { version = "2", optional = true }
 
 [dev-dependencies]
 pretty_assertions = "^1"
 toml = "^0.8"
 tempfile = "^3"
+tokio = { version = "1", features = ["full"] }
 
 [features]
 default = ["derive", "dep:crossterm"]
+async-ports = ["dep:async-trait", "dep:tokio"]
 derive = ["dep:tuirealm_derive"]
 serialize = ["dep:serde", "bitflags/serde"]
 crossterm = ["dep:crossterm", "ratatui/crossterm"]
 termion = ["dep:termion", "ratatui/termion"]
+
+[[example]]
+name = "async-ports"
+path = "examples/async_ports.rs"
+required-features = ["async-ports", "crossterm"]
 
 [[example]]
 name = "demo"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 </p>
 
 <p align="center">Developed by <a href="https://veeso.github.io/" target="_blank">@veeso</a></p>
-<p align="center">Current version: 2.2.0 (15/05/2025)</p>
+<p align="center">Current version: 2.3.0 (17/05/2025)</p>
 
 <p align="center">
   <a href="https://opensource.org/licenses/MIT"

--- a/examples/async_ports.rs
+++ b/examples/async_ports.rs
@@ -1,0 +1,298 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use tempfile::NamedTempFile;
+use tokio::io::AsyncWriteExt as _;
+use tokio::runtime::Handle;
+use tuirealm::command::{Cmd, CmdResult};
+use tuirealm::event::{Key, KeyEvent};
+use tuirealm::listener::{ListenerResult, PollAsync};
+use tuirealm::props::{Alignment, Color, Style, TextModifiers};
+use tuirealm::ratatui::layout::{Constraint, Direction, Layout, Rect};
+use tuirealm::ratatui::widgets::Paragraph;
+use tuirealm::terminal::{CrosstermTerminalAdapter, TerminalAdapter, TerminalBridge};
+use tuirealm::{
+    Application, AttrValue, Attribute, Component, Event, EventListenerCfg, Frame, MockComponent,
+    PollStrategy, Props, State, Sub, SubClause, SubEventClause, Update,
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let handle = Arc::new(Handle::current());
+
+    let event_listener = EventListenerCfg::default()
+        .crossterm_input_listener(Duration::from_millis(10), 3)
+        .add_async_port(
+            Box::new(AsyncPort::new()),
+            Duration::from_millis(1000),
+            1,
+            &handle,
+        );
+
+    let mut app: Application<Id, Msg, UserEvent> = Application::init(event_listener);
+
+    // subscribe component to clause
+    app.mount(
+        Id::Label,
+        Box::new(Label::default()),
+        vec![Sub::new(
+            SubEventClause::User(UserEvent::WroteFile(Duration::ZERO)),
+            SubClause::Always,
+        )],
+    )?;
+
+    app.active(&Id::Label).expect("failed to active");
+
+    let mut model = Model::new(app, CrosstermTerminalAdapter::new()?);
+    // Main loop
+    // NOTE: loop until quit; quit is set in update if AppClose is received from counter
+    while !model.quit {
+        // Tick
+        match model.app.tick(PollStrategy::Once) {
+            Err(err) => {
+                panic!("application error {err}");
+            }
+            Ok(messages) if messages.len() > 0 => {
+                // NOTE: redraw if at least one msg has been processed
+                model.redraw = true;
+                for msg in messages.into_iter() {
+                    let mut msg = Some(msg);
+                    while msg.is_some() {
+                        msg = model.update(msg);
+                    }
+                }
+            }
+            _ => {}
+        }
+        // Redraw
+        if model.redraw {
+            model.view();
+            model.redraw = false;
+        }
+    }
+
+    model.terminal.restore()?;
+
+    Ok(())
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Msg {
+    AppClose,
+    None,
+}
+
+// Let's define the component ids for our application
+#[derive(Debug, Eq, PartialEq, Clone, Hash)]
+pub enum Id {
+    Label,
+}
+
+#[derive(Debug, Eq, Clone, Copy, PartialOrd, Ord)]
+pub enum UserEvent {
+    WroteFile(Duration),
+    None,
+}
+
+impl PartialEq for UserEvent {
+    fn eq(&self, other: &Self) -> bool {
+        std::mem::discriminant(self) == std::mem::discriminant(other)
+    }
+}
+
+pub struct Model<T>
+where
+    T: TerminalAdapter,
+{
+    /// Application
+    pub app: Application<Id, Msg, UserEvent>,
+    /// Indicates that the application must quit
+    pub quit: bool,
+    /// Tells whether to redraw interface
+    pub redraw: bool,
+    /// Used to draw to terminal
+    pub terminal: TerminalBridge<T>,
+}
+
+impl<T> Model<T>
+where
+    T: TerminalAdapter,
+{
+    pub fn new(app: Application<Id, Msg, UserEvent>, adapter: T) -> Self {
+        Self {
+            app,
+            quit: false,
+            redraw: true,
+            terminal: TerminalBridge::init(adapter).expect("Cannot initialize terminal"),
+        }
+    }
+
+    pub fn view(&mut self) {
+        assert!(
+            self.terminal
+                .draw(|f| {
+                    let chunks = Layout::default()
+                        .direction(Direction::Vertical)
+                        .margin(1)
+                        .constraints(
+                            [
+                                Constraint::Length(3), // Label
+                            ]
+                            .as_ref(),
+                        )
+                        .split(f.area());
+                    self.app.view(&Id::Label, f, chunks[0]);
+                })
+                .is_ok()
+        );
+    }
+}
+
+// Let's implement Update for model
+
+impl<T> Update<Msg> for Model<T>
+where
+    T: TerminalAdapter,
+{
+    fn update(&mut self, msg: Option<Msg>) -> Option<Msg> {
+        if let Some(msg) = msg {
+            // Set redraw
+            self.redraw = true;
+            // Match message
+            match msg {
+                Msg::AppClose => {
+                    self.quit = true; // Terminate
+                    None
+                }
+                Msg::None => None,
+            }
+        } else {
+            None
+        }
+    }
+}
+
+struct AsyncPort {
+    tempfile: Arc<NamedTempFile>,
+}
+
+impl AsyncPort {
+    pub fn new() -> Self {
+        let tempfile = Arc::new(NamedTempFile::new().unwrap());
+        Self { tempfile }
+    }
+
+    pub async fn write_file(&self) -> Duration {
+        let t_start = std::time::Instant::now();
+        // Write to file
+        let mut file = tokio::fs::File::create(self.tempfile.path()).await.unwrap();
+        file.write_all(b"Hello, world!").await.unwrap();
+
+        t_start.elapsed()
+    }
+}
+
+#[tuirealm::async_trait]
+impl PollAsync<UserEvent> for AsyncPort {
+    async fn poll(&self) -> ListenerResult<Option<Event<UserEvent>>> {
+        let result = self.write_file().await;
+
+        Ok(Some(Event::User(UserEvent::WroteFile(result))))
+    }
+}
+
+/// Simple label component; just renders a text
+/// NOTE: since I need just one label, I'm not going to use different object; I will directly implement Component for Label.
+/// This is not ideal actually and in a real app you should differentiate Mock Components from Application Components.
+pub struct Label {
+    props: Props,
+}
+
+impl Default for Label {
+    fn default() -> Self {
+        Self {
+            props: Props::default(),
+        }
+    }
+}
+
+impl MockComponent for Label {
+    fn view(&mut self, frame: &mut Frame, area: Rect) {
+        // Check if visible
+        if self.props.get_or(Attribute::Display, AttrValue::Flag(true)) == AttrValue::Flag(true) {
+            // Get properties
+            let text = self
+                .props
+                .get_or(Attribute::Text, AttrValue::String(String::default()))
+                .unwrap_string();
+            let alignment = self
+                .props
+                .get_or(Attribute::TextAlign, AttrValue::Alignment(Alignment::Left))
+                .unwrap_alignment();
+            let foreground = self
+                .props
+                .get_or(Attribute::Foreground, AttrValue::Color(Color::Reset))
+                .unwrap_color();
+            let background = self
+                .props
+                .get_or(Attribute::Background, AttrValue::Color(Color::Reset))
+                .unwrap_color();
+            let modifiers = self
+                .props
+                .get_or(
+                    Attribute::TextProps,
+                    AttrValue::TextModifiers(TextModifiers::empty()),
+                )
+                .unwrap_text_modifiers();
+            frame.render_widget(
+                Paragraph::new(text)
+                    .style(
+                        Style::default()
+                            .fg(foreground)
+                            .bg(background)
+                            .add_modifier(modifiers),
+                    )
+                    .alignment(alignment),
+                area,
+            );
+        }
+    }
+
+    fn query(&self, attr: Attribute) -> Option<AttrValue> {
+        self.props.get(attr)
+    }
+
+    fn attr(&mut self, attr: Attribute, value: AttrValue) {
+        self.props.set(attr, value);
+    }
+
+    fn state(&self) -> State {
+        State::None
+    }
+
+    fn perform(&mut self, _: Cmd) -> CmdResult {
+        CmdResult::None
+    }
+}
+
+impl Component<Msg, UserEvent> for Label {
+    fn on(&mut self, ev: Event<UserEvent>) -> Option<Msg> {
+        // Does nothing
+        match ev {
+            Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => Some(Msg::AppClose),
+            Event::User(UserEvent::WroteFile(duration)) => {
+                // set text
+                self.attr(
+                    Attribute::Text,
+                    AttrValue::String(format!(
+                        "file wrote in {} nanos",
+                        duration.as_nanos().to_string()
+                    )),
+                );
+
+                Some(Msg::None)
+            }
+            _ => None,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,3 +91,8 @@ pub use self::core::props::{self, AttrValue, Attribute, Props};
 pub use self::core::subscription::{EventClause as SubEventClause, Sub, SubClause};
 pub use self::core::{Component, MockComponent, State, StateValue, Update, ViewError, command};
 pub use self::ratatui::Frame;
+
+// export async trait for async-ports
+#[cfg(feature = "async-ports")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async-ports")))]
+pub use async_trait::async_trait;

--- a/src/listener/port.rs
+++ b/src/listener/port.rs
@@ -2,77 +2,120 @@
 //!
 //! This module exposes the poll wrapper to include in the worker
 
-use std::ops::Add;
+#[cfg(feature = "async-ports")]
+mod async_p;
+mod sync;
+
 use std::time::{Duration, Instant};
 
-use super::{Event, ListenerResult, Poll};
+#[cfg(feature = "async-ports")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async-ports")))]
+pub use self::async_p::AsyncPort;
+pub use self::sync::SyncPort;
+use super::ListenerResult;
+use crate::Event;
 
 /// A port is a wrapper around the poll trait object, which also defines an interval, which defines
 /// the amount of time between each [`Poll::poll`] call.
 /// Its purpose is to listen for incoming events of a user-defined type
-pub struct Port<U>
+///
+/// There are two types of ports:
+///
+/// - [`SyncPort`] - A port that is polled synchronously
+/// - [`AsyncPort`] - A port that is polled asynchronously and supports tokio
+pub enum Port<U>
 where
     U: Eq + PartialEq + Clone + PartialOrd + Send,
 {
-    poll: Box<dyn Poll<U>>,
-    interval: Duration,
-    next_poll: Instant,
-    max_poll: usize,
+    Sync(SyncPort<U>),
+    #[cfg(feature = "async-ports")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "async-ports")))]
+    Async(AsyncPort<U>),
+}
+
+impl<U> From<SyncPort<U>> for Port<U>
+where
+    U: Eq + PartialEq + Clone + PartialOrd + Send,
+{
+    fn from(port: SyncPort<U>) -> Self {
+        Port::Sync(port)
+    }
+}
+
+#[cfg(feature = "async-ports")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async-ports")))]
+impl<U> From<AsyncPort<U>> for Port<U>
+where
+    U: Eq + PartialEq + Clone + PartialOrd + Send,
+{
+    fn from(port: AsyncPort<U>) -> Self {
+        Port::Async(port)
+    }
 }
 
 impl<U> Port<U>
 where
     U: Eq + PartialEq + Clone + PartialOrd + Send + 'static,
 {
-    /// Define a new [`Port`]
-    ///
-    /// # Parameters
-    ///
-    /// * `poll` - The poll trait object
-    /// * `interval` - The interval between each poll
-    /// * `max_poll` - The maximum amount of times the port should be polled in a single poll
-    pub fn new(poll: Box<dyn Poll<U>>, interval: Duration, max_poll: usize) -> Self {
-        Self {
-            poll,
-            interval,
-            next_poll: Instant::now(),
-            max_poll,
-        }
-    }
-
     /// Get how often a port should get polled in a single poll
     pub fn max_poll(&self) -> usize {
-        self.max_poll
+        match self {
+            Port::Sync(port) => port.max_poll(),
+            #[cfg(feature = "async-ports")]
+            Port::Async(port) => port.max_poll(),
+        }
     }
 
     /// Returns the interval for the current [`Port`]
     pub fn interval(&self) -> &Duration {
-        &self.interval
+        match self {
+            Port::Sync(port) => port.interval(),
+            #[cfg(feature = "async-ports")]
+            Port::Async(port) => port.interval(),
+        }
     }
 
     /// Returns the time of the next poll for this listener
     pub fn next_poll(&self) -> Instant {
-        self.next_poll
+        match self {
+            Port::Sync(port) => port.next_poll(),
+            #[cfg(feature = "async-ports")]
+            Port::Async(port) => port.next_poll(),
+        }
     }
 
     /// Returns whether next poll is now or in the past
     pub fn should_poll(&self) -> bool {
-        self.next_poll <= Instant::now()
+        match self {
+            Port::Sync(port) => port.should_poll(),
+            #[cfg(feature = "async-ports")]
+            Port::Async(port) => port.should_poll(),
+        }
     }
 
     /// Calls [`Poll::poll`] on the inner [`Poll`] trait object.
     pub fn poll(&mut self) -> ListenerResult<Option<Event<U>>> {
-        self.poll.poll()
+        match self {
+            Port::Sync(port) => port.poll(),
+            #[cfg(feature = "async-ports")]
+            Port::Async(port) => port.poll(),
+        }
     }
 
     /// Calculate the next poll (t_now + interval)
     pub fn calc_next_poll(&mut self) {
-        self.next_poll = Instant::now().add(self.interval);
+        match self {
+            Port::Sync(port) => port.calc_next_poll(),
+            #[cfg(feature = "async-ports")]
+            Port::Async(port) => port.calc_next_poll(),
+        }
     }
 }
 
 #[cfg(test)]
 mod test {
+
+    use std::time::Duration;
 
     use pretty_assertions::assert_eq;
 
@@ -81,8 +124,32 @@ mod test {
 
     #[test]
     fn test_single_listener() {
-        let mut listener =
-            Port::<MockEvent>::new(Box::new(MockPoll::default()), Duration::from_secs(5), 1);
+        let mut listener = Port::from(SyncPort::<MockEvent>::new(
+            Box::new(MockPoll::default()),
+            Duration::from_secs(5),
+            1,
+        ));
+        assert!(listener.next_poll() <= Instant::now());
+        assert_eq!(listener.should_poll(), true);
+        assert!(listener.poll().ok().unwrap().is_some());
+        listener.calc_next_poll();
+        assert_eq!(listener.should_poll(), false);
+        assert_eq!(*listener.interval(), Duration::from_secs(5));
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "async-ports")]
+    async fn test_single_async_listener() {
+        use crate::mock::MockPollAsync;
+
+        let runtime = std::sync::Arc::new(tokio::runtime::Handle::current());
+
+        let mut listener = Port::from(AsyncPort::<MockEvent>::new(
+            Box::new(MockPollAsync::default()),
+            Duration::from_secs(5),
+            1,
+            &runtime,
+        ));
         assert!(listener.next_poll() <= Instant::now());
         assert_eq!(listener.should_poll(), true);
         assert!(listener.poll().ok().unwrap().is_some());

--- a/src/listener/port/async_p.rs
+++ b/src/listener/port/async_p.rs
@@ -1,0 +1,87 @@
+use std::ops::Add as _;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tokio::runtime::Handle as TokioRuntime;
+
+use crate::listener::{ListenerResult, PollAsync};
+use crate::{Event, ListenerError};
+
+/// An async port is a wrapper around the [`PollAsync`] trait object, which also defines an interval, which defines
+/// the amount of time between each [`PollAsync::poll`] call.
+/// Its purpose is to listen for incoming events of a user-defined type
+///
+/// [`AsyncPort`] has the possibility to run
+pub struct AsyncPort<U>
+where
+    U: Eq + PartialEq + Clone + PartialOrd + Send,
+{
+    poll: Arc<Box<dyn PollAsync<U> + Send + Sync>>,
+    interval: Duration,
+    next_poll: Instant,
+    max_poll: usize,
+    runtime: Arc<TokioRuntime>,
+}
+
+impl<U> AsyncPort<U>
+where
+    U: Eq + PartialEq + Clone + PartialOrd + Send + 'static,
+{
+    /// Define a new [`AsyncPort`]
+    ///
+    /// # Parameters
+    ///
+    /// * `poll` - The poll trait object
+    /// * `interval` - The interval between each poll
+    /// * `max_poll` - The maximum amount of times the port should be polled in a single poll
+    /// * `runtime` - The tokio runtime to use for async polling
+    pub fn new(
+        poll: Box<dyn PollAsync<U> + Send + Sync>,
+        interval: Duration,
+        max_poll: usize,
+        runtime: &Arc<TokioRuntime>,
+    ) -> Self {
+        Self {
+            poll: Arc::new(poll),
+            interval,
+            next_poll: Instant::now(),
+            max_poll,
+            runtime: runtime.clone(),
+        }
+    }
+
+    /// Get how often a port should get polled in a single poll
+    pub fn max_poll(&self) -> usize {
+        self.max_poll
+    }
+
+    /// Returns the interval for the current [`Port`]
+    pub fn interval(&self) -> &Duration {
+        &self.interval
+    }
+
+    /// Returns the time of the next poll for this listener
+    pub fn next_poll(&self) -> Instant {
+        self.next_poll
+    }
+
+    /// Returns whether next poll is now or in the past
+    pub fn should_poll(&self) -> bool {
+        self.next_poll <= Instant::now()
+    }
+
+    /// Calls [`PollAsync::poll`] on the inner [`PollAsync`] trait object.
+    pub fn poll(&mut self) -> ListenerResult<Option<Event<U>>> {
+        let rt = self.runtime.clone();
+        let poll_impl = self.poll.clone();
+
+        std::thread::spawn(move || rt.block_on(poll_impl.poll()))
+            .join()
+            .map_err(|_| ListenerError::PollFailed)?
+    }
+
+    /// Calculate the next poll (t_now + interval)
+    pub fn calc_next_poll(&mut self) {
+        self.next_poll = Instant::now().add(self.interval);
+    }
+}

--- a/src/listener/port/sync.rs
+++ b/src/listener/port/sync.rs
@@ -1,0 +1,69 @@
+use std::ops::Add as _;
+use std::time::{Duration, Instant};
+
+use crate::Event;
+use crate::listener::{ListenerResult, Poll};
+
+/// A port is a wrapper around the poll trait object, which also defines an interval, which defines
+/// the amount of time between each [`Poll::poll`] call.
+/// Its purpose is to listen for incoming events of a user-defined type
+pub struct SyncPort<U>
+where
+    U: Eq + PartialEq + Clone + PartialOrd + Send,
+{
+    poll: Box<dyn Poll<U>>,
+    interval: Duration,
+    next_poll: Instant,
+    max_poll: usize,
+}
+
+impl<U> SyncPort<U>
+where
+    U: Eq + PartialEq + Clone + PartialOrd + Send + 'static,
+{
+    /// Define a new [`SyncPort`]
+    ///
+    /// # Parameters
+    ///
+    /// * `poll` - The poll trait object
+    /// * `interval` - The interval between each poll
+    /// * `max_poll` - The maximum amount of times the port should be polled in a single poll
+    pub fn new(poll: Box<dyn Poll<U>>, interval: Duration, max_poll: usize) -> Self {
+        Self {
+            poll,
+            interval,
+            next_poll: Instant::now(),
+            max_poll,
+        }
+    }
+
+    /// Get how often a port should get polled in a single poll
+    pub fn max_poll(&self) -> usize {
+        self.max_poll
+    }
+
+    /// Returns the interval for the current [`Port`]
+    pub fn interval(&self) -> &Duration {
+        &self.interval
+    }
+
+    /// Returns the time of the next poll for this listener
+    pub fn next_poll(&self) -> Instant {
+        self.next_poll
+    }
+
+    /// Returns whether next poll is now or in the past
+    pub fn should_poll(&self) -> bool {
+        self.next_poll <= Instant::now()
+    }
+
+    /// Calls [`Poll::poll`] on the inner [`Poll`] trait object.
+    pub fn poll(&mut self) -> ListenerResult<Option<Event<U>>> {
+        self.poll.poll()
+    }
+
+    /// Calculate the next poll (t_now + interval)
+    pub fn calc_next_poll(&mut self) {
+        self.next_poll = Instant::now().add(self.interval);
+    }
+}

--- a/src/listener/worker.rs
+++ b/src/listener/worker.rs
@@ -176,6 +176,7 @@ mod test {
     use super::*;
     use crate::Event;
     use crate::core::event::{Key, KeyEvent};
+    use crate::listener::SyncPort;
     use crate::mock::{MockEvent, MockPoll};
 
     #[test]
@@ -186,7 +187,8 @@ mod test {
         let running = Arc::new(AtomicBool::new(true));
         let running_t = Arc::clone(&running);
 
-        let mock_port = Port::new(Box::new(MockPoll::default()), Duration::from_secs(5), 10);
+        let mock_port =
+            SyncPort::new(Box::new(MockPoll::default()), Duration::from_secs(5), 10).into();
 
         let mut worker =
             EventListenerWorker::<MockEvent>::new(vec![mock_port], tx, paused_t, running_t, None);
@@ -209,11 +211,7 @@ mod test {
         let running = Arc::new(AtomicBool::new(true));
         let running_t = Arc::clone(&running);
         let mut worker = EventListenerWorker::<MockEvent>::new(
-            vec![Port::new(
-                Box::new(MockPoll::default()),
-                Duration::from_secs(5),
-                1,
-            )],
+            vec![SyncPort::new(Box::new(MockPoll::default()), Duration::from_secs(5), 1).into()],
             tx,
             paused_t,
             running_t,
@@ -236,11 +234,7 @@ mod test {
         let running = Arc::new(AtomicBool::new(true));
         let running_t = Arc::clone(&running);
         let mut worker = EventListenerWorker::<MockEvent>::new(
-            vec![Port::new(
-                Box::new(MockPoll::default()),
-                Duration::from_secs(5),
-                1,
-            )],
+            vec![SyncPort::new(Box::new(MockPoll::default()), Duration::from_secs(5), 1).into()],
             tx,
             paused_t,
             running_t,
@@ -263,11 +257,7 @@ mod test {
         let running = Arc::new(AtomicBool::new(true));
         let running_t = Arc::clone(&running);
         let mut worker = EventListenerWorker::<MockEvent>::new(
-            vec![Port::new(
-                Box::new(MockPoll::default()),
-                Duration::from_secs(5),
-                1,
-            )],
+            vec![SyncPort::new(Box::new(MockPoll::default()), Duration::from_secs(5), 1).into()],
             tx,
             paused_t,
             running_t,
@@ -300,11 +290,7 @@ mod test {
         let running = Arc::new(AtomicBool::new(true));
         let running_t = Arc::clone(&running);
         let worker = EventListenerWorker::<MockEvent>::new(
-            vec![Port::new(
-                Box::new(MockPoll::default()),
-                Duration::from_secs(3),
-                1,
-            )],
+            vec![SyncPort::new(Box::new(MockPoll::default()), Duration::from_secs(3), 1).into()],
             tx,
             paused_t,
             running_t,

--- a/src/mock/mod.rs
+++ b/src/mock/mod.rs
@@ -51,6 +51,31 @@ impl<U: Eq + PartialEq + Clone + PartialOrd + Send + 'static> Poll<U> for MockPo
     }
 }
 
+#[cfg(feature = "async-ports")]
+pub struct MockPollAsync<U: Eq + PartialEq + Clone + PartialOrd + Send> {
+    ghost: PhantomData<U>,
+}
+
+#[cfg(feature = "async-ports")]
+impl<U: Eq + PartialEq + Clone + PartialOrd + Send> Default for MockPollAsync<U> {
+    fn default() -> Self {
+        Self { ghost: PhantomData }
+    }
+}
+
+#[cfg(feature = "async-ports")]
+#[async_trait::async_trait]
+impl<U: Eq + PartialEq + Clone + PartialOrd + Send + Sync + 'static> crate::listener::PollAsync<U>
+    for MockPollAsync<U>
+{
+    async fn poll(&self) -> ListenerResult<Option<Event<U>>> {
+        let tempfile = tempfile::NamedTempFile::new().expect("tempfile");
+        let _file = tokio::fs::File::open(tempfile.path()).await.expect("file");
+
+        Ok(Some(Event::Keyboard(KeyEvent::from(Key::Enter))))
+    }
+}
+
 // -- msg
 
 /// Mocked Msg for components and view

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -52,7 +52,7 @@ pub enum TerminalError {
 ///
 /// To quickly setup a terminal with default settings, you can use the [`TerminalBridge::init()`] method.
 ///
-/// ```rust
+/// ```rust,ignore
 /// use tuirealm::terminal::TerminalBridge;
 ///
 /// #[cfg(feature = "crossterm")]


### PR DESCRIPTION
[Issue 94](https://github.com/veeso/tui-realm/issues/94): Added support for **Async Ports**. It is now possible to create async ports by implementing the `PollAsync` trait and then by passing the `tokio::rt::Handle` to the `EventListenerCfg::port` method.

```rust
let handle = Arc::new(tokio::rt::Handle::current());

let event_listener = EventListenerCfg::default()
    .crossterm_input_listener(Duration::from_millis(10), 3)
    .add_async_port(
        Box::new(AsyncPort::new()),
        Duration::from_millis(1000),
        1,
        &handle,
    );

#[tuirealm::async_trait]
impl PollAsync<UserEvent> for AsyncPort {
    async fn poll(&self) -> ListenerResult<Option<Event<UserEvent>>> {
        let result = self.write_file().await;

        Ok(Some(Event::User(UserEvent::WroteFile(result))))
    }
}
```

 ⚠️ `PollAsync` takes a `&self` reference, and not a `&mut self` reference as `Poll` does; this is because it is not possible to have mutable references with async in this case. Also consider that `UserEvent` must be `Send` and `Sync` if you want to use it in an async context.

‼️ **PollAsync** is featured behind the `async-ports` feature.

❗ You can find an example of this at `examples/async_ports.rs`.