### PR TITLE
style: improve documentation for async ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Unreleased
 - Remove `PartialOrd` bound for `UserEvent`.
 - Add `Send` bound for `UserEvent` to trait `Poll`, as was already required for adding it to `SyncPort`.
 - Remove unnecessary bounds on Input Event Listeners.
+- Improve documentation for `PollAsync` and `Poll`.
 
 ## 3.0.1
 

--- a/src/listener/port/async_p.rs
+++ b/src/listener/port/async_p.rs
@@ -28,9 +28,8 @@ where
     /// # Parameters
     ///
     /// * `poll` - The poll trait object
-    /// * `interval` - The interval between each poll
-    /// * `max_poll` - The maximum amount of times the port should be polled in a single poll
-    /// * `runtime` - The tokio runtime to use for async polling
+    /// * `interval` - The interval between each poll. For async ports it is recommended the set this to [`Duration::ZERO`]
+    /// * `max_poll` - The maximum amount of times the port should be polled in a single loop
     pub fn new(poll: Box<dyn PollAsync<UserEvent>>, interval: Duration, max_poll: usize) -> Self {
         Self {
             poll,


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

fixes #107

## Description

Document how the ports expect events to be returned and how the function should behave.

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

---

@SteveXCIV do the changes address the documentation issue fully, or is there still some problem?