### PR TITLE
Some more Async changes, including default async ports.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           tool: cargo-llvm-cov
       - name: Run tests
-        run: cargo llvm-cov --no-fail-fast --no-default-features --features derive,serialize,crossterm --workspace --lcov --output-path lcov.info
+        run: cargo llvm-cov --no-fail-fast --no-default-features --features derive,serialize,crossterm,async-ports --workspace --lcov --output-path lcov.info
       - name: Coveralls
         uses: coverallsapp/github-action@v2.3.6
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Unreleased
 - Fix bug that `EventListener::stop` did not actually stop any async tasks.
 - Add function `EventListenerCfg::async_tick` to switch the ticker from Sync-Port to Async-Ports. Note that `EventListenerCfg::tick_interval` is still necessary to enable any ticker.
 - Dont start the Sync-Port worker if there are no sync ports (note that `async_tick(false)`(the default) also counts as a sync port).
+- Fix accidental always inclusion of `crossterm` dependency, even if `crossterm` feature was disabled. (since [2.2.0](#220))
 
 ## 2.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Unreleased
 - Add function `EventListenerCfg::async_tick` to switch the ticker from Sync-Port to Async-Ports. Note that `EventListenerCfg::tick_interval` is still necessary to enable any ticker.
 - Dont start the Sync-Port worker if there are no sync ports (note that `async_tick(false)`(the default) also counts as a sync port).
 - Fix accidental always inclusion of `crossterm` dependency, even if `crossterm` feature was disabled. (since [2.2.0](#220))
+- Change `PollAsync::poll` to take `&mut self` instead of `&self`.
 
 ## 2.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@
 
 ---
 
+## next
+
+Unreleased
+
+- Remove `+ Sync` bound on `PollAsync` trait and `U`(Event) bound and all related functions.
+
 ## 2.4.0
 
 Released on 19/05/2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 Unreleased
 
 - Remove `+ Sync` bound on `PollAsync` trait and `U`(Event) bound and all related functions.
+- Fix bug that `EventListener::stop` did not actually stop any async tasks.
 
 ## 2.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Unreleased
 - Dont start the Sync-Port worker if there are no sync ports (note that `async_tick(false)`(the default) also counts as a sync port).
 - Fix accidental always inclusion of `crossterm` dependency, even if `crossterm` feature was disabled. (since [2.2.0](#220))
 - Change `PollAsync::poll` to take `&mut self` instead of `&self`.
+- Add async `crossterm` input listener `CrosstermAsyncStream` as a alternative to the sync `CrosstermInputListener`.
 
 ## 2.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ Unreleased
 
 - Remove `+ Sync` bound on `PollAsync` trait and `U`(Event) bound and all related functions.
 - Fix bug that `EventListener::stop` did not actually stop any async tasks.
+- Add function `EventListenerCfg::async_tick` to switch the ticker from Sync-Port to Async-Ports. Note that `EventListenerCfg::tick_interval` is still necessary to enable any ticker.
+- Dont start the Sync-Port worker if there are no sync ports (note that `async_tick(false)`(the default) also counts as a sync port).
 
 ## 2.4.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ tempfile = "^3"
 tokio = { version = "1", features = ["full"] }
 
 [features]
-default = ["derive", "dep:crossterm"]
+default = ["derive", "crossterm"]
 async-ports = ["dep:async-trait", "dep:tokio", "dep:tokio-util"]
 derive = ["dep:tuirealm_derive"]
 serialize = ["dep:serde", "bitflags/serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ tokio = { version = "1", features = [
 tokio-util = { version = "0.7", features = [
   "rt",
 ], default-features = false, optional = true }
+futures-util = { version = "0.3", default-features = false, optional = true }
 tuirealm_derive = { version = "2", optional = true }
 
 [dev-dependencies]
@@ -41,7 +42,7 @@ tokio = { version = "1", features = ["full"] }
 
 [features]
 default = ["derive", "crossterm"]
-async-ports = ["dep:async-trait", "dep:tokio", "dep:tokio-util"]
+async-ports = ["dep:async-trait", "dep:tokio", "dep:tokio-util", "crossterm?/event-stream", "dep:futures-util"]
 derive = ["dep:tuirealm_derive"]
 serialize = ["dep:serde", "bitflags/serde"]
 crossterm = ["dep:crossterm", "ratatui/crossterm"]

--- a/examples/async_ports.rs
+++ b/examples/async_ports.rs
@@ -190,7 +190,7 @@ impl AsyncPort {
 
 #[tuirealm::async_trait]
 impl PollAsync<UserEvent> for AsyncPort {
-    async fn poll(&self) -> ListenerResult<Option<Event<UserEvent>>> {
+    async fn poll(&mut self) -> ListenerResult<Option<Event<UserEvent>>> {
         let result = self.write_file().await;
 
         Ok(Some(Event::User(UserEvent::WroteFile(result))))

--- a/examples/async_ports.rs
+++ b/examples/async_ports.rs
@@ -21,8 +21,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let handle = Handle::current();
 
     let event_listener = EventListenerCfg::default()
-        .crossterm_input_listener(Duration::from_millis(10), 3)
         .with_handle(handle)
+        .async_crossterm_input_listener(Duration::default(), 3)
         .add_async_port(Box::new(AsyncPort::new()), Duration::from_millis(1000), 1);
 
     let mut app: Application<Id, Msg, UserEvent> = Application::init(event_listener);

--- a/src/listener/async_ticker.rs
+++ b/src/listener/async_ticker.rs
@@ -1,0 +1,39 @@
+use super::{ListenerResult, PollAsync};
+use crate::Event;
+
+/// [`PollAsync`] implementation to have a Async-Port for emitting [`Event::Tick`].
+///
+/// This will emit a [`Event::Tick`] on every [`poll`](Self::poll) call, relying on the [`tick_interval`](super::EventListener) to handle intervals.
+#[derive(Debug, Clone, Copy)]
+pub struct AsyncTicker();
+
+impl AsyncTicker {
+    pub fn new() -> Self {
+        Self()
+    }
+}
+
+#[async_trait::async_trait]
+impl<U> PollAsync<U> for AsyncTicker
+where
+    U: Eq + PartialEq + Clone + PartialOrd + Send + 'static,
+{
+    async fn poll(&self) -> ListenerResult<Option<Event<U>>> {
+        Ok(Some(Event::Tick))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AsyncTicker;
+    use crate::listener::PollAsync;
+    use crate::{Event, NoUserEvent};
+
+    #[tokio::test]
+    async fn should_emit_tick_on_every_poll() {
+        let ticker = AsyncTicker::new();
+        assert_eq!(ticker.poll().await, Ok(Some(Event::<NoUserEvent>::Tick)));
+        assert_eq!(ticker.poll().await, Ok(Some(Event::<NoUserEvent>::Tick)));
+        assert_eq!(ticker.poll().await, Ok(Some(Event::<NoUserEvent>::Tick)));
+    }
+}

--- a/src/listener/async_ticker.rs
+++ b/src/listener/async_ticker.rs
@@ -18,7 +18,7 @@ impl<U> PollAsync<U> for AsyncTicker
 where
     U: Eq + PartialEq + Clone + PartialOrd + Send + 'static,
 {
-    async fn poll(&self) -> ListenerResult<Option<Event<U>>> {
+    async fn poll(&mut self) -> ListenerResult<Option<Event<U>>> {
         Ok(Some(Event::Tick))
     }
 }
@@ -31,7 +31,7 @@ mod tests {
 
     #[tokio::test]
     async fn should_emit_tick_on_every_poll() {
-        let ticker = AsyncTicker::new();
+        let mut ticker = AsyncTicker::new();
         assert_eq!(ticker.poll().await, Ok(Some(Event::<NoUserEvent>::Tick)));
         assert_eq!(ticker.poll().await, Ok(Some(Event::<NoUserEvent>::Tick)));
         assert_eq!(ticker.poll().await, Ok(Some(Event::<NoUserEvent>::Tick)));

--- a/src/listener/builder.rs
+++ b/src/listener/builder.rs
@@ -132,10 +132,25 @@ where
     /// Add to the event listener the default crossterm input listener [`crate::terminal::CrosstermInputListener`]
     ///
     /// The interval is the amount of time between each [`Poll::poll`] call.
-    /// The max_poll is the maximum amount of times the port should be polled in a single poll.
+    /// The max_poll is the maximum amount of times the port should be polled in a `interval`.
     pub fn crossterm_input_listener(self, interval: Duration, max_poll: usize) -> Self {
         self.add_port(
             Box::new(crate::terminal::CrosstermInputListener::<U>::new(interval)),
+            interval,
+            max_poll,
+        )
+    }
+
+    #[cfg(all(feature = "crossterm", feature = "async-ports"))]
+    /// Add to the async event listener the default crossterm input listener [`crate::terminal::CrosstermAsyncStream`]
+    ///
+    /// The `interval` is the amount of time between each [`PollAsync::poll`](super::PollAsync) call.
+    /// The `max_poll` is the maximum amount of times the port should be polled in a single `interval`.
+    ///
+    /// It is recommended to set `interval` to `0` to have immediate events.
+    pub fn async_crossterm_input_listener(self, interval: Duration, max_poll: usize) -> Self {
+        self.add_async_port(
+            Box::new(crate::terminal::CrosstermAsyncStream::new()),
             interval,
             max_poll,
         )
@@ -145,7 +160,7 @@ where
     /// Add to the event listener the default termion input listener [`crate::terminal::TermionInputListener`]
     ///
     /// The interval is the amount of time between each [`Poll::poll`] call.
-    /// The max_poll is the maximum amount of times the port should be polled in a single poll.
+    /// The max_poll is the maximum amount of times the port should be polled in a `interval`.
     pub fn termion_input_listener(self, interval: Duration, max_poll: usize) -> Self {
         self.add_port(
             Box::new(crate::terminal::TermionInputListener::<U>::new(interval)),

--- a/src/listener/builder.rs
+++ b/src/listener/builder.rs
@@ -140,9 +140,10 @@ where
     }
 }
 
+/// Implementations for feature `async-ports`
 impl<U> EventListenerCfg<U>
 where
-    U: Eq + PartialEq + Clone + PartialOrd + Send + Sync + 'static,
+    U: Eq + PartialEq + Clone + PartialOrd + Send + 'static,
 {
     /// Add a new [`Port`] (Poll, Interval) to the the event listener.
     ///
@@ -152,7 +153,7 @@ where
     #[cfg_attr(docsrs, doc(cfg(feature = "async-ports")))]
     pub fn add_async_port(
         self,
-        poll: Box<dyn super::PollAsync<U> + Send + Sync>,
+        poll: Box<dyn super::PollAsync<U>>,
         interval: Duration,
         max_poll: usize,
     ) -> Self {

--- a/src/listener/builder.rs
+++ b/src/listener/builder.rs
@@ -321,10 +321,9 @@ mod test {
         assert_eq!(Handle::current().metrics().num_alive_tasks(), 1);
         assert!(listener.thread.is_none()); // there are no sync ports or tasks, so no sync worker
         assert!(listener.taskpool.is_some());
-        sleep(Duration::from_millis(25)).await; // wait for at least 2 events
+        sleep(Duration::from_millis(25)).await; // wait for at least 1 event
 
         listener.stop().unwrap();
-        assert_eq!(listener.poll(), Ok(Some(Event::Tick)));
         assert_eq!(listener.poll(), Ok(Some(Event::Tick)));
     }
 }

--- a/src/listener/builder.rs
+++ b/src/listener/builder.rs
@@ -57,9 +57,8 @@ where
         #[cfg(feature = "async-ports")]
         let store_tx = !self.async_ports.is_empty();
         #[allow(unused_mut)] // mutability is necessary when "async-ports" is active
-        let mut res = EventListener::start(
+        let mut res = EventListener::new(self.poll_timeout).start(
             self.sync_ports,
-            self.poll_timeout,
             self.tick_interval,
             store_tx,
         );

--- a/src/listener/mod.rs
+++ b/src/listener/mod.rs
@@ -101,8 +101,9 @@ where
     /// The taskpool to track all async ports and cancel them
     #[cfg(feature = "async-ports")]
     taskpool: Option<TaskPool>,
-    /// The event transmitter to allow async ports from a different function
-    #[cfg(feature = "async-ports")]
+    /// The event emitter associated with `recv`, until `start` and `start_async` are called.
+    ///
+    /// This needs to be [`None`] after either [`start`](Self::start) or [`start_async`](Self::start_async) is called, otherwise the channel will never close.
     tx: Option<mpsc::Sender<ListenerMsg<U>>>,
 }
 
@@ -110,9 +111,37 @@ impl<U> EventListener<U>
 where
     U: Eq + PartialEq + Clone + PartialOrd + Send + 'static,
 {
-    /// Create a new [`EventListener`] and start it.
-    /// - `poll` is the trait object which polls for input events
+    /// Create a new [`EventListener`].
     /// - `poll_interval` is the interval to poll for input events. It should always be at least a poll time used by `poll`
+    ///
+    /// # Panics
+    ///
+    /// - if `poll_timeout` is 0
+    pub(self) fn new(poll_timeout: Duration) -> Self {
+        if poll_timeout == Duration::ZERO {
+            panic!(
+                "poll timeout cannot be 0 (see <https://github.com/rust-lang/rust/issues/39364>)"
+            )
+        }
+
+        let (sender, recv) = mpsc::channel();
+        let paused = Arc::new(AtomicBool::new(false));
+        let running = Arc::new(AtomicBool::new(false));
+
+        Self {
+            poll_timeout,
+            paused,
+            running,
+            recv,
+            thread: None,
+            #[cfg(feature = "async-ports")]
+            taskpool: None,
+            tx: Some(sender),
+        }
+    }
+
+    /// Start a worker for Sync-Ports.
+    /// - `ports` are the sync-ports to start on the worker.
     /// - `tick_interval` is the interval used to send the `Tick` event. If `None`, no tick will be sent.
     /// - `store_tx` is used to determine if the Transmitter should be stored for [`start_async`](Self::start_async). Has not effect if `async-ports` is not enabled.
     ///
@@ -121,42 +150,31 @@ where
     ///
     /// NOTE: if `store_tx` is set to `true` but [`start_async`](Self::start_async) is never called, [`poll`](Self::poll) will always timeout instead of returning `Disconnected`
     /// after [`stop`](Self::stop) due a still open channel.
-    ///
-    /// # Panics
-    ///
-    /// - if `poll_timeout` is 0
     #[allow(unused_variables)] // "store_tx" is necessary when "async-ports" is active
     pub(self) fn start(
+        self,
         ports: Vec<SyncPort<U>>,
-        poll_timeout: Duration,
         tick_interval: Option<Duration>,
         store_tx: bool,
     ) -> Self {
-        if poll_timeout == Duration::ZERO {
-            panic!(
-                "poll timeout cannot be 0 (see <https://github.com/rust-lang/rust/issues/39364>)"
-            )
-        }
+        #[cfg(feature = "async-ports")]
+        let tx = if store_tx { self.tx.clone() } else { None };
+
         // Prepare channel and running state
-        let config = Self::setup_thread(ports, tick_interval);
+        #[allow(unused_mut)] // mutability is necessary when "async-ports" is active
+        let mut res = self.setup_sync_worker(ports, tick_interval);
 
         #[cfg(feature = "async-ports")]
-        let tx = if store_tx { Some(config.tx) } else { None };
-
-        Self {
-            paused: config.paused,
-            running: config.running,
-            poll_timeout,
-            recv: config.rx,
-            thread: Some(config.thread),
-            #[cfg(feature = "async-ports")]
-            taskpool: None,
-            #[cfg(feature = "async-ports")]
-            tx,
+        {
+            res.tx = tx;
         }
+
+        res
     }
 
     /// Start the given async `ports` on a taskpool.
+    /// - `ports` are the async-ports to start on the given runtime.
+    /// - `tick_interval` is the interval used to send the `Tick` event. If `None`, no tick will be sent.
     ///
     /// # Panics
     ///
@@ -226,18 +244,21 @@ where
     }
 
     /// Setup the thread and returns the structs necessary to interact with it
-    fn setup_thread(ports: Vec<SyncPort<U>>, tick_interval: Option<Duration>) -> ThreadConfig<U> {
-        let (sender, recv) = mpsc::channel();
-        let paused = Arc::new(AtomicBool::new(false));
-        let paused_t = Arc::clone(&paused);
-        let running = Arc::new(AtomicBool::new(true));
-        let running_t = Arc::clone(&running);
-        let sender_t = sender.clone();
+    fn setup_sync_worker(
+        mut self,
+        ports: Vec<SyncPort<U>>,
+        tick_interval: Option<Duration>,
+    ) -> Self {
+        self.running.store(true, Ordering::Relaxed);
+        let paused_t = self.paused.clone();
+        let running_t = self.running.clone();
+        let sender_t = self.tx.take().unwrap().clone();
         // Start thread
         let thread = thread::spawn(move || {
             EventListenerWorker::new(ports, sender_t, paused_t, running_t, tick_interval).run();
         });
-        ThreadConfig::new(recv, sender, paused, running, thread)
+        self.thread = Some(thread);
+        self
     }
 }
 
@@ -287,42 +308,6 @@ where
     }
 }
 
-// -- thread config
-
-/// Config returned by thread setup
-struct ThreadConfig<U>
-where
-    U: Eq + PartialEq + Clone + PartialOrd + Send + 'static,
-{
-    rx: mpsc::Receiver<ListenerMsg<U>>,
-    #[allow(dead_code)] // used when "async-ports" is active, but always assigned
-    tx: mpsc::Sender<ListenerMsg<U>>,
-    paused: Arc<AtomicBool>,
-    running: Arc<AtomicBool>,
-    thread: JoinHandle<()>,
-}
-
-impl<U> ThreadConfig<U>
-where
-    U: Eq + PartialEq + Clone + PartialOrd + Send + 'static,
-{
-    pub fn new(
-        rx: mpsc::Receiver<ListenerMsg<U>>,
-        tx: mpsc::Sender<ListenerMsg<U>>,
-        paused: Arc<AtomicBool>,
-        running: Arc<AtomicBool>,
-        thread: JoinHandle<()>,
-    ) -> Self {
-        Self {
-            rx,
-            tx,
-            paused,
-            running,
-            thread,
-        }
-    }
-}
-
 // -- listener thread
 
 /// Listener message is returned by the listener thread
@@ -359,13 +344,12 @@ mod test {
 
     #[test]
     fn worker_should_run_thread() {
-        let mut listener = EventListener::<MockEvent>::start(
+        let mut listener = EventListener::<MockEvent>::new(Duration::from_millis(10)).start(
             vec![SyncPort::new(
                 Box::new(MockPoll::default()),
                 Duration::from_secs(10),
                 1,
             )],
-            Duration::from_millis(10),
             Some(Duration::from_secs(3)),
             false,
         );
@@ -390,9 +374,8 @@ mod test {
 
     #[test]
     fn worker_should_be_paused() {
-        let mut listener = EventListener::<MockEvent>::start(
+        let mut listener = EventListener::<MockEvent>::new(Duration::from_millis(10)).start(
             vec![],
-            Duration::from_millis(10),
             Some(Duration::from_millis(750)),
             false,
         );
@@ -426,13 +409,9 @@ mod test {
         );
         assert_eq!(Handle::current().metrics().num_alive_tasks(), 0);
 
-        let mut listener = EventListener::<MockEvent>::start(
-            vec![],
-            Duration::from_millis(10),
-            Some(Duration::from_secs(3)),
-            true,
-        )
-        .start_async(vec![port], Handle::current());
+        let mut listener = EventListener::<MockEvent>::new(Duration::from_millis(10))
+            .start(vec![], Some(Duration::from_secs(3)), true)
+            .start_async(vec![port], Handle::current());
         sleep(Duration::from_millis(5)).await; // ensure the tasks are spawned and have a chance to generate already
         assert_eq!(Handle::current().metrics().num_alive_tasks(), 1);
 
@@ -461,13 +440,8 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic = "poll timeout cannot be 0"]
     fn event_listener_with_poll_timeout_zero_should_panic() {
-        EventListener::<MockEvent>::start(
-            vec![],
-            Duration::from_millis(0),
-            Some(Duration::from_secs(3)),
-            false,
-        );
+        EventListener::<MockEvent>::new(Duration::from_millis(0));
     }
 }

--- a/src/listener/mod.rs
+++ b/src/listener/mod.rs
@@ -67,7 +67,7 @@ where
 #[cfg(feature = "async-ports")]
 #[cfg_attr(docsrs, doc(cfg(feature = "async-ports")))]
 #[async_trait::async_trait]
-pub trait PollAsync<UserEvent>: Send + Sync
+pub trait PollAsync<UserEvent>: Send
 where
     UserEvent: Eq + PartialEq + Clone + PartialOrd + Send + 'static,
 {

--- a/src/listener/mod.rs
+++ b/src/listener/mod.rs
@@ -79,7 +79,7 @@ where
     /// If it was possible to poll for event, `Ok` must be returned.
     /// If an event was read, then [`Some`] must be returned, otherwise [`None`].
     /// The event must be converted to `Event` using the `adapters`.
-    async fn poll(&self) -> ListenerResult<Option<Event<UserEvent>>>;
+    async fn poll(&mut self) -> ListenerResult<Option<Event<UserEvent>>>;
 }
 
 /// The event listener is a worker that runs in a separate thread and polls for events

--- a/src/listener/port/async_p.rs
+++ b/src/listener/port/async_p.rs
@@ -1,5 +1,4 @@
 use std::ops::Add as _;
-use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use crate::Event;
@@ -14,7 +13,7 @@ pub struct AsyncPort<U>
 where
     U: Eq + PartialEq + Clone + PartialOrd + Send,
 {
-    poll: Arc<Box<dyn PollAsync<U> + Send + Sync>>,
+    poll: Box<dyn PollAsync<U>>,
     interval: Duration,
     next_poll: Instant,
     max_poll: usize,
@@ -32,13 +31,9 @@ where
     /// * `interval` - The interval between each poll
     /// * `max_poll` - The maximum amount of times the port should be polled in a single poll
     /// * `runtime` - The tokio runtime to use for async polling
-    pub fn new(
-        poll: Box<dyn PollAsync<U> + Send + Sync>,
-        interval: Duration,
-        max_poll: usize,
-    ) -> Self {
+    pub fn new(poll: Box<dyn PollAsync<U>>, interval: Duration, max_poll: usize) -> Self {
         Self {
-            poll: Arc::new(poll),
+            poll,
             interval,
             next_poll: Instant::now(),
             max_poll,

--- a/src/listener/worker.rs
+++ b/src/listener/worker.rs
@@ -29,6 +29,10 @@ impl<U> EventListenerWorker<U>
 where
     U: Eq + PartialEq + Clone + PartialOrd + Send + 'static,
 {
+    /// Create a new Worker.
+    ///
+    /// If `tick_interval` is [`None`], no [`Event::Tick`](crate::Event::Tick) will be sent and a fallback interval time will be used.
+    /// If `tick_interval` is [`Some`], [`Event::Tick`](crate::Event::Tick) will be sent and be used as the interval time.
     pub(super) fn new(
         ports: Vec<SyncPort<U>>,
         sender: mpsc::Sender<ListenerMsg<U>>,
@@ -55,6 +59,7 @@ where
     /// Calc the distance in time between now and the first upcoming event
     fn next_event(&self) -> Duration {
         let now = Instant::now();
+        // TODO: this time should likely be lowered
         let fallback_time = now.add(Duration::from_secs(60));
         // Get first upcoming event from ports
         let min_listener_event = self

--- a/src/mock/mod.rs
+++ b/src/mock/mod.rs
@@ -60,7 +60,7 @@ pub struct MockPollAsync();
 impl<U: Eq + PartialEq + Clone + PartialOrd + Send + 'static> crate::listener::PollAsync<U>
     for MockPollAsync
 {
-    async fn poll(&self) -> ListenerResult<Option<Event<U>>> {
+    async fn poll(&mut self) -> ListenerResult<Option<Event<U>>> {
         let tempfile = tempfile::NamedTempFile::new().expect("tempfile");
         let _file = tokio::fs::File::open(tempfile.path()).await.expect("file");
 

--- a/src/mock/mod.rs
+++ b/src/mock/mod.rs
@@ -52,21 +52,13 @@ impl<U: Eq + PartialEq + Clone + PartialOrd + Send + 'static> Poll<U> for MockPo
 }
 
 #[cfg(feature = "async-ports")]
-pub struct MockPollAsync<U: Eq + PartialEq + Clone + PartialOrd + Send> {
-    ghost: PhantomData<U>,
-}
-
-#[cfg(feature = "async-ports")]
-impl<U: Eq + PartialEq + Clone + PartialOrd + Send> Default for MockPollAsync<U> {
-    fn default() -> Self {
-        Self { ghost: PhantomData }
-    }
-}
+#[derive(Default)]
+pub struct MockPollAsync();
 
 #[cfg(feature = "async-ports")]
 #[async_trait::async_trait]
-impl<U: Eq + PartialEq + Clone + PartialOrd + Send + Sync + 'static> crate::listener::PollAsync<U>
-    for MockPollAsync<U>
+impl<U: Eq + PartialEq + Clone + PartialOrd + Send + 'static> crate::listener::PollAsync<U>
+    for MockPollAsync
 {
     async fn poll(&self) -> ListenerResult<Option<Event<U>>> {
         let tempfile = tempfile::NamedTempFile::new().expect("tempfile");

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -15,6 +15,9 @@ pub use self::adapter::TerminalAdapter;
 #[cfg(feature = "termion")]
 #[cfg_attr(docsrs, doc(cfg(feature = "termion")))]
 pub use self::adapter::TermionTerminalAdapter;
+#[cfg(all(feature = "crossterm", feature = "async-ports"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "crossterm", feature = "async-ports"))))]
+pub use self::event_listener::CrosstermAsyncStream;
 #[cfg(feature = "crossterm")]
 #[cfg_attr(docsrs, doc(cfg(feature = "crossterm")))]
 pub use self::event_listener::CrosstermInputListener;

--- a/src/terminal/event_listener.rs
+++ b/src/terminal/event_listener.rs
@@ -1,10 +1,14 @@
 #[cfg(feature = "crossterm")]
 mod crossterm;
+#[cfg(all(feature = "crossterm", feature = "async-ports"))]
+mod crossterm_async;
 #[cfg(feature = "termion")]
 mod termion;
 
 #[cfg(feature = "crossterm")]
 pub use crossterm::CrosstermInputListener;
+#[cfg(all(feature = "crossterm", feature = "async-ports"))]
+pub use crossterm_async::CrosstermAsyncStream;
 #[cfg(feature = "termion")]
 pub use termion::TermionInputListener;
 

--- a/src/terminal/event_listener/crossterm.rs
+++ b/src/terminal/event_listener/crossterm.rs
@@ -17,7 +17,7 @@ use crate::listener::{ListenerResult, Poll};
 
 /// The input listener for crossterm.
 /// If crossterm is enabled, this will already be exported as `InputEventListener` in the `adapter` module
-/// or you can use it directly in the event listener, calling `default_input_listener()` in the `EventListenerCfg`
+/// or you can use it directly in the event listener, calling [`EventListenerCfg::crossterm_input_listener()`](crate::EventListenerCfg::crossterm_input_listener)
 #[doc(alias = "InputEventListener")]
 pub struct CrosstermInputListener<U>
 where

--- a/src/terminal/event_listener/crossterm_async.rs
+++ b/src/terminal/event_listener/crossterm_async.rs
@@ -1,0 +1,44 @@
+use crossterm::event::EventStream;
+use futures_util::StreamExt;
+
+use crate::listener::{ListenerResult, PollAsync};
+use crate::{Event, ListenerError};
+
+/// The async input listener for crossterm.
+/// This can be manually added as a async port, or directly via [`EventListenerCfg::crossterm_input_listener()`](crate::EventListenerCfg::crossterm_input_listener)
+///
+/// NOTE: This relies on [`From`] implementations in [`super::crossterm`].
+#[doc(alias = "InputEventListener")]
+#[derive(Debug)]
+pub struct CrosstermAsyncStream {
+    stream: EventStream,
+}
+
+impl CrosstermAsyncStream {
+    pub fn new() -> Self {
+        CrosstermAsyncStream {
+            stream: EventStream::new(),
+        }
+    }
+}
+
+impl Default for CrosstermAsyncStream {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait::async_trait]
+impl<U: Eq + PartialEq + Clone + PartialOrd + Send + 'static> PollAsync<U>
+    for CrosstermAsyncStream
+{
+    async fn poll(&mut self) -> ListenerResult<Option<Event<U>>> {
+        let res = match self.stream.next().await {
+            Some(Ok(event)) => event,
+            Some(Err(_err)) => return Err(ListenerError::PollFailed),
+            None => return Ok(None),
+        };
+
+        Ok(Some(Event::from(res)))
+    }
+}


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

re #94

## Description

This PR does some more async changes re #98, #97 and #94, the following changes are included:
- fix not being able to close the async taskpool that was added in #98 (i forgot to actually assign the created taskpool, 
resulting in it always being `None` on `close`)
- fix always having dependency `crossterm` enabled as a default instead of feature `crossterm` (re version `2.2.0`)
- change `PollAsync::poll` to not require `+ Sync` anymore
- change `PollAsync::poll` to take `&mut self`
- add default async ports:
  - `AsyncTicker` to generate ticks in a async way
  - `CrosstermAsyncStream` for a async crossterm input listener
    -  due to how `crossterm::EventStream` is implemented, we need to depend on `futures-util` for the `StreamExt` trait (note that this does not actually add any new dependency to the chain, as `tokio-util` already depends on it)
- dont start the sync worker if there are no sync tasks (due to now being able to have the ticker be async)

Note that `termion` does not have a async listener as it does not provide a async interface, and the only workaround would be to bridge the sync-port to be a async port, where it could just run as a sync port directly.
(it does provide [`AsyncReader`](https://docs.rs/termion/latest/termion/struct.AsyncReader.html), but unlike its name, it just means it has non-blocking reads instead of reads with futures and there is no `notify`-like function to manually implement async functionality)

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [ ] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

---

Unless there is some kind of issue, i think this is the last PR for async ports.
