### PR TITLE
Improve Async-Ports by fully running them on the runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,23 @@
 
 ---
 
+## next
+
+Unreleased
+
+- [Issue 94](https://github.com/veeso/tui-realm/issues/94) / [PR 94](https://github.com/veeso/tui-realm/issues/97): improve **Async Ports** to make full use of it being async by running all async ports on the runtime instead of blocking on them like a Sync-port.
+
+  ```rust
+  let event_listener = EventListenerCfg::default()
+        .crossterm_input_listener(Duration::from_millis(10), 3)
+        .with_handle(tokio::runtime::Handle::current())
+        .add_async_port(
+            Box::new(AsyncPort::new()),
+            Duration::from_millis(1000),
+            1,
+        );
+  ```
+
 ## 2.3.0
 
 Released on 17/05/2025

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ termion = { version = "^4", optional = true }
 thiserror = "2"
 tokio = { version = "1", features = [
   "rt",
+  "macros",
+  "time"
 ], default-features = false, optional = true }
 tokio-util = { version = "0.7", features = ["rt"], default-features = false, optional = true }
 tuirealm_derive = { version = "2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ thiserror = "2"
 tokio = { version = "1", features = [
   "rt",
 ], default-features = false, optional = true }
+tokio-util = { version = "0.7", features = ["rt"], default-features = false, optional = true }
 tuirealm_derive = { version = "2", optional = true }
 
 [dev-dependencies]
@@ -36,7 +37,7 @@ tokio = { version = "1", features = ["full"] }
 
 [features]
 default = ["derive", "dep:crossterm"]
-async-ports = ["dep:async-trait", "dep:tokio"]
+async-ports = ["dep:async-trait", "dep:tokio", "dep:tokio-util"]
 derive = ["dep:tuirealm_derive"]
 serialize = ["dep:serde", "bitflags/serde"]
 crossterm = ["dep:crossterm", "ratatui/crossterm"]

--- a/examples/async_ports.rs
+++ b/examples/async_ports.rs
@@ -18,16 +18,12 @@ use tuirealm::{
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let handle = Arc::new(Handle::current());
+    let handle = Handle::current();
 
     let event_listener = EventListenerCfg::default()
         .crossterm_input_listener(Duration::from_millis(10), 3)
-        .add_async_port(
-            Box::new(AsyncPort::new()),
-            Duration::from_millis(1000),
-            1,
-            &handle,
-        );
+        .with_handle(handle)
+        .add_async_port(Box::new(AsyncPort::new()), Duration::from_millis(1000), 1);
 
     let mut app: Application<Id, Msg, UserEvent> = Application::init(event_listener);
 

--- a/src/core/application.rs
+++ b/src/core/application.rs
@@ -44,8 +44,13 @@ where
     /// Initialize a new [`Application`].
     /// The event listener is immediately created and started.
     pub fn init(listener_cfg: EventListenerCfg<UserEvent>) -> Self {
+        // TODO: maybe consider bubbling this up?
+        let listener = listener_cfg
+            .start()
+            .expect("EventListenerCfg to be configured correctly");
+
         Self {
-            listener: listener_cfg.start(),
+            listener,
             subs: Vec::new(),
             sub_lock: false,
             view: View::default(),
@@ -60,7 +65,7 @@ where
         listener_cfg: EventListenerCfg<UserEvent>,
     ) -> ApplicationResult<()> {
         self.listener.stop()?;
-        self.listener = listener_cfg.start();
+        self.listener = listener_cfg.start()?;
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,10 @@ pub mod mock;
 pub mod ratatui;
 pub mod terminal;
 pub mod utils;
+// export async trait for async-ports
+#[cfg(feature = "async-ports")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async-ports")))]
+pub use async_trait::async_trait;
 pub use listener::{EventListenerCfg, ListenerError};
 // -- derive
 #[cfg(feature = "derive")]
@@ -91,8 +95,3 @@ pub use self::core::props::{self, AttrValue, Attribute, Props};
 pub use self::core::subscription::{EventClause as SubEventClause, Sub, SubClause};
 pub use self::core::{Component, MockComponent, State, StateValue, Update, ViewError, command};
 pub use self::ratatui::Frame;
-
-// export async trait for async-ports
-#[cfg(feature = "async-ports")]
-#[cfg_attr(docsrs, doc(cfg(feature = "async-ports")))]
-pub use async_trait::async_trait;

--- a/src/listener/builder.rs
+++ b/src/listener/builder.rs
@@ -2,7 +2,12 @@
 //!
 //! This module exposes the EventListenerCfg which is used to build the event listener
 
-use super::{Duration, EventListener, Poll, Port, SyncPort};
+#[cfg(feature = "async-ports")]
+use tokio::runtime::Handle;
+
+#[cfg(feature = "async-ports")]
+use super::AsyncPort;
+use super::{Duration, EventListener, ListenerError, Poll, SyncPort};
 
 /// The event listener configurator is used to setup an event listener.
 /// Once you're done with configuration just call `EventListenerCfg::start` and the event listener will start and the listener
@@ -11,7 +16,11 @@ pub struct EventListenerCfg<U>
 where
     U: Eq + PartialEq + Clone + PartialOrd + Send,
 {
-    ports: Vec<Port<U>>,
+    sync_ports: Vec<SyncPort<U>>,
+    #[cfg(feature = "async-ports")]
+    async_ports: Vec<AsyncPort<U>>,
+    #[cfg(feature = "async-ports")]
+    handle: Option<Handle>,
     tick_interval: Option<Duration>,
     poll_timeout: Duration,
 }
@@ -22,7 +31,11 @@ where
 {
     fn default() -> Self {
         Self {
-            ports: Vec::default(),
+            sync_ports: Vec::default(),
+            #[cfg(feature = "async-ports")]
+            async_ports: Vec::default(),
+            #[cfg(feature = "async-ports")]
+            handle: None,
             poll_timeout: Duration::from_millis(10),
             tick_interval: None,
         }
@@ -33,9 +46,34 @@ impl<U> EventListenerCfg<U>
 where
     U: Eq + PartialEq + Clone + PartialOrd + Send + 'static,
 {
-    /// Create the event listener with the parameters provided and start the workers
-    pub(crate) fn start(self) -> EventListener<U> {
-        EventListener::start(self.ports, self.poll_timeout, self.tick_interval)
+    /// Create the event listener with the parameters provided and start the workers.
+    ///
+    /// # Errors
+    ///
+    /// - if there are async ports defined, but no handle is set.
+    pub(crate) fn start(self) -> Result<EventListener<U>, ListenerError> {
+        #[cfg(not(feature = "async-ports"))]
+        let store_tx = false;
+        #[cfg(feature = "async-ports")]
+        let store_tx = !self.async_ports.is_empty();
+        #[allow(unused_mut)] // mutability is necessary when "async-ports" is active
+        let mut res = EventListener::start(
+            self.sync_ports,
+            self.poll_timeout,
+            self.tick_interval,
+            store_tx,
+        );
+
+        // dont start a taskpool without any actual tasks
+        #[cfg(feature = "async-ports")]
+        if !self.async_ports.is_empty() {
+            let Some(handle) = self.handle else {
+                return Err(ListenerError::NoHandle);
+            };
+            res = res.start_async(self.async_ports, handle);
+        }
+
+        Ok(res)
     }
 
     /// Set poll timeout.
@@ -64,14 +102,14 @@ where
     /// The interval is the amount of time between each [`Poll::poll`] call.
     /// The max_poll is the maximum amount of times the port should be polled in a single poll.
     pub fn add_port(self, poll: Box<dyn Poll<U>>, interval: Duration, max_poll: usize) -> Self {
-        self.port(SyncPort::new(poll, interval, max_poll).into())
+        self.port(SyncPort::new(poll, interval, max_poll))
     }
 
     /// Add a new [`Port`] to the the event listener
     ///
     /// The [`Port`] needs to be manually constructed, unlike [`Self::add_port`]
-    pub fn port(mut self, port: Port<U>) -> Self {
-        self.ports.push(port);
+    pub fn port(mut self, port: SyncPort<U>) -> Self {
+        self.sync_ports.push(port);
         self
     }
 
@@ -117,9 +155,28 @@ where
         poll: Box<dyn super::PollAsync<U> + Send + Sync>,
         interval: Duration,
         max_poll: usize,
-        rt: &std::sync::Arc<tokio::runtime::Handle>,
     ) -> Self {
-        self.port(super::AsyncPort::new(poll, interval, max_poll, rt).into())
+        self.async_port(super::AsyncPort::new(poll, interval, max_poll))
+    }
+
+    /// Add a new [`AsyncPort`] to the the event listener.
+    ///
+    /// The [`AsyncPort`] needs to be manually constructed, unlike [`Self::add_async_port`].
+    #[cfg(feature = "async-ports")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "async-ports")))]
+    pub fn async_port(mut self, port: AsyncPort<U>) -> Self {
+        self.async_ports.push(port);
+        self
+    }
+
+    /// Set the async runtime handle to use to spawn the async ports on.
+    ///
+    /// If this is not set, a Error is returned on [`start`](Self::start).
+    #[cfg(feature = "async-ports")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "async-ports")))]
+    pub fn with_handle(mut self, handle: tokio::runtime::Handle) -> Self {
+        self.handle = Some(handle);
+        self
     }
 }
 
@@ -135,7 +192,7 @@ mod test {
     #[cfg(feature = "crossterm")]
     fn should_configure_and_start_event_listener_crossterm() {
         let builder = EventListenerCfg::<MockEvent>::default();
-        assert!(builder.ports.is_empty());
+        assert!(builder.sync_ports.is_empty());
         assert!(builder.tick_interval.is_none());
         assert_eq!(builder.poll_timeout, Duration::from_millis(10));
         let builder = builder.tick_interval(Duration::from_secs(10));
@@ -145,8 +202,8 @@ mod test {
         let builder = builder
             .crossterm_input_listener(Duration::from_millis(200), 1)
             .add_port(Box::new(MockPoll::default()), Duration::from_secs(300), 1);
-        assert_eq!(builder.ports.len(), 2);
-        let mut listener = builder.start();
+        assert_eq!(builder.sync_ports.len(), 2);
+        let mut listener = builder.start().unwrap();
         assert!(listener.stop().is_ok());
     }
 
@@ -154,7 +211,7 @@ mod test {
     #[cfg(feature = "termion")]
     fn should_configure_and_start_event_listener_termion() {
         let builder = EventListenerCfg::<MockEvent>::default();
-        assert!(builder.ports.is_empty());
+        assert!(builder.sync_ports.is_empty());
         assert!(builder.tick_interval.is_none());
         assert_eq!(builder.poll_timeout, Duration::from_millis(10));
         let builder = builder.tick_interval(Duration::from_secs(10));
@@ -164,15 +221,15 @@ mod test {
         let builder = builder
             .termion_input_listener(Duration::from_millis(200), 1)
             .add_port(Box::new(MockPoll::default()), Duration::from_secs(300), 1);
-        assert_eq!(builder.ports.len(), 2);
-        let mut listener = builder.start();
+        assert_eq!(builder.sync_ports.len(), 2);
+        let mut listener = builder.start().unwrap();
         assert!(listener.stop().is_ok());
     }
 
     #[test]
     #[should_panic]
     fn event_listener_cfg_should_panic_with_poll_timeout_zero() {
-        EventListenerCfg::<MockEvent>::default()
+        let _ = EventListenerCfg::<MockEvent>::default()
             .poll_timeout(Duration::from_secs(0))
             .start();
     }
@@ -180,9 +237,30 @@ mod test {
     #[test]
     fn should_add_port_via_port_1() {
         let builder = EventListenerCfg::<MockEvent>::default();
-        assert!(builder.ports.is_empty());
-        let builder = builder
-            .port(SyncPort::new(Box::new(MockPoll::default()), Duration::from_millis(1), 1).into());
-        assert_eq!(builder.ports.len(), 1);
+        assert!(builder.sync_ports.is_empty());
+        let builder = builder.port(SyncPort::new(
+            Box::new(MockPoll::default()),
+            Duration::from_millis(1),
+            1,
+        ));
+        assert_eq!(builder.sync_ports.len(), 1);
+    }
+
+    #[test]
+    #[cfg(feature = "async-ports")]
+    fn should_error_without_handle() {
+        use crate::mock::MockPollAsync;
+
+        let port = AsyncPort::<MockEvent>::new(
+            Box::new(MockPollAsync::default()),
+            Duration::from_secs(5),
+            1,
+        );
+
+        let builder = EventListenerCfg::<MockEvent>::default();
+        assert!(builder.async_ports.is_empty());
+        let builder = builder.async_port(port);
+
+        assert_eq!(builder.start().unwrap_err(), ListenerError::NoHandle);
     }
 }

--- a/src/listener/port.rs
+++ b/src/listener/port.rs
@@ -6,116 +6,14 @@
 mod async_p;
 mod sync;
 
-use std::time::{Duration, Instant};
-
 #[cfg(feature = "async-ports")]
 #[cfg_attr(docsrs, doc(cfg(feature = "async-ports")))]
 pub use self::async_p::AsyncPort;
 pub use self::sync::SyncPort;
-use super::ListenerResult;
-use crate::Event;
-
-/// A port is a wrapper around the poll trait object, which also defines an interval, which defines
-/// the amount of time between each [`Poll::poll`] call.
-/// Its purpose is to listen for incoming events of a user-defined type
-///
-/// There are two types of ports:
-///
-/// - [`SyncPort`] - A port that is polled synchronously
-/// - [`AsyncPort`] - A port that is polled asynchronously and supports tokio
-pub enum Port<U>
-where
-    U: Eq + PartialEq + Clone + PartialOrd + Send,
-{
-    Sync(SyncPort<U>),
-    #[cfg(feature = "async-ports")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "async-ports")))]
-    Async(AsyncPort<U>),
-}
-
-impl<U> From<SyncPort<U>> for Port<U>
-where
-    U: Eq + PartialEq + Clone + PartialOrd + Send,
-{
-    fn from(port: SyncPort<U>) -> Self {
-        Port::Sync(port)
-    }
-}
-
-#[cfg(feature = "async-ports")]
-#[cfg_attr(docsrs, doc(cfg(feature = "async-ports")))]
-impl<U> From<AsyncPort<U>> for Port<U>
-where
-    U: Eq + PartialEq + Clone + PartialOrd + Send,
-{
-    fn from(port: AsyncPort<U>) -> Self {
-        Port::Async(port)
-    }
-}
-
-impl<U> Port<U>
-where
-    U: Eq + PartialEq + Clone + PartialOrd + Send + 'static,
-{
-    /// Get how often a port should get polled in a single poll
-    pub fn max_poll(&self) -> usize {
-        match self {
-            Port::Sync(port) => port.max_poll(),
-            #[cfg(feature = "async-ports")]
-            Port::Async(port) => port.max_poll(),
-        }
-    }
-
-    /// Returns the interval for the current [`Port`]
-    pub fn interval(&self) -> &Duration {
-        match self {
-            Port::Sync(port) => port.interval(),
-            #[cfg(feature = "async-ports")]
-            Port::Async(port) => port.interval(),
-        }
-    }
-
-    /// Returns the time of the next poll for this listener
-    pub fn next_poll(&self) -> Instant {
-        match self {
-            Port::Sync(port) => port.next_poll(),
-            #[cfg(feature = "async-ports")]
-            Port::Async(port) => port.next_poll(),
-        }
-    }
-
-    /// Returns whether next poll is now or in the past
-    pub fn should_poll(&self) -> bool {
-        match self {
-            Port::Sync(port) => port.should_poll(),
-            #[cfg(feature = "async-ports")]
-            Port::Async(port) => port.should_poll(),
-        }
-    }
-
-    /// Calls [`Poll::poll`] on the inner [`Poll`] trait object.
-    pub fn poll(&mut self) -> ListenerResult<Option<Event<U>>> {
-        match self {
-            Port::Sync(port) => port.poll(),
-            #[cfg(feature = "async-ports")]
-            Port::Async(port) => port.poll(),
-        }
-    }
-
-    /// Calculate the next poll (t_now + interval)
-    pub fn calc_next_poll(&mut self) {
-        match self {
-            Port::Sync(port) => port.calc_next_poll(),
-            #[cfg(feature = "async-ports")]
-            Port::Async(port) => port.calc_next_poll(),
-        }
-    }
-}
 
 #[cfg(test)]
 mod test {
-
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
     use pretty_assertions::assert_eq;
 
@@ -124,11 +22,8 @@ mod test {
 
     #[test]
     fn test_single_listener() {
-        let mut listener = Port::from(SyncPort::<MockEvent>::new(
-            Box::new(MockPoll::default()),
-            Duration::from_secs(5),
-            1,
-        ));
+        let mut listener =
+            SyncPort::<MockEvent>::new(Box::new(MockPoll::default()), Duration::from_secs(5), 1);
         assert!(listener.next_poll() <= Instant::now());
         assert_eq!(listener.should_poll(), true);
         assert!(listener.poll().ok().unwrap().is_some());
@@ -142,17 +37,14 @@ mod test {
     async fn test_single_async_listener() {
         use crate::mock::MockPollAsync;
 
-        let runtime = std::sync::Arc::new(tokio::runtime::Handle::current());
-
-        let mut listener = Port::from(AsyncPort::<MockEvent>::new(
+        let mut listener = AsyncPort::<MockEvent>::new(
             Box::new(MockPollAsync::default()),
             Duration::from_secs(5),
             1,
-            &runtime,
-        ));
+        );
         assert!(listener.next_poll() <= Instant::now());
         assert_eq!(listener.should_poll(), true);
-        assert!(listener.poll().ok().unwrap().is_some());
+        assert!(listener.poll().await.ok().unwrap().is_some());
         listener.calc_next_poll();
         assert_eq!(listener.should_poll(), false);
         assert_eq!(*listener.interval(), Duration::from_secs(5));

--- a/src/listener/task_pool.rs
+++ b/src/listener/task_pool.rs
@@ -1,0 +1,130 @@
+//! A Taskpool for spawning, tracking and cancelling async ports.
+
+use tokio::runtime::Handle;
+use tokio::select;
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
+
+#[derive(Debug)]
+pub struct TaskPool {
+    tracker: TaskTracker,
+    handle: Handle,
+    // the tracker itself does not cancel tasks on close
+    cancel_token: CancellationToken,
+}
+
+impl TaskPool {
+    pub fn new(handle: Handle) -> Self {
+        Self {
+            tracker: TaskTracker::new(),
+            handle,
+            cancel_token: CancellationToken::new(),
+        }
+    }
+
+    /// Spawn a new future on the [`TaskPool`]s which is tracked and can be cancelled.
+    pub fn spawn<F>(&self, fut: F)
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        let token = self.cancel_token.clone();
+        self.handle.spawn(self.tracker.track_future(async move {
+            select! {
+                () = fut => {},
+                () = token.cancelled() => {}
+            }
+        }));
+    }
+
+    /// Close the tracker and allow [`wait_done`](Self::wait_done) to exit.
+    ///
+    /// Does not prevent adding new tasks.
+    /// Does not cancel any tasks.
+    pub fn close(&self) {
+        self.tracker.close();
+    }
+
+    /// Cancel all tracked tasks.
+    pub fn cancel_all(&self) {
+        self.cancel_token.cancel();
+    }
+
+    /// Wait until all tasks have finished.
+    ///
+    /// NOTE: this will wait infinitely until the task tracker is closed!
+    #[allow(dead_code)]
+    pub async fn wait_done(&self) {
+        self.tracker.wait().await
+    }
+
+    /// Close the Tracker, cancel all tasks in the tracker and wait for all tasks to settle.
+    #[allow(dead_code)]
+    pub async fn cancel_and_wait(&self) {
+        self.close();
+        self.cancel_all();
+        self.wait_done().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    use tokio::runtime::Handle;
+    use tokio::time::sleep;
+
+    use crate::listener::task_pool::TaskPool;
+
+    #[tokio::test]
+    async fn should_spawn_and_close() {
+        let taskpool = TaskPool::new(Handle::current());
+        assert!(taskpool.tracker.is_empty());
+        assert!(!taskpool.tracker.is_closed());
+
+        let active = Arc::new(AtomicUsize::new(0));
+
+        let active_t = active.clone();
+        taskpool.spawn(async move {
+            sleep(Duration::from_millis(2)).await;
+            active_t.fetch_add(1, Ordering::Relaxed);
+        });
+
+        taskpool.close();
+        taskpool.wait_done().await;
+
+        assert_eq!(active.load(Ordering::Relaxed), 1);
+        assert!(taskpool.tracker.is_empty());
+        assert!(taskpool.tracker.is_closed());
+    }
+
+    #[tokio::test]
+    async fn should_cancel() {
+        let taskpool = TaskPool::new(Handle::current());
+        assert!(taskpool.tracker.is_empty());
+        assert!(!taskpool.tracker.is_closed());
+        // note: it seemingly does not count the main async function of the runtime
+        assert_eq!(Handle::current().metrics().num_alive_tasks(), 0);
+
+        let active = Arc::new(AtomicUsize::new(0));
+
+        let active_t = active.clone();
+        taskpool.spawn(async move {
+            active_t.fetch_add(1, Ordering::Relaxed);
+            sleep(Duration::MAX).await;
+        });
+
+        // just to be sure that the other tasks gets executed too
+        sleep(Duration::from_millis(10)).await;
+
+        assert_eq!(Handle::current().metrics().num_alive_tasks(), 1);
+
+        taskpool.cancel_and_wait().await;
+
+        assert_eq!(active.load(Ordering::Relaxed), 1);
+        assert!(taskpool.tracker.is_empty());
+        assert!(taskpool.tracker.is_closed());
+        assert_eq!(Handle::current().metrics().num_alive_tasks(), 0);
+    }
+}

--- a/src/listener/worker.rs
+++ b/src/listener/worker.rs
@@ -111,7 +111,6 @@ where
 
     /// Poll and send poll to listener. Calc next poll.
     /// Returns only the messages, while the None returned by poll are discarded
-    #[allow(clippy::needless_collect)]
     fn poll(&mut self) -> Result<(), mpsc::SendError<ListenerMsg<U>>> {
         let port_iter = self.ports.iter_mut().filter(|port| port.should_poll());
 

--- a/src/listener/worker.rs
+++ b/src/listener/worker.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, mpsc};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use super::{ListenerMsg, Port};
+use super::{ListenerMsg, SyncPort};
 
 // -- worker
 
@@ -17,7 +17,7 @@ pub(super) struct EventListenerWorker<U>
 where
     U: Eq + PartialEq + Clone + PartialOrd + Send,
 {
-    ports: Vec<Port<U>>,
+    ports: Vec<SyncPort<U>>,
     sender: mpsc::Sender<ListenerMsg<U>>,
     paused: Arc<AtomicBool>,
     running: Arc<AtomicBool>,
@@ -30,7 +30,7 @@ where
     U: Eq + PartialEq + Clone + PartialOrd + Send + 'static,
 {
     pub(super) fn new(
-        ports: Vec<Port<U>>,
+        ports: Vec<SyncPort<U>>,
         sender: mpsc::Sender<ListenerMsg<U>>,
         paused: Arc<AtomicBool>,
         running: Arc<AtomicBool>,
@@ -186,8 +186,7 @@ mod test {
         let running = Arc::new(AtomicBool::new(true));
         let running_t = Arc::clone(&running);
 
-        let mock_port =
-            SyncPort::new(Box::new(MockPoll::default()), Duration::from_secs(5), 10).into();
+        let mock_port = SyncPort::new(Box::new(MockPoll::default()), Duration::from_secs(5), 10);
 
         let mut worker =
             EventListenerWorker::<MockEvent>::new(vec![mock_port], tx, paused_t, running_t, None);
@@ -210,7 +209,11 @@ mod test {
         let running = Arc::new(AtomicBool::new(true));
         let running_t = Arc::clone(&running);
         let mut worker = EventListenerWorker::<MockEvent>::new(
-            vec![SyncPort::new(Box::new(MockPoll::default()), Duration::from_secs(5), 1).into()],
+            vec![SyncPort::new(
+                Box::new(MockPoll::default()),
+                Duration::from_secs(5),
+                1,
+            )],
             tx,
             paused_t,
             running_t,
@@ -233,7 +236,11 @@ mod test {
         let running = Arc::new(AtomicBool::new(true));
         let running_t = Arc::clone(&running);
         let mut worker = EventListenerWorker::<MockEvent>::new(
-            vec![SyncPort::new(Box::new(MockPoll::default()), Duration::from_secs(5), 1).into()],
+            vec![SyncPort::new(
+                Box::new(MockPoll::default()),
+                Duration::from_secs(5),
+                1,
+            )],
             tx,
             paused_t,
             running_t,
@@ -256,7 +263,11 @@ mod test {
         let running = Arc::new(AtomicBool::new(true));
         let running_t = Arc::clone(&running);
         let mut worker = EventListenerWorker::<MockEvent>::new(
-            vec![SyncPort::new(Box::new(MockPoll::default()), Duration::from_secs(5), 1).into()],
+            vec![SyncPort::new(
+                Box::new(MockPoll::default()),
+                Duration::from_secs(5),
+                1,
+            )],
             tx,
             paused_t,
             running_t,
@@ -289,7 +300,11 @@ mod test {
         let running = Arc::new(AtomicBool::new(true));
         let running_t = Arc::clone(&running);
         let worker = EventListenerWorker::<MockEvent>::new(
-            vec![SyncPort::new(Box::new(MockPoll::default()), Duration::from_secs(3), 1).into()],
+            vec![SyncPort::new(
+                Box::new(MockPoll::default()),
+                Duration::from_secs(3),
+                1,
+            )],
             tx,
             paused_t,
             running_t,

--- a/src/terminal/event_listener.rs
+++ b/src/terminal/event_listener.rs
@@ -8,4 +8,5 @@ pub use crossterm::CrosstermInputListener;
 #[cfg(feature = "termion")]
 pub use termion::TermionInputListener;
 
+#[allow(unused_imports)] // used in the event listeners
 use crate::Event;


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

re https://github.com/veeso/tui-realm/pull/97#pullrequestreview-2848380162
re #94

## Description

This PR changes Async-Ports to fully run on the provided runtime without basically being a bridge to a Sync-Port. This has some notable changes:

- Removed the need for a handle on *each* async-port, instead
- set a handle on the `EventListenerCfg` via `with_handle`, which in turn
- returns a error on `EventListenerCfg::start` if there is no handle, but async-ports are defined, which finally
- panics in `Application::init` if no handle had been set, but async-ports were defined (due to not wanting to change that function signature)

Note that the async-ports fully support:
- pausing
- cancelling & stop

The only thing i dont *quite* like is how `EventListener::start` and `EventListener::start_async` have dependencies on each other, but i didnt want `::start`'s function signature to change depending on if a feature is active or not, but as long as it stays private to the crate, i dont think it should be a big problem.

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [ ] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

---

I only noticed later than #94 and #97 that it may be a good idea to use something like [`futures::Stream`](https://docs.rs/futures-core/0.3.31/futures_core/stream/trait.Stream.html)(basically a async iterator) instead of a custom trait, and it may be beneficial to change the sync `Poll` to be a Iterator as well (similar to how rodio handles [Samples in a Source](https://github.com/RustAudio/rodio/blob/d2313b0bfee41fdf5ad6da5c1bd1a5a18ea71e75/src/source/mod.rs#L154)?).