### PR TITLE
Less moving of values & apply some clippy pedantic lints

### DIFF
--- a/examples/async_ports.rs
+++ b/examples/async_ports.rs
@@ -51,7 +51,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Ok(messages) if !messages.is_empty() => {
                 // NOTE: redraw if at least one msg has been processed
                 model.redraw = true;
-                for msg in messages.into_iter() {
+                for msg in messages {
                     let mut msg = Some(msg);
                     while msg.is_some() {
                         msg = model.update(msg);

--- a/examples/demo/app/model.rs
+++ b/examples/demo/app/model.rs
@@ -165,7 +165,7 @@ where
                             .attr(
                                 &Id::Label,
                                 Attribute::Text,
-                                AttrValue::String(format!("DigitCounter has now value: {}", v))
+                                AttrValue::String(format!("DigitCounter has now value: {v}"))
                             )
                             .is_ok()
                     );
@@ -183,7 +183,7 @@ where
                             .attr(
                                 &Id::Label,
                                 Attribute::Text,
-                                AttrValue::String(format!("LetterCounter has now value: {}", v))
+                                AttrValue::String(format!("LetterCounter has now value: {v}"))
                             )
                             .is_ok()
                     );

--- a/examples/demo/components/clock.rs
+++ b/examples/demo/components/clock.rs
@@ -56,7 +56,7 @@ impl Clock {
         let hours = (since_the_epoch / 3600) % 24;
         let minutes = (since_the_epoch / 60) % 60;
         let seconds = since_the_epoch % 60;
-        format!("{:02}:{:02}:{:02}", hours, minutes, seconds)
+        format!("{hours:02}:{minutes:02}:{seconds:02}")
     }
 
     fn get_epoch_time(&self) -> u64 {

--- a/examples/demo/components/mod.rs
+++ b/examples/demo/components/mod.rs
@@ -17,15 +17,16 @@ pub use clock::Clock;
 pub use counter::{DigitCounter, LetterCounter};
 pub use label::Label;
 
-/// ### get_block
+/// ### `get_block`
 ///
 /// Get block
 pub(crate) fn get_block<'a>(props: Borders, title: (String, Alignment), focus: bool) -> Block<'a> {
     Block::default()
         .borders(props.sides)
-        .border_style(match focus {
-            true => props.style(),
-            false => Style::default().fg(Color::Reset).bg(Color::Reset),
+        .border_style(if focus {
+            props.style()
+        } else {
+            Style::default().fg(Color::Reset).bg(Color::Reset)
         })
         .border_type(props.modifiers)
         .title(title.0)

--- a/examples/demo/demo.rs
+++ b/examples/demo/demo.rs
@@ -49,7 +49,7 @@ fn main() {
                         .attr(
                             &Id::Label,
                             Attribute::Text,
-                            AttrValue::String(format!("Application error: {}", err)),
+                            AttrValue::String(format!("Application error: {err}")),
                         )
                         .is_ok()
                 );
@@ -57,7 +57,7 @@ fn main() {
             Ok(messages) if !messages.is_empty() => {
                 // NOTE: redraw if at least one msg has been processed
                 model.redraw = true;
-                for msg in messages.into_iter() {
+                for msg in messages {
                     let mut msg = Some(msg);
                     while msg.is_some() {
                         msg = model.update(msg);

--- a/examples/user_events/user_events.rs
+++ b/examples/user_events/user_events.rs
@@ -97,7 +97,7 @@ fn main() {
             Ok(messages) if !messages.is_empty() => {
                 // NOTE: redraw if at least one msg has been processed
                 model.redraw = true;
-                for msg in messages.into_iter() {
+                for msg in messages {
                     let mut msg = Some(msg);
                     while msg.is_some() {
                         msg = model.update(msg);

--- a/src/core/application.rs
+++ b/src/core/application.rs
@@ -101,7 +101,7 @@ where
             .collect();
         // Forward to subscriptions and extend vector
         if !self.sub_lock {
-            messages.extend(self.forward_to_subscriptions(events));
+            self.forward_to_subscriptions(events, &mut messages);
         }
         Ok(messages)
     }
@@ -334,8 +334,7 @@ where
     }
 
     /// Forward events to subscriptions listening to the incoming event.
-    fn forward_to_subscriptions(&mut self, events: Vec<Event<UserEvent>>) -> Vec<Msg> {
-        let mut messages: Vec<Msg> = Vec::new();
+    fn forward_to_subscriptions(&mut self, events: Vec<Event<UserEvent>>, messages: &mut Vec<Msg>) {
         // NOTE: don't touch this code again and don't try to use iterators, cause it's not gonna work :)
         for ev in events.iter() {
             for sub in self.subs.iter() {
@@ -356,7 +355,6 @@ where
                 }
             }
         }
-        messages
     }
 }
 

--- a/src/core/application.rs
+++ b/src/core/application.rs
@@ -710,7 +710,7 @@ mod test {
                 .ok()
                 .unwrap()
                 .as_slice(),
-            &[MockMsg::FooSubmit(String::from("")), MockMsg::BarTick]
+            &[MockMsg::FooSubmit(String::new()), MockMsg::BarTick]
         );
         // Active BAR
         assert!(application.active(&MockComponentId::InputBar).is_ok());
@@ -727,7 +727,7 @@ mod test {
                 .ok()
                 .unwrap()
                 .as_slice(),
-            &[MockMsg::BarSubmit(String::from(""))]
+            &[MockMsg::BarSubmit(String::new())]
         );
         // Let's try TryFor strategy
         let events = application
@@ -782,7 +782,7 @@ mod test {
                 .ok()
                 .unwrap()
                 .as_slice(),
-            &[MockMsg::FooSubmit(String::from(""))]
+            &[MockMsg::FooSubmit(String::new())]
         );
         // unlock subs
         application.unlock_subs();
@@ -828,7 +828,7 @@ mod test {
                 .ok()
                 .unwrap()
                 .as_slice(),
-            &[MockMsg::FooSubmit(String::from(""))]
+            &[MockMsg::FooSubmit(String::new())]
         );
     }
 
@@ -870,7 +870,7 @@ mod test {
                 .ok()
                 .unwrap()
                 .as_slice(),
-            &[MockMsg::FooSubmit(String::from("")), MockMsg::BarTick]
+            &[MockMsg::FooSubmit(String::new()), MockMsg::BarTick]
         );
     }
 
@@ -908,7 +908,7 @@ mod test {
                 .ok()
                 .unwrap()
                 .as_slice(),
-            &[MockMsg::FooSubmit(String::from(""))]
+            &[MockMsg::FooSubmit(String::new())]
         );
     }
 
@@ -950,7 +950,7 @@ mod test {
                 .ok()
                 .unwrap()
                 .as_slice(),
-            &[MockMsg::FooSubmit(String::from("")), MockMsg::BarTick]
+            &[MockMsg::FooSubmit(String::new()), MockMsg::BarTick]
         );
     }
 
@@ -988,7 +988,7 @@ mod test {
                 .ok()
                 .unwrap()
                 .as_slice(),
-            &[MockMsg::FooSubmit(String::from(""))]
+            &[MockMsg::FooSubmit(String::new())]
         );
     }
 
@@ -1026,7 +1026,7 @@ mod test {
                 .ok()
                 .unwrap()
                 .as_slice(),
-            &[MockMsg::FooSubmit(String::from("")), MockMsg::BarTick]
+            &[MockMsg::FooSubmit(String::new()), MockMsg::BarTick]
         );
     }
 
@@ -1064,7 +1064,7 @@ mod test {
                 .ok()
                 .unwrap()
                 .as_slice(),
-            &[MockMsg::FooSubmit(String::from("")), MockMsg::BarTick]
+            &[MockMsg::FooSubmit(String::new()), MockMsg::BarTick]
         );
         // Lock ports
         assert!(application.lock_ports().is_ok());
@@ -1090,7 +1090,7 @@ mod test {
                 .ok()
                 .unwrap()
                 .as_slice(),
-            &[MockMsg::FooSubmit(String::from("")), MockMsg::BarTick]
+            &[MockMsg::FooSubmit(String::new()), MockMsg::BarTick]
         );
     }
 

--- a/src/core/props/dataset.rs
+++ b/src/core/props/dataset.rs
@@ -30,8 +30,8 @@ impl Default for Dataset {
 
 impl Dataset {
     /// Set name for dataset
-    pub fn name<S: AsRef<str>>(mut self, s: S) -> Self {
-        self.name = s.as_ref().to_string();
+    pub fn name<S: Into<String>>(mut self, s: S) -> Self {
+        self.name = s.into();
         self
     }
 

--- a/src/core/props/input_type.rs
+++ b/src/core/props/input_type.rs
@@ -62,10 +62,10 @@ impl fmt::Debug for InputType {
         match *self {
             Self::Color => write!(f, "InputType::Color"),
             Self::Custom(..) => write!(f, "InputType::Custom"),
-            Self::CustomPassword(c, _, _) => write!(f, "InputType::CustomPassword({})", c),
+            Self::CustomPassword(c, _, _) => write!(f, "InputType::CustomPassword({c})"),
             Self::Email => write!(f, "InputType::Email"),
             Self::Number => write!(f, "InputType::Number"),
-            Self::Password(ch) => write!(f, "InputType::Password({})", ch),
+            Self::Password(ch) => write!(f, "InputType::Password({ch})"),
             Self::SignedInteger => write!(f, "InputType::SignedInteger"),
             Self::Telephone => write!(f, "InputType::Telephone"),
             Self::Text => write!(f, "InputType::Text"),

--- a/src/core/props/texts.rs
+++ b/src/core/props/texts.rs
@@ -20,9 +20,9 @@ pub struct TextSpan {
 
 impl TextSpan {
     /// Instantiate a new `TextSpan`
-    pub fn new<S: AsRef<str>>(text: S) -> Self {
+    pub fn new<S: Into<String>>(text: S) -> Self {
         Self {
-            content: text.as_ref().to_string(),
+            content: text.into(),
             fg: Color::Reset,
             bg: Color::Reset,
             modifiers: Modifier::empty(),
@@ -90,7 +90,7 @@ impl Default for TextSpan {
 
 impl<S> From<S> for TextSpan
 where
-    S: AsRef<str>,
+    S: Into<String>,
 {
     fn from(txt: S) -> Self {
         TextSpan::new(txt)

--- a/src/core/props/value.rs
+++ b/src/core/props/value.rs
@@ -140,7 +140,7 @@ impl PropPayload {
         }
     }
 
-    /// Get a Vec value from PropPa&Vec<PropValue>None
+    /// Get a Vec value from PropPayload, or None
     pub fn as_vec(&self) -> Option<&Vec<PropValue>> {
         match self {
             PropPayload::Vec(v) => Some(v),

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -49,49 +49,49 @@ impl State {
     pub fn unwrap_one(self) -> StateValue {
         match self {
             Self::One(val) => val,
-            state => panic!("Could not unwrap {:?} as `One`", state),
+            state => panic!("Could not unwrap {state:?} as `One`"),
         }
     }
 
     pub fn unwrap_tup2(self) -> (StateValue, StateValue) {
         match self {
             Self::Tup2(val) => val,
-            state => panic!("Could not unwrap {:?} as `Tup2`", state),
+            state => panic!("Could not unwrap {state:?} as `Tup2`"),
         }
     }
 
     pub fn unwrap_tup3(self) -> (StateValue, StateValue, StateValue) {
         match self {
             Self::Tup3(val) => val,
-            state => panic!("Could not unwrap {:?} as `Tup3`", state),
+            state => panic!("Could not unwrap {state:?} as `Tup3`"),
         }
     }
 
     pub fn unwrap_tup4(self) -> (StateValue, StateValue, StateValue, StateValue) {
         match self {
             Self::Tup4(val) => val,
-            state => panic!("Could not unwrap {:?} as `Tup4`", state),
+            state => panic!("Could not unwrap {state:?} as `Tup4`"),
         }
     }
 
     pub fn unwrap_vec(self) -> Vec<StateValue> {
         match self {
             Self::Vec(val) => val,
-            state => panic!("Could not unwrap {:?} as `Vec`", state),
+            state => panic!("Could not unwrap {state:?} as `Vec`"),
         }
     }
 
     pub fn unwrap_map(self) -> HashMap<String, StateValue> {
         match self {
             Self::Map(val) => val,
-            state => panic!("Could not unwrap {:?} as `Map`", state),
+            state => panic!("Could not unwrap {state:?} as `Map`"),
         }
     }
 
     pub fn unwrap_linked(self) -> LinkedList<State> {
         match self {
             Self::Linked(val) => val,
-            state => panic!("Could not unwrap {:?} as `Linked`", state),
+            state => panic!("Could not unwrap {state:?} as `Linked`"),
         }
     }
 
@@ -110,126 +110,126 @@ impl StateValue {
     pub fn unwrap_bool(self) -> bool {
         match self {
             Self::Bool(val) => val,
-            value => panic!("Could not unwrap {:?} as `Bool`", value),
+            value => panic!("Could not unwrap {value:?} as `Bool`"),
         }
     }
 
     pub fn unwrap_u8(self) -> u8 {
         match self {
             Self::U8(val) => val,
-            value => panic!("Could not unwrap {:?} as `U8`", value),
+            value => panic!("Could not unwrap {value:?} as `U8`"),
         }
     }
 
     pub fn unwrap_u16(self) -> u16 {
         match self {
             Self::U16(val) => val,
-            value => panic!("Could not unwrap {:?} as `U16`", value),
+            value => panic!("Could not unwrap {value:?} as `U16`"),
         }
     }
 
     pub fn unwrap_u32(self) -> u32 {
         match self {
             Self::U32(val) => val,
-            value => panic!("Could not unwrap {:?} as `U32`", value),
+            value => panic!("Could not unwrap {value:?} as `U32`"),
         }
     }
 
     pub fn unwrap_u64(self) -> u64 {
         match self {
             Self::U64(val) => val,
-            value => panic!("Could not unwrap {:?} as `U64`", value),
+            value => panic!("Could not unwrap {value:?} as `U64`"),
         }
     }
 
     pub fn unwrap_u128(self) -> u128 {
         match self {
             Self::U128(val) => val,
-            value => panic!("Could not unwrap {:?} as `U128`", value),
+            value => panic!("Could not unwrap {value:?} as `U128`"),
         }
     }
 
     pub fn unwrap_usize(self) -> usize {
         match self {
             Self::Usize(val) => val,
-            value => panic!("Could not unwrap {:?} as `Usize`", value),
+            value => panic!("Could not unwrap {value:?} as `Usize`"),
         }
     }
 
     pub fn unwrap_i8(self) -> i8 {
         match self {
             Self::I8(val) => val,
-            value => panic!("Could not unwrap {:?} as `I8`", value),
+            value => panic!("Could not unwrap {value:?} as `I8`"),
         }
     }
 
     pub fn unwrap_i16(self) -> i16 {
         match self {
             Self::I16(val) => val,
-            value => panic!("Could not unwrap {:?} as `I16`", value),
+            value => panic!("Could not unwrap {value:?} as `I16`"),
         }
     }
 
     pub fn unwrap_i32(self) -> i32 {
         match self {
             Self::I32(val) => val,
-            value => panic!("Could not unwrap {:?} as `I32`", value),
+            value => panic!("Could not unwrap {value:?} as `I32`"),
         }
     }
 
     pub fn unwrap_i64(self) -> i64 {
         match self {
             Self::I64(val) => val,
-            value => panic!("Could not unwrap {:?} as `I64`", value),
+            value => panic!("Could not unwrap {value:?} as `I64`"),
         }
     }
 
     pub fn unwrap_i128(self) -> i128 {
         match self {
             Self::I128(val) => val,
-            value => panic!("Could not unwrap {:?} as `I128`", value),
+            value => panic!("Could not unwrap {value:?} as `I128`"),
         }
     }
 
     pub fn unwrap_isize(self) -> isize {
         match self {
             Self::Isize(val) => val,
-            value => panic!("Could not unwrap {:?} as `Isize`", value),
+            value => panic!("Could not unwrap {value:?} as `Isize`"),
         }
     }
 
     pub fn unwrap_f64(self) -> f64 {
         match self {
             Self::F64(val) => val,
-            value => panic!("Could not unwrap {:?} as `F64`", value),
+            value => panic!("Could not unwrap {value:?} as `F64`"),
         }
     }
 
     pub fn unwrap_string(self) -> String {
         match self {
             Self::String(val) => val,
-            value => panic!("Could not unwrap {:?} as `String`", value),
+            value => panic!("Could not unwrap {value:?} as `String`"),
         }
     }
 
     pub fn unwrap_color(self) -> Color {
         match self {
             Self::Color(val) => val,
-            value => panic!("Could not unwrap {:?} as `Color`", value),
+            value => panic!("Could not unwrap {value:?} as `Color`"),
         }
     }
 
     pub fn unwrap_email(self) -> Email {
         match self {
             Self::Email(val) => val,
-            value => panic!("Could not unwrap {:?} as `Email`", value),
+            value => panic!("Could not unwrap {value:?} as `Email`"),
         }
     }
 
     pub fn unwrap_phone_number(self) -> PhoneNumber {
         match self {
             Self::PhoneNumber(val) => val,
-            value => panic!("Could not unwrap {:?} as `PhoneNumber`", value),
+            value => panic!("Could not unwrap {value:?} as `PhoneNumber`"),
         }
     }
 }

--- a/src/core/subscription.rs
+++ b/src/core/subscription.rs
@@ -106,7 +106,7 @@ pub struct MouseEventClause {
 }
 
 impl MouseEventClause {
-    fn is_in_range(&self, ev: &MouseEvent) -> bool {
+    fn is_in_range(&self, ev: MouseEvent) -> bool {
         self.column.contains(&ev.column) && self.row.contains(&ev.row)
     }
 }
@@ -154,7 +154,7 @@ where
         match self {
             EventClause::Any => true,
             EventClause::Keyboard(k) => Some(k) == ev.as_keyboard(),
-            EventClause::Mouse(m) => ev.as_mouse().map(|ev| m.is_in_range(ev)).unwrap_or(false),
+            EventClause::Mouse(m) => ev.as_mouse().is_some_and(|ev| m.is_in_range(*ev)),
             EventClause::WindowResize => ev.as_window_resize(),
             EventClause::Tick => ev.as_tick(),
             EventClause::User(u) => Some(u) == ev.as_user(),

--- a/src/core/view.rs
+++ b/src/core/view.rs
@@ -73,14 +73,14 @@ where
 {
     /// Mount component on View.
     /// Returns error if the component is already mounted
-    pub fn mount(&mut self, id: K, component: WrappedComponent<Msg, UserEvent>) -> ViewResult<()> {
-        if self.mounted(&id) {
+    pub fn mount(&mut self, id: &K, component: WrappedComponent<Msg, UserEvent>) -> ViewResult<()> {
+        if self.mounted(id) {
             Err(ViewError::ComponentAlreadyMounted)
         } else {
             // Insert
             self.components.insert(id.clone(), component);
             // Inject properties
-            self.inject(&id)
+            self.inject(id)
         }
     }
 
@@ -102,20 +102,20 @@ where
     /// Remount component. This method WON'T change the focus stack
     pub fn remount(
         &mut self,
-        id: K,
+        id: &K,
         component: WrappedComponent<Msg, UserEvent>,
     ) -> ViewResult<()> {
         // Umount, but keep focus
-        let had_focus = self.has_focus(&id);
-        if self.mounted(&id) {
-            self.components.remove(&id);
+        let had_focus = self.has_focus(id);
+        if self.mounted(id) {
+            self.components.remove(id);
         }
         // remount
         self.components.insert(id.clone(), component);
         // Inject properties
-        self.inject(&id)?;
+        self.inject(id)?;
         // give focus if needed
-        if had_focus { self.active(&id) } else { Ok(()) }
+        if had_focus { self.active(id) } else { Ok(()) }
     }
 
     /// Umount all components in the view and clear focus stack and state
@@ -283,7 +283,7 @@ where
     /// Inject properties for `id` using view injectors
     fn inject(&mut self, id: &K) -> ViewResult<()> {
         for (attr, value) in self.properties_to_inject(id) {
-            self.attr(id, attr, value)?
+            self.attr(id, attr, value)?;
         }
         Ok(())
     }
@@ -319,23 +319,32 @@ mod test {
         let mut view: View<MockComponentId, MockMsg, MockEvent> = View::default();
         // Mount foo
         assert!(
-            view.mount(MockComponentId::InputFoo, Box::new(MockFooInput::default()))
-                .is_ok()
+            view.mount(
+                &MockComponentId::InputFoo,
+                Box::new(MockFooInput::default())
+            )
+            .is_ok()
         );
         assert_eq!(view.components.len(), 1);
         assert!(view.mounted(&MockComponentId::InputFoo));
         assert_eq!(view.mounted(&MockComponentId::InputBar), false);
         // Mount bar
         assert!(
-            view.mount(MockComponentId::InputBar, Box::new(MockBarInput::default()))
-                .is_ok()
+            view.mount(
+                &MockComponentId::InputBar,
+                Box::new(MockBarInput::default())
+            )
+            .is_ok()
         );
         assert_eq!(view.components.len(), 2);
         assert!(view.mounted(&MockComponentId::InputBar));
         // Mount twice
         assert!(
-            view.mount(MockComponentId::InputBar, Box::new(MockBarInput::default()))
-                .is_err()
+            view.mount(
+                &MockComponentId::InputBar,
+                Box::new(MockBarInput::default())
+            )
+            .is_err()
         );
         assert_eq!(view.components.len(), 2);
         assert!(view.mounted(&MockComponentId::InputBar));
@@ -356,20 +365,29 @@ mod test {
         let mut view: View<MockComponentId, MockMsg, MockEvent> = View::default();
         // Mount foo
         assert!(
-            view.mount(MockComponentId::InputFoo, Box::new(MockFooInput::default()))
-                .is_ok()
+            view.mount(
+                &MockComponentId::InputFoo,
+                Box::new(MockFooInput::default())
+            )
+            .is_ok()
         );
         assert!(view.active(&MockComponentId::InputFoo).is_ok());
         // mount another component
         assert!(
-            view.mount(MockComponentId::InputBar, Box::new(MockBarInput::default()))
-                .is_ok()
+            view.mount(
+                &MockComponentId::InputBar,
+                Box::new(MockBarInput::default())
+            )
+            .is_ok()
         );
         assert!(view.active(&MockComponentId::InputBar).is_ok());
         // Remount foo
         assert!(
-            view.remount(MockComponentId::InputFoo, Box::new(MockFooInput::default()))
-                .is_ok()
+            view.remount(
+                &MockComponentId::InputFoo,
+                Box::new(MockFooInput::default())
+            )
+            .is_ok()
         );
         // Blur bar
         assert!(view.blur().is_ok());
@@ -382,23 +400,32 @@ mod test {
         let mut view: View<MockComponentId, MockMsg, MockEvent> = View::default();
         // Mount foo
         assert!(
-            view.mount(MockComponentId::InputFoo, Box::new(MockFooInput::default()))
-                .is_ok()
+            view.mount(
+                &MockComponentId::InputFoo,
+                Box::new(MockFooInput::default())
+            )
+            .is_ok()
         );
         assert_eq!(view.components.len(), 1);
         assert!(view.mounted(&MockComponentId::InputFoo));
         assert_eq!(view.mounted(&MockComponentId::InputBar), false);
         // Mount bar
         assert!(
-            view.mount(MockComponentId::InputBar, Box::new(MockBarInput::default()))
-                .is_ok()
+            view.mount(
+                &MockComponentId::InputBar,
+                Box::new(MockBarInput::default())
+            )
+            .is_ok()
         );
         assert_eq!(view.components.len(), 2);
         assert!(view.mounted(&MockComponentId::InputBar));
         // Mount twice
         assert!(
-            view.mount(MockComponentId::InputBar, Box::new(MockBarInput::default()))
-                .is_err()
+            view.mount(
+                &MockComponentId::InputBar,
+                Box::new(MockBarInput::default())
+            )
+            .is_err()
         );
         assert_eq!(view.components.len(), 2);
         // Give focus
@@ -418,10 +445,7 @@ mod test {
             .map(|x| MockComponentId::Dyn(format!("INPUT_{}", x)))
             .collect();
         names.iter().for_each(|x| {
-            assert!(
-                view.mount(x.clone(), Box::new(MockBarInput::default()))
-                    .is_ok()
-            );
+            assert!(view.mount(x, Box::new(MockBarInput::default())).is_ok());
         });
         assert_eq!(view.components.len(), 10);
         names.iter().for_each(|x| assert!(view.mounted(x)));
@@ -431,16 +455,22 @@ mod test {
     fn view_should_handle_focus() {
         let mut view: View<MockComponentId, MockMsg, MockEvent> = View::default();
         assert!(
-            view.mount(MockComponentId::InputFoo, Box::new(MockFooInput::default()))
-                .is_ok()
-        );
-        assert!(
-            view.mount(MockComponentId::InputBar, Box::new(MockBarInput::default()))
-                .is_ok()
+            view.mount(
+                &MockComponentId::InputFoo,
+                Box::new(MockFooInput::default())
+            )
+            .is_ok()
         );
         assert!(
             view.mount(
-                MockComponentId::InputOmar,
+                &MockComponentId::InputBar,
+                Box::new(MockBarInput::default())
+            )
+            .is_ok()
+        );
+        assert!(
+            view.mount(
+                &MockComponentId::InputOmar,
                 Box::new(MockBarInput::default())
             )
             .is_ok()
@@ -498,8 +528,11 @@ mod test {
         assert_eq!(view.focus_stack.len(), 0);
         // Remount BAR
         assert!(
-            view.mount(MockComponentId::InputBar, Box::new(MockBarInput::default()))
-                .is_ok()
+            view.mount(
+                &MockComponentId::InputBar,
+                Box::new(MockBarInput::default())
+            )
+            .is_ok()
         );
         // Active BAR
         assert!(view.active(&MockComponentId::InputBar).is_ok());
@@ -519,8 +552,11 @@ mod test {
     fn view_should_forward_events() {
         let mut view: View<MockComponentId, MockMsg, MockEvent> = View::default();
         assert!(
-            view.mount(MockComponentId::InputFoo, Box::new(MockFooInput::default()))
-                .is_ok()
+            view.mount(
+                &MockComponentId::InputFoo,
+                Box::new(MockFooInput::default())
+            )
+            .is_ok()
         );
         let ev: Event<MockEvent> = Event::Keyboard(KeyEvent::from(Key::Char('a')));
         assert_eq!(
@@ -541,8 +577,11 @@ mod test {
     fn view_should_read_and_write_attributes() {
         let mut view: View<MockComponentId, MockMsg, MockEvent> = View::default();
         assert!(
-            view.mount(MockComponentId::InputFoo, Box::new(MockFooInput::default()))
-                .is_ok()
+            view.mount(
+                &MockComponentId::InputFoo,
+                Box::new(MockFooInput::default())
+            )
+            .is_ok()
         );
         assert_eq!(
             view.query(&MockComponentId::InputFoo, Attribute::Focus)
@@ -574,8 +613,11 @@ mod test {
     fn view_should_read_state() {
         let mut view: View<MockComponentId, MockMsg, MockEvent> = View::default();
         assert!(
-            view.mount(MockComponentId::InputFoo, Box::new(MockFooInput::default()))
-                .is_ok()
+            view.mount(
+                &MockComponentId::InputFoo,
+                Box::new(MockFooInput::default())
+            )
+            .is_ok()
         );
         assert_eq!(
             view.state(&MockComponentId::InputFoo).unwrap(),
@@ -589,8 +631,11 @@ mod test {
         let mut view: View<MockComponentId, MockMsg, MockEvent> = View::default();
         view.add_injector(Box::new(MockInjector));
         assert!(
-            view.mount(MockComponentId::InputBar, Box::new(MockBarInput::default()))
-                .is_ok()
+            view.mount(
+                &MockComponentId::InputBar,
+                Box::new(MockBarInput::default())
+            )
+            .is_ok()
         );
         // Check if property has been injected
         assert_eq!(

--- a/src/core/view.rs
+++ b/src/core/view.rs
@@ -579,7 +579,7 @@ mod test {
         );
         assert_eq!(
             view.state(&MockComponentId::InputFoo).unwrap(),
-            State::One(StateValue::String(String::from("")))
+            State::One(StateValue::String(String::new()))
         );
         assert!(view.state(&MockComponentId::InputBar).is_err());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@
 //! Supported features are:
 //!
 //! - `derive` (*default*): add the `#[derive(MockComponent)]` proc macro to automatically implement `MockComponent` for `Component`. [Read more](https://github.com/veeso/tuirealm_derive).
+//! - `async-ports`: add support for async ports
 //! - `serialize`: add the serialize/deserialize trait implementation for `KeyEvent` and `Key`.
 //! - `crossterm`: use the [crossterm](https://github.com/crossterm-rs/crossterm) terminal backend
 //! - `termion`: use the [termion](https://github.com/redox-os/termion) terminal backend

--- a/src/listener/builder.rs
+++ b/src/listener/builder.rs
@@ -112,7 +112,7 @@ where
         self
     }
 
-    /// Add a new [`Port`] (Poll, Interval) to the the event listener.
+    /// Add a new [`SyncPort`] (Poll, Interval) to the the event listener.
     ///
     /// The interval is the amount of time between each [`Poll::poll`] call.
     /// The max_poll is the maximum amount of times the port should be polled in a single poll.
@@ -120,9 +120,9 @@ where
         self.port(SyncPort::new(poll, interval, max_poll))
     }
 
-    /// Add a new [`Port`] to the the event listener
+    /// Add a new [`SyncPort`] to the the event listener
     ///
-    /// The [`Port`] needs to be manually constructed, unlike [`Self::add_port`]
+    /// The [`SyncPort`] needs to be manually constructed, unlike [`Self::add_port`]
     pub fn port(mut self, port: SyncPort<U>) -> Self {
         self.sync_ports.push(port);
         self
@@ -175,7 +175,7 @@ impl<U> EventListenerCfg<U>
 where
     U: Eq + PartialEq + Clone + PartialOrd + Send + 'static,
 {
-    /// Add a new [`Port`] (Poll, Interval) to the the event listener.
+    /// Add a new [`AsyncPort`] (Poll, Interval) to the the event listener.
     ///
     /// The interval is the amount of time between each [`super::PollAsync::poll`] call.
     /// The max_poll is the maximum amount of times the port should be polled in a single poll.
@@ -187,7 +187,7 @@ where
         interval: Duration,
         max_poll: usize,
     ) -> Self {
-        self.async_port(super::AsyncPort::new(poll, interval, max_poll))
+        self.async_port(AsyncPort::new(poll, interval, max_poll))
     }
 
     /// Add a new [`AsyncPort`] to the the event listener.

--- a/src/listener/mod.rs
+++ b/src/listener/mod.rs
@@ -229,7 +229,7 @@ where
 
         // Join thread
         match self.thread.take().map(|x| x.join()) {
-            Some(Ok(_)) => Ok(()),
+            Some(Ok(())) => Ok(()),
             Some(Err(_)) => Err(ListenerError::CouldNotStop),
             None => Ok(()), // Never happens, unless someone calls stop twice
         }

--- a/src/listener/port/async_p.rs
+++ b/src/listener/port/async_p.rs
@@ -45,7 +45,7 @@ where
         self.max_poll
     }
 
-    /// Returns the interval for the current [`Port`]
+    /// Returns the interval for the current [`AsyncPort`]
     pub fn interval(&self) -> &Duration {
         &self.interval
     }

--- a/src/listener/port/sync.rs
+++ b/src/listener/port/sync.rs
@@ -42,7 +42,7 @@ where
         self.max_poll
     }
 
-    /// Returns the interval for the current [`Port`]
+    /// Returns the interval for the current [`SyncPort`]
     pub fn interval(&self) -> &Duration {
         &self.interval
     }

--- a/src/listener/task_pool.rs
+++ b/src/listener/task_pool.rs
@@ -54,7 +54,7 @@ impl TaskPool {
     /// NOTE: this will wait infinitely until the task tracker is closed!
     #[allow(dead_code)]
     pub async fn wait_done(&self) {
-        self.tracker.wait().await
+        self.tracker.wait().await;
     }
 
     /// Close the Tracker, cancel all tasks in the tracker and wait for all tasks to settle.

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -235,12 +235,12 @@ impl TerminalBridge<adapter::TermionTerminalAdapter> {
         Self::init(adapter::TermionTerminalAdapter::new().unwrap())
     }
 
-    /// Returns a reference to the underlying [`Terminal`]
+    /// Returns a reference to the underlying Terminal
     pub fn raw(&self) -> &adapter::TermionBackend {
         self.terminal.raw()
     }
 
-    /// Returns a mutable reference to the underlying [`Terminal`]
+    /// Returns a mutable reference to the underlying Terminal
     pub fn raw_mut(&mut self) -> &mut adapter::TermionBackend {
         self.terminal.raw_mut()
     }

--- a/src/utils/types.rs
+++ b/src/utils/types.rs
@@ -13,8 +13,7 @@ pub struct PhoneNumber {
 
 impl PhoneNumber {
     pub fn new<S: AsRef<str>>(prefix: Option<S>, number: S) -> Self {
-        let number = number.as_ref().replace(' ', "");
-        let number = number.replace('-', "");
+        let number = number.as_ref().replace([' ', '-'], "");
         Self {
             prefix: prefix.map(|x| x.as_ref().to_string()),
             number,
@@ -25,7 +24,7 @@ impl PhoneNumber {
     pub fn phone_number(&self) -> String {
         match &self.prefix {
             None => self.number.clone(),
-            Some(prefix) => format!("+{}{}", prefix, self.number),
+            Some(prefix) => format!("+{prefix}{}", self.number),
         }
     }
 }

--- a/src/utils/types.rs
+++ b/src/utils/types.rs
@@ -39,10 +39,10 @@ pub struct Email {
 }
 
 impl Email {
-    pub fn new<S: AsRef<str>>(name: S, agent: S) -> Self {
+    pub fn new<S: Into<String>>(name: S, agent: S) -> Self {
         Self {
-            name: name.as_ref().to_string(),
-            agent: agent.as_ref().to_string(),
+            name: name.into(),
+            agent: agent.into(),
         }
     }
 


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

None

## Description

This PR refactors some internal functions to move less values (ex `Application::forward_to_subscriptions`), applies some clippy pedantic suggestions where appropriate, derives common traits on `PollStrategy`, replaces `AsRef<str>` with `Into<String>` where the values are always cloned anyway and finally fixes most warnings `cargo doc` generates.

There are likely more improvements that could be done, but i didnt wanna touch the public API in this PR or make too big changes.

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
