### PR TITLE
fix(border): add derive "Copy"

### DIFF
--- a/src/core/props/borders.rs
+++ b/src/core/props/borders.rs
@@ -9,7 +9,7 @@ pub use crate::ratatui::widgets::{BorderType, Borders as BorderSides};
 // -- Border
 
 /// Defines the properties of the borders
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Borders {
     pub sides: BorderSides,
     pub modifiers: BorderType,


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

None

## Description

This adds derive `Copy` on `Borders` as its size is small enough and inner values allow copy.
I noticed this could be done by going through the clippy lints in https://github.com/veeso/tui-realm-stdlib/pull/32.

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
