### PR TITLE
Update macros to new `SubClause::*Many` cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ Unreleased
 
 - Add `SubClause::AndMany` for easier adding of many clauses that would otherwise be nested `SubClause::And`.
 - Add `SubClause::OrMany` for easier adding of many clauses that would otherwise be nested `SubClause::Or`.
+- Change the `subclause_` macros to make use of the new `SubClause::*Many` variants.
+- Change the `subclause_` macros to be able to end with a `,` without error.
+- Change the `subclause_and_not` to only have one `Not` instead of for every case.
 
 ## 2.4.1
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -28,7 +28,6 @@
 ///     ])
 ///  );
 /// ```
-///
 #[macro_export]
 macro_rules! subclause_and {
     ($id:expr) => {
@@ -64,31 +63,27 @@ macro_rules! subclause_and {
 ///    Id::InputBar,
 ///    Id::InputFoo,
 ///    Id::InputOmar
-///    );
+/// );
 ///
 /// assert_eq!(
 ///     sub_clause,
-///     SubClause::And(
-///         Box::new(SubClause::Not(Box::new(SubClause::IsMounted(Id::InputBar)))),
-///         Box::new(SubClause::And(
-///             Box::new(SubClause::Not(Box::new(SubClause::IsMounted(Id::InputFoo)))),
-///             Box::new(SubClause::Not(Box::new(SubClause::IsMounted(
-///                 Id::InputOmar
-///             ))))
-///         ))
-///     )
+///     SubClause::not(SubClause::AndMany(vec![
+///         SubClause::IsMounted(Id::InputBar),
+///         SubClause::IsMounted(Id::InputFoo),
+///         SubClause::IsMounted(Id::InputOmar),
+///     ]))
 ///  );
 /// ```
-///
 #[macro_export]
 macro_rules! subclause_and_not {
     ($id:expr) => {
         SubClause::not(SubClause::IsMounted($id))
     };
-    ($id:expr, $($rest:expr),+) => {
-        SubClause::and(
-            SubClause::not(SubClause::IsMounted($id)),
-            tuirealm::subclause_and_not!($($rest),+)
+    ($($rest:expr),+ $(,)?) => {
+        SubClause::not(
+            SubClause::AndMany(vec![
+                $(SubClause::IsMounted($rest)),*
+            ])
         )
     };
 }
@@ -123,7 +118,6 @@ macro_rules! subclause_and_not {
 ///     ])
 ///  );
 /// ```
-///
 #[macro_export]
 macro_rules! subclause_or {
     ($id:expr) => {
@@ -175,6 +169,43 @@ mod tests {
                 SubClause::IsMounted(MockComponentId::InputFoo),
                 SubClause::IsMounted(MockComponentId::InputOmar),
             ])
+        );
+    }
+
+    #[test]
+    fn subclause_and_not() {
+        // single
+        assert_eq!(
+            subclause_and_not!(MockComponentId::InputBar),
+            SubClause::not(SubClause::IsMounted(MockComponentId::InputBar)),
+        );
+
+        // multiple with no ending comma
+        assert_eq!(
+            subclause_and_not!(
+                MockComponentId::InputBar,
+                MockComponentId::InputFoo,
+                MockComponentId::InputOmar
+            ),
+            SubClause::not(SubClause::AndMany(vec![
+                SubClause::IsMounted(MockComponentId::InputBar),
+                SubClause::IsMounted(MockComponentId::InputFoo),
+                SubClause::IsMounted(MockComponentId::InputOmar),
+            ]))
+        );
+
+        // multiple with ending comma
+        assert_eq!(
+            subclause_and_not!(
+                MockComponentId::InputBar,
+                MockComponentId::InputFoo,
+                MockComponentId::InputOmar,
+            ),
+            SubClause::not(SubClause::AndMany(vec![
+                SubClause::IsMounted(MockComponentId::InputBar),
+                SubClause::IsMounted(MockComponentId::InputFoo),
+                SubClause::IsMounted(MockComponentId::InputOmar),
+            ]))
         );
     }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,7 +1,7 @@
 /// A macro to generate a chain of [`crate::SubClause::AndMany`] from a list of
 /// Ids with the case [`crate::SubClause::IsMounted`] for every id.
 ///
-/// ### example
+/// ### Example
 ///
 /// ```rust
 /// use tuirealm::{SubClause, subclause_and};
@@ -17,7 +17,7 @@
 ///    Id::InputBar,
 ///    Id::InputFoo,
 ///    Id::InputOmar
-///    );
+/// );
 ///
 /// assert_eq!(
 ///     sub_clause,
@@ -48,7 +48,7 @@ macro_rules! subclause_and {
 /// Well, it happens quite often at least in my application to require a subclause for a "Global Listener" item
 /// to have no "Popup" mounted in the application.
 ///
-/// ### example
+/// ### Example
 ///
 /// ```rust
 /// use tuirealm::{SubClause, subclause_and_not};
@@ -93,10 +93,10 @@ macro_rules! subclause_and_not {
     };
 }
 
-/// A macro to generate a chain of [`crate::SubClause::Or`] from a list of
+/// A macro to generate a chain of [`crate::SubClause::OrMany`] from a list of
 /// Ids with the case [`crate::SubClause::IsMounted`] for every id.
 ///
-/// ### example
+/// ### Example
 ///
 /// ```rust
 /// use tuirealm::{SubClause, subclause_or};
@@ -112,17 +112,15 @@ macro_rules! subclause_and_not {
 ///    Id::InputBar,
 ///    Id::InputFoo,
 ///    Id::InputOmar
-///    );
+/// );
 ///
 /// assert_eq!(
 ///     sub_clause,
-///     SubClause::or(
+///     SubClause::OrMany(vec![
 ///         SubClause::IsMounted(Id::InputBar),
-///         SubClause::or(
-///             SubClause::IsMounted(Id::InputFoo),
-///             SubClause::IsMounted(Id::InputOmar)
-///         )
-///     )
+///         SubClause::IsMounted(Id::InputFoo),
+///         SubClause::IsMounted(Id::InputOmar),
+///     ])
 ///  );
 /// ```
 ///
@@ -131,11 +129,10 @@ macro_rules! subclause_or {
     ($id:expr) => {
         SubClause::IsMounted($id)
     };
-    ($id:expr, $($rest:expr),+) => {
-        SubClause::or(
-            SubClause::IsMounted($id),
-            tuirealm::subclause_or!($($rest),+)
-        )
+    ($($rest:expr),+ $(,)?) => {
+        SubClause::OrMany(vec![
+            $(SubClause::IsMounted($rest)),*
+        ])
     };
 }
 
@@ -174,6 +171,43 @@ mod tests {
                 MockComponentId::InputOmar,
             ),
             SubClause::AndMany(vec![
+                SubClause::IsMounted(MockComponentId::InputBar),
+                SubClause::IsMounted(MockComponentId::InputFoo),
+                SubClause::IsMounted(MockComponentId::InputOmar),
+            ])
+        );
+    }
+
+    #[test]
+    fn subclause_or() {
+        // single
+        assert_eq!(
+            subclause_or!(MockComponentId::InputBar),
+            SubClause::IsMounted(MockComponentId::InputBar),
+        );
+
+        // multiple with no ending comma
+        assert_eq!(
+            subclause_or!(
+                MockComponentId::InputBar,
+                MockComponentId::InputFoo,
+                MockComponentId::InputOmar
+            ),
+            SubClause::OrMany(vec![
+                SubClause::IsMounted(MockComponentId::InputBar),
+                SubClause::IsMounted(MockComponentId::InputFoo),
+                SubClause::IsMounted(MockComponentId::InputOmar),
+            ])
+        );
+
+        // multiple with ending comma
+        assert_eq!(
+            subclause_or!(
+                MockComponentId::InputBar,
+                MockComponentId::InputFoo,
+                MockComponentId::InputOmar,
+            ),
+            SubClause::OrMany(vec![
                 SubClause::IsMounted(MockComponentId::InputBar),
                 SubClause::IsMounted(MockComponentId::InputFoo),
                 SubClause::IsMounted(MockComponentId::InputOmar),


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

re #102

## Description

This PR updates all the macros in `macros` to use the new `SubClause::AndMany` and `SubClause::OrMany`.
Additionally, updates `subclause_and_not` to only use one `Not` instead of having each case be `Not`, this is to my knowledge equivalent.
By the way, now the macros support ending with a `,` instead of having to leave it blank.
Also extra tests to confirm that the macros compile and generate what is expected.

PS: i did not deprecate them as i think some users might find it useful to not have to repeat `SubClause::IsMounted` for every entry.

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
