### PR TITLE
Add `SubClause::OrMany` and `SubClause::AndMany`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,13 @@
 
 ---
 
+## next
+
+Unreleased
+
+- Add `SubClause::AndMany` for easier adding of many clauses that would otherwise be nested `SubClause::And`.
+- Add `SubClause::OrMany` for easier adding of many clauses that would otherwise be nested `SubClause::Or`.
+
 ## 2.4.1
 
 Released on 19/05/2025

--- a/src/core/subscription.rs
+++ b/src/core/subscription.rs
@@ -20,6 +20,7 @@ where
     U: Eq + PartialEq + Clone + PartialOrd,
 {
     /// Creates a new `Sub`
+    #[must_use]
     pub fn new(event_clause: EventClause<U>, sub_clause: SubClause<K>) -> Self {
         Self(event_clause, sub_clause)
     }
@@ -57,6 +58,7 @@ where
     U: Eq + PartialEq + Clone + PartialOrd + Send,
 {
     /// Instantiates a new [`Subscription`]
+    #[must_use]
     pub fn new(target: K, sub: Sub<K, U>) -> Self {
         Self {
             target,
@@ -66,16 +68,19 @@ where
     }
 
     /// Returns sub target
+    #[must_use]
     pub(crate) fn target(&self) -> &K {
         &self.target
     }
 
     /// Returns reference to subscription event clause
+    #[must_use]
     pub(crate) fn event(&self) -> &EventClause<U> {
         &self.ev
     }
 
     /// Returns whether to forward event to component
+    #[must_use]
     pub(crate) fn forward<HasAttrFn, GetStateFn, MountedFn>(
         &self,
         ev: &Event<U>,
@@ -212,21 +217,25 @@ where
 {
     /// Shortcut for [`SubClause::Not`] without specifying `Box::new(...)`
     #[allow(clippy::should_implement_trait)]
+    #[must_use]
     pub fn not(clause: Self) -> Self {
         Self::Not(Box::new(clause))
     }
 
     /// Shortcut for [`SubClause::And`] without specifying `Box::new(...)`
+    #[must_use]
     pub fn and(a: Self, b: Self) -> Self {
         Self::And(Box::new(a), Box::new(b))
     }
 
     /// Shortcut for [`SubClause::Or`] without specifying `Box::new(...)`
+    #[must_use]
     pub fn or(a: Self, b: Self) -> Self {
         Self::Or(Box::new(a), Box::new(b))
     }
 
     /// Returns whether the subscription clause is satisfied
+    #[must_use]
     pub(crate) fn forward<HasAttrFn, GetStateFn, MountedFn>(
         &self,
         has_attr_fn: HasAttrFn,
@@ -243,6 +252,7 @@ where
     }
 
     /// Function to recursively check forwarding.
+    #[must_use]
     fn check_forwarding<HasAttrFn, GetStateFn, MountedFn>(
         &self,
         has_attr_fn: HasAttrFn,
@@ -325,6 +335,7 @@ where
 
     // -- privates
 
+    #[must_use]
     fn has_attribute<HasAttrFn>(
         id: &Id,
         query: &Attribute,
@@ -343,6 +354,7 @@ where
         )
     }
 
+    #[must_use]
     fn has_state<GetStateFn>(id: &Id, state: &State, get_state_fn: GetStateFn) -> (bool, GetStateFn)
     where
         GetStateFn: Fn(&Id) -> Option<State>,
@@ -356,6 +368,7 @@ where
         )
     }
 
+    #[must_use]
     fn is_mounted<MountedFn>(id: &Id, mounted_fn: MountedFn) -> (bool, MountedFn)
     where
         MountedFn: Fn(&Id) -> bool,


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

None

## Description

This PR adds variants `OrMany` and `AndMany` for `SubClause` to reduce nesting when there are many conditions.
For example this would help flatten [termusic's popup condition code](https://github.com/tramhao/termusic/blob/00aa02f4f29a714e48206de99eb4367f946b5c15/tui/src/ui/components/global_listener.rs#L265-L347) to be way less nested.
This is mainly aiming to help with cognitive load and "view at a glance" and so to improve code quality in application code, though i think this also reduces the RAM fragmentation and should also improve cache-locality, not that this a important in this code-path.
Also annotate functions with `must_use` to get hints when forgetting to use something.

Note: both clauses always return `false` if they dont have any clauses, as anything else i dont think makes sense. (there is no panic as i dont think that code path should panic)

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

---

PS: i just noticed there are macros for a similar action already (`crate::subclause_and` & `crate::subclause_or`), should those be changed to the new version or documentation changed to indicate that a alternative is available or deprecate them?