### PR TITLE
UserEvents: remove unnecessary bounds and consistent generic names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@
 
 ---
 
+## next
+
+Unreleased
+
+- Remove `PartialOrd` bound for `UserEvent`.
+
 ## 3.0.1
 
 Released on 09/06/2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 Unreleased
 
 - Remove `PartialOrd` bound for `UserEvent`.
+- Add `Send` bound for `UserEvent` to trait `Poll`, as was already required for adding it to `SyncPort`.
 
 ## 3.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Unreleased
 
 - Remove `PartialOrd` bound for `UserEvent`.
 - Add `Send` bound for `UserEvent` to trait `Poll`, as was already required for adding it to `SyncPort`.
+- Remove unnecessary bounds on Input Event Listeners.
 
 ## 3.0.1
 

--- a/src/core/application.rs
+++ b/src/core/application.rs
@@ -26,7 +26,7 @@ pub struct Application<ComponentId, Msg, UserEvent>
 where
     ComponentId: Eq + PartialEq + Clone + Hash,
     Msg: PartialEq,
-    UserEvent: Eq + PartialEq + Clone + PartialOrd + Send + 'static,
+    UserEvent: Eq + PartialEq + Clone + Send + 'static,
 {
     listener: EventListener<UserEvent>,
     subs: Vec<Subscription<ComponentId, UserEvent>>,
@@ -39,7 +39,7 @@ impl<K, Msg, UserEvent> Application<K, Msg, UserEvent>
 where
     K: Eq + PartialEq + Clone + Hash,
     Msg: PartialEq,
-    UserEvent: Eq + PartialEq + Clone + PartialOrd + Send + 'static,
+    UserEvent: Eq + PartialEq + Clone + Send + 'static,
 {
     /// Initialize a new [`Application`].
     /// The event listener is immediately created and started.

--- a/src/core/application.rs
+++ b/src/core/application.rs
@@ -35,9 +35,9 @@ where
     view: View<ComponentId, Msg, UserEvent>,
 }
 
-impl<K, Msg, UserEvent> Application<K, Msg, UserEvent>
+impl<ComponentId, Msg, UserEvent> Application<ComponentId, Msg, UserEvent>
 where
-    K: Eq + PartialEq + Clone + Hash,
+    ComponentId: Eq + PartialEq + Clone + Hash,
     Msg: PartialEq,
     UserEvent: Eq + PartialEq + Clone + Send + 'static,
 {
@@ -109,7 +109,7 @@ where
     // -- view bridge
 
     /// Add an injector to the view
-    pub fn add_injector(&mut self, injector: Box<dyn Injector<K>>) {
+    pub fn add_injector(&mut self, injector: Box<dyn Injector<ComponentId>>) {
         self.view.add_injector(injector);
     }
 
@@ -118,9 +118,9 @@ where
     /// NOTE: if subs vector contains duplicated, these will be discarded
     pub fn mount(
         &mut self,
-        id: K,
+        id: ComponentId,
         component: WrappedComponent<Msg, UserEvent>,
-        subs: Vec<Sub<K, UserEvent>>,
+        subs: Vec<Sub<ComponentId, UserEvent>>,
     ) -> ApplicationResult<()> {
         // Mount
         self.view.mount(&id, component)?;
@@ -131,7 +131,7 @@ where
 
     /// Umount component associated to `id` and remove ALL its SUBSCRIPTIONS.
     /// Returns Error if the component doesn't exist
-    pub fn umount(&mut self, id: &K) -> ApplicationResult<()> {
+    pub fn umount(&mut self, id: &ComponentId) -> ApplicationResult<()> {
         self.view.umount(id)?;
         self.unsubscribe_component(id);
         Ok(())
@@ -142,9 +142,9 @@ where
     /// If component had focus, focus is preserved
     pub fn remount(
         &mut self,
-        id: K,
+        id: ComponentId,
         component: WrappedComponent<Msg, UserEvent>,
-        subs: Vec<Sub<K, UserEvent>>,
+        subs: Vec<Sub<ComponentId, UserEvent>>,
     ) -> ApplicationResult<()> {
         // remove subs
         self.unsubscribe_component(&id);
@@ -162,25 +162,34 @@ where
     }
 
     /// Returns whether component `id` is mounted
-    pub fn mounted(&self, id: &K) -> bool {
+    pub fn mounted(&self, id: &ComponentId) -> bool {
         self.view.mounted(id)
     }
 
     /// Render component called `id`
-    pub fn view(&mut self, id: &K, f: &mut Frame, area: Rect) {
+    pub fn view(&mut self, id: &ComponentId, f: &mut Frame, area: Rect) {
         self.view.view(id, f, area);
     }
 
     /// Query view component for a certain `AttrValue`
     /// Returns error if the component doesn't exist
     /// Returns None if the attribute doesn't exist.
-    pub fn query(&self, id: &K, query: Attribute) -> ApplicationResult<Option<AttrValue>> {
+    pub fn query(
+        &self,
+        id: &ComponentId,
+        query: Attribute,
+    ) -> ApplicationResult<Option<AttrValue>> {
         self.view.query(id, query).map_err(ApplicationError::from)
     }
 
     /// Set attribute for component `id`
     /// Returns error if the component doesn't exist
-    pub fn attr(&mut self, id: &K, attr: Attribute, value: AttrValue) -> ApplicationResult<()> {
+    pub fn attr(
+        &mut self,
+        id: &ComponentId,
+        attr: Attribute,
+        value: AttrValue,
+    ) -> ApplicationResult<()> {
         self.view
             .attr(id, attr, value)
             .map_err(ApplicationError::from)
@@ -188,7 +197,7 @@ where
 
     /// Get state for component `id`.
     /// Returns `Err` if component doesn't exist
-    pub fn state(&self, id: &K) -> ApplicationResult<State> {
+    pub fn state(&self, id: &ComponentId) -> ApplicationResult<State> {
         self.view.state(id).map_err(ApplicationError::from)
     }
 
@@ -198,7 +207,7 @@ where
     /// Returns error: if component doesn't exist. Use `mounted()` to check if component exists
     ///
     /// > NOTE: users should always use this function to give focus to components.
-    pub fn active(&mut self, id: &K) -> ApplicationResult<()> {
+    pub fn active(&mut self, id: &ComponentId) -> ApplicationResult<()> {
         self.view.active(id).map_err(ApplicationError::from)
     }
 
@@ -213,7 +222,7 @@ where
     }
 
     /// Get a reference to the id of the current active component in the view
-    pub fn focus(&self) -> Option<&K> {
+    pub fn focus(&self) -> Option<&ComponentId> {
         self.view.focus()
     }
 
@@ -221,7 +230,11 @@ where
 
     /// Subscribe component to a certain event.
     /// Returns Error if the component doesn't exist or if the component is already subscribed to this event
-    pub fn subscribe(&mut self, id: &K, sub: Sub<K, UserEvent>) -> ApplicationResult<()> {
+    pub fn subscribe(
+        &mut self,
+        id: &ComponentId,
+        sub: Sub<ComponentId, UserEvent>,
+    ) -> ApplicationResult<()> {
         if !self.view.mounted(id) {
             return Err(ViewError::ComponentNotFound.into());
         }
@@ -235,7 +248,11 @@ where
 
     /// Unsubscribe a component from a certain event.
     /// Returns error if the component doesn't exist or if the component is not subscribed to this event
-    pub fn unsubscribe(&mut self, id: &K, ev: SubEventClause<UserEvent>) -> ApplicationResult<()> {
+    pub fn unsubscribe(
+        &mut self,
+        id: &ComponentId,
+        ev: SubEventClause<UserEvent>,
+    ) -> ApplicationResult<()> {
         if !self.view.mounted(id) {
             return Err(ViewError::ComponentNotFound.into());
         }
@@ -260,19 +277,19 @@ where
     // -- private
 
     /// remove all subscriptions for component
-    fn unsubscribe_component(&mut self, id: &K) {
+    fn unsubscribe_component(&mut self, id: &ComponentId) {
         self.subs.retain(|x| x.target() != id);
     }
 
     /// Returns whether component `id` is subscribed to event described by `clause`
-    fn subscribed(&self, id: &K, clause: &SubEventClause<UserEvent>) -> bool {
+    fn subscribed(&self, id: &ComponentId, clause: &SubEventClause<UserEvent>) -> bool {
         self.subs
             .iter()
             .any(|s| s.target() == id && s.event() == clause)
     }
 
     /// Insert subscriptions
-    fn insert_subscriptions(&mut self, id: &K, subs: Vec<Sub<K, UserEvent>>) {
+    fn insert_subscriptions(&mut self, id: &ComponentId, subs: Vec<Sub<ComponentId, UserEvent>>) {
         for sub in subs {
             // Push only if not already subscribed
             let subscription = Subscription::new(id.clone(), sub);

--- a/src/core/component.rs
+++ b/src/core/component.rs
@@ -55,7 +55,7 @@ pub trait MockComponent {
 pub trait Component<Msg, UserEvent>: MockComponent
 where
     Msg: PartialEq,
-    UserEvent: Eq + PartialEq + Clone + PartialOrd,
+    UserEvent: Eq + PartialEq + Clone,
 {
     /// Handle input event and update internal states.
     /// Returns a Msg to the view.

--- a/src/core/event.rs
+++ b/src/core/event.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Eq, PartialEq, Clone, PartialOrd)]
 pub enum Event<UserEvent>
 where
-    UserEvent: Eq + PartialEq + Clone + PartialOrd,
+    UserEvent: Eq + PartialEq + Clone,
 {
     /// A keyboard event
     Keyboard(KeyEvent),
@@ -37,7 +37,7 @@ where
 
 impl<U> Event<U>
 where
-    U: Eq + PartialEq + Clone + PartialOrd,
+    U: Eq + PartialEq + Clone,
 {
     pub(crate) fn as_keyboard(&self) -> Option<&KeyEvent> {
         if let Event::Keyboard(k) = self {

--- a/src/core/event.rs
+++ b/src/core/event.rs
@@ -35,9 +35,9 @@ where
     User(UserEvent),
 }
 
-impl<U> Event<U>
+impl<UserEvent> Event<UserEvent>
 where
-    U: Eq + PartialEq + Clone,
+    UserEvent: Eq + PartialEq + Clone,
 {
     pub(crate) fn as_keyboard(&self) -> Option<&KeyEvent> {
         if let Event::Keyboard(k) = self {
@@ -63,7 +63,7 @@ where
         matches!(self, Self::Tick)
     }
 
-    pub(crate) fn as_user(&self) -> Option<&U> {
+    pub(crate) fn as_user(&self) -> Option<&UserEvent> {
         if let Event::User(u) = self {
             Some(u)
         } else {

--- a/src/core/subscription.rs
+++ b/src/core/subscription.rs
@@ -28,7 +28,7 @@ where
 
 /// Defines a subscription for a component.
 /// A subscription tells the application to forward an event to the `target` component, when an event of type `ev`
-/// is received by the listener. In order to forward the event, the `where` clause must also be satisfied.
+/// is received by the listener, regardless if it has focus or not. In order to forward the event, the `when` clause must also be satisfied.
 ///
 /// > NOTE: Remember that "Component has focus" is NOT a subscription. Events are ALWAYS FORWARDED to components that have
 /// > FOCUS
@@ -37,8 +37,6 @@ where
 ///     - target: the id of the target component
 ///     - ev: the event it listens for
 ///     - when: a clause that must be satisfied to forward the event to the component.
-///
-///
 pub(crate) struct Subscription<ComponentId, UserEvent>
 where
     ComponentId: Eq + PartialEq + Clone + Hash,

--- a/src/core/subscription.rs
+++ b/src/core/subscription.rs
@@ -176,42 +176,42 @@ where
 /// - [`SubClause::Or`]: the OR of the two clauses must be `true`
 #[derive(Debug, PartialEq)]
 #[allow(clippy::large_enum_variant)]
-pub enum SubClause<Id>
+pub enum SubClause<ComponentId>
 where
-    Id: Eq + PartialEq + Clone + Hash,
+    ComponentId: Eq + PartialEq + Clone + Hash,
 {
     /// Always forward event to component
     Always,
     /// Forward event if target component has provided attribute with the provided value
     /// If the attribute doesn't exist on component, result is always `false`.
-    HasAttrValue(Id, Attribute, AttrValue),
+    HasAttrValue(ComponentId, Attribute, AttrValue),
     /// Forward event if target component has provided state
-    HasState(Id, State),
+    HasState(ComponentId, State),
     /// Forward event if target component is mounted
-    IsMounted(Id),
+    IsMounted(ComponentId),
     /// Forward event if the inner clause is `false`
-    Not(Box<SubClause<Id>>),
+    Not(Box<SubClause<ComponentId>>),
     /// Forward event if both the inner clauses are `true`
-    And(Box<SubClause<Id>>, Box<SubClause<Id>>),
+    And(Box<SubClause<ComponentId>>, Box<SubClause<ComponentId>>),
     /// Forward event if all the inner clauses are `true`.
     ///
     /// Short-circuits on first `false`.
     ///
     /// If empty will always return `false`.
-    AndMany(Vec<SubClause<Id>>),
+    AndMany(Vec<SubClause<ComponentId>>),
     /// Forward event if at least one of the inner clauses is `true`
-    Or(Box<SubClause<Id>>, Box<SubClause<Id>>),
+    Or(Box<SubClause<ComponentId>>, Box<SubClause<ComponentId>>),
     /// Forward event if at least one of the inner clauses is `true`.
     ///
     /// Short-circuits on first `true`.
     ///
     /// If empty will always return `false`.
-    OrMany(Vec<SubClause<Id>>),
+    OrMany(Vec<SubClause<ComponentId>>),
 }
 
-impl<Id> SubClause<Id>
+impl<ComponentId> SubClause<ComponentId>
 where
-    Id: Eq + PartialEq + Clone + Hash,
+    ComponentId: Eq + PartialEq + Clone + Hash,
 {
     /// Shortcut for [`SubClause::Not`] without specifying `Box::new(...)`
     #[allow(clippy::should_implement_trait)]
@@ -241,9 +241,9 @@ where
         mounted_fn: MountedFn,
     ) -> bool
     where
-        HasAttrFn: Fn(&Id, Attribute) -> Option<AttrValue>,
-        GetStateFn: Fn(&Id) -> Option<State>,
-        MountedFn: Fn(&Id) -> bool,
+        HasAttrFn: Fn(&ComponentId, Attribute) -> Option<AttrValue>,
+        GetStateFn: Fn(&ComponentId) -> Option<State>,
+        MountedFn: Fn(&ComponentId) -> bool,
     {
         self.check_forwarding(has_attr_fn, get_state_fn, mounted_fn)
             .0
@@ -258,9 +258,9 @@ where
         mounted_fn: MountedFn,
     ) -> (bool, HasAttrFn, GetStateFn, MountedFn)
     where
-        HasAttrFn: Fn(&Id, Attribute) -> Option<AttrValue>,
-        GetStateFn: Fn(&Id) -> Option<State>,
-        MountedFn: Fn(&Id) -> bool,
+        HasAttrFn: Fn(&ComponentId, Attribute) -> Option<AttrValue>,
+        GetStateFn: Fn(&ComponentId) -> Option<State>,
+        MountedFn: Fn(&ComponentId) -> bool,
     {
         match self {
             Self::Always => (true, has_attr_fn, get_state_fn, mounted_fn),
@@ -335,13 +335,13 @@ where
 
     #[must_use]
     fn has_attribute<HasAttrFn>(
-        id: &Id,
+        id: &ComponentId,
         query: &Attribute,
         value: &AttrValue,
         has_attr_fn: HasAttrFn,
     ) -> (bool, HasAttrFn)
     where
-        HasAttrFn: Fn(&Id, Attribute) -> Option<AttrValue>,
+        HasAttrFn: Fn(&ComponentId, Attribute) -> Option<AttrValue>,
     {
         (
             match has_attr_fn(id, *query) {
@@ -353,9 +353,13 @@ where
     }
 
     #[must_use]
-    fn has_state<GetStateFn>(id: &Id, state: &State, get_state_fn: GetStateFn) -> (bool, GetStateFn)
+    fn has_state<GetStateFn>(
+        id: &ComponentId,
+        state: &State,
+        get_state_fn: GetStateFn,
+    ) -> (bool, GetStateFn)
     where
-        GetStateFn: Fn(&Id) -> Option<State>,
+        GetStateFn: Fn(&ComponentId) -> Option<State>,
     {
         (
             match get_state_fn(id) {
@@ -367,9 +371,9 @@ where
     }
 
     #[must_use]
-    fn is_mounted<MountedFn>(id: &Id, mounted_fn: MountedFn) -> (bool, MountedFn)
+    fn is_mounted<MountedFn>(id: &ComponentId, mounted_fn: MountedFn) -> (bool, MountedFn)
     where
-        MountedFn: Fn(&Id) -> bool,
+        MountedFn: Fn(&ComponentId) -> bool,
     {
         (mounted_fn(id), mounted_fn)
     }

--- a/src/core/subscription.rs
+++ b/src/core/subscription.rs
@@ -12,12 +12,12 @@ use crate::{AttrValue, Attribute, Event, State};
 pub struct Sub<ComponentId, UserEvent>(EventClause<UserEvent>, SubClause<ComponentId>)
 where
     ComponentId: Eq + PartialEq + Clone + Hash,
-    UserEvent: Eq + PartialEq + Clone + PartialOrd;
+    UserEvent: Eq + PartialEq + Clone;
 
 impl<K, U> Sub<K, U>
 where
     K: Eq + PartialEq + Clone + Hash,
-    U: Eq + PartialEq + Clone + PartialOrd,
+    U: Eq + PartialEq + Clone,
 {
     /// Creates a new `Sub`
     #[must_use]
@@ -42,7 +42,7 @@ where
 pub(crate) struct Subscription<ComponentId, UserEvent>
 where
     ComponentId: Eq + PartialEq + Clone + Hash,
-    UserEvent: Eq + PartialEq + Clone + PartialOrd,
+    UserEvent: Eq + PartialEq + Clone,
 {
     /// Target component
     target: ComponentId,
@@ -55,7 +55,7 @@ where
 impl<K, U> Subscription<K, U>
 where
     K: Eq + PartialEq + Clone + Hash,
-    U: Eq + PartialEq + Clone + PartialOrd + Send,
+    U: Eq + PartialEq + Clone + Send,
 {
     /// Instantiates a new [`Subscription`]
     #[must_use]
@@ -120,7 +120,7 @@ impl MouseEventClause {
 /// An event clause indicates on which kind of event the event must be forwarded to the `target` component.
 pub enum EventClause<UserEvent>
 where
-    UserEvent: Eq + PartialEq + Clone + PartialOrd,
+    UserEvent: Eq + PartialEq + Clone,
 {
     /// Forward, no matter what kind of event
     Any,
@@ -142,7 +142,7 @@ where
 
 impl<U> EventClause<U>
 where
-    U: Eq + PartialEq + Clone + PartialOrd,
+    U: Eq + PartialEq + Clone,
 {
     /// Check whether to forward based on even type and event clause.
     ///

--- a/src/core/subscription.rs
+++ b/src/core/subscription.rs
@@ -14,14 +14,14 @@ where
     ComponentId: Eq + PartialEq + Clone + Hash,
     UserEvent: Eq + PartialEq + Clone;
 
-impl<K, U> Sub<K, U>
+impl<ComponentId, UserEvent> Sub<ComponentId, UserEvent>
 where
-    K: Eq + PartialEq + Clone + Hash,
-    U: Eq + PartialEq + Clone,
+    ComponentId: Eq + PartialEq + Clone + Hash,
+    UserEvent: Eq + PartialEq + Clone,
 {
     /// Creates a new `Sub`
     #[must_use]
-    pub fn new(event_clause: EventClause<U>, sub_clause: SubClause<K>) -> Self {
+    pub fn new(event_clause: EventClause<UserEvent>, sub_clause: SubClause<ComponentId>) -> Self {
         Self(event_clause, sub_clause)
     }
 }
@@ -52,14 +52,14 @@ where
     when: SubClause<ComponentId>,
 }
 
-impl<K, U> Subscription<K, U>
+impl<ComponentId, UserEvent> Subscription<ComponentId, UserEvent>
 where
-    K: Eq + PartialEq + Clone + Hash,
-    U: Eq + PartialEq + Clone + Send,
+    ComponentId: Eq + PartialEq + Clone + Hash,
+    UserEvent: Eq + PartialEq + Clone + Send,
 {
     /// Instantiates a new [`Subscription`]
     #[must_use]
-    pub fn new(target: K, sub: Sub<K, U>) -> Self {
+    pub fn new(target: ComponentId, sub: Sub<ComponentId, UserEvent>) -> Self {
         Self {
             target,
             ev: sub.0,
@@ -69,13 +69,13 @@ where
 
     /// Returns sub target
     #[must_use]
-    pub(crate) fn target(&self) -> &K {
+    pub(crate) fn target(&self) -> &ComponentId {
         &self.target
     }
 
     /// Returns reference to subscription event clause
     #[must_use]
-    pub(crate) fn event(&self) -> &EventClause<U> {
+    pub(crate) fn event(&self) -> &EventClause<UserEvent> {
         &self.ev
     }
 
@@ -83,15 +83,15 @@ where
     #[must_use]
     pub(crate) fn forward<HasAttrFn, GetStateFn, MountedFn>(
         &self,
-        ev: &Event<U>,
+        ev: &Event<UserEvent>,
         has_attr_fn: HasAttrFn,
         get_state_fn: GetStateFn,
         mounted_fn: MountedFn,
     ) -> bool
     where
-        HasAttrFn: Fn(&K, Attribute) -> Option<AttrValue>,
-        GetStateFn: Fn(&K) -> Option<State>,
-        MountedFn: Fn(&K) -> bool,
+        HasAttrFn: Fn(&ComponentId, Attribute) -> Option<AttrValue>,
+        GetStateFn: Fn(&ComponentId) -> Option<State>,
+        MountedFn: Fn(&ComponentId) -> bool,
     {
         self.ev.forward(ev) && self.when.forward(has_attr_fn, get_state_fn, mounted_fn)
     }
@@ -140,9 +140,9 @@ where
     Discriminant(UserEvent),
 }
 
-impl<U> EventClause<U>
+impl<UserEvent> EventClause<UserEvent>
 where
-    U: Eq + PartialEq + Clone,
+    UserEvent: Eq + PartialEq + Clone,
 {
     /// Check whether to forward based on even type and event clause.
     ///
@@ -155,7 +155,7 @@ where
     /// - [`EventClause::Tick`]: matches tick event
     /// - [`EventClause::User`]: depends on UserEvent [`PartialEq`]
     /// - [`EventClause::Discriminant`]: matches only event type, not values
-    fn forward(&self, ev: &Event<U>) -> bool {
+    fn forward(&self, ev: &Event<UserEvent>) -> bool {
         match self {
             EventClause::Any => true,
             EventClause::Keyboard(k) => Some(k) == ev.as_keyboard(),

--- a/src/core/view.rs
+++ b/src/core/view.rs
@@ -49,9 +49,9 @@ where
     injectors: Vec<Box<dyn Injector<ComponentId>>>,
 }
 
-impl<K, Msg, UserEvent> Default for View<K, Msg, UserEvent>
+impl<ComponentId, Msg, UserEvent> Default for View<ComponentId, Msg, UserEvent>
 where
-    K: Eq + PartialEq + Clone + Hash,
+    ComponentId: Eq + PartialEq + Clone + Hash,
     Msg: PartialEq,
     UserEvent: Eq + PartialEq + Clone,
 {
@@ -65,15 +65,19 @@ where
     }
 }
 
-impl<K, Msg, UserEvent> View<K, Msg, UserEvent>
+impl<ComponentId, Msg, UserEvent> View<ComponentId, Msg, UserEvent>
 where
-    K: Eq + PartialEq + Clone + Hash,
+    ComponentId: Eq + PartialEq + Clone + Hash,
     Msg: PartialEq,
     UserEvent: Eq + PartialEq + Clone,
 {
     /// Mount component on View.
     /// Returns error if the component is already mounted
-    pub fn mount(&mut self, id: &K, component: WrappedComponent<Msg, UserEvent>) -> ViewResult<()> {
+    pub fn mount(
+        &mut self,
+        id: &ComponentId,
+        component: WrappedComponent<Msg, UserEvent>,
+    ) -> ViewResult<()> {
         if self.mounted(id) {
             Err(ViewError::ComponentAlreadyMounted)
         } else {
@@ -85,7 +89,7 @@ where
     }
 
     /// Umount component from View
-    pub fn umount(&mut self, id: &K) -> ViewResult<()> {
+    pub fn umount(&mut self, id: &ComponentId) -> ViewResult<()> {
         if !self.mounted(id) {
             return Err(ViewError::ComponentNotFound);
         }
@@ -102,7 +106,7 @@ where
     /// Remount component. This method WON'T change the focus stack
     pub fn remount(
         &mut self,
-        id: &K,
+        id: &ComponentId,
         component: WrappedComponent<Msg, UserEvent>,
     ) -> ViewResult<()> {
         // Umount, but keep focus
@@ -126,17 +130,17 @@ where
     }
 
     /// Returns whether component `id` is mounted
-    pub fn mounted(&self, id: &K) -> bool {
+    pub fn mounted(&self, id: &ComponentId) -> bool {
         self.components.contains_key(id)
     }
 
     /// Returns current active element (if any)
-    pub(crate) fn focus(&self) -> Option<&K> {
+    pub(crate) fn focus(&self) -> Option<&ComponentId> {
         self.focus.as_ref()
     }
 
     /// Render component called `id`
-    pub fn view(&mut self, id: &K, f: &mut Frame, area: Rect) {
+    pub fn view(&mut self, id: &ComponentId, f: &mut Frame, area: Rect) {
         if let Some(c) = self.components.get_mut(id) {
             c.view(f, area);
         }
@@ -144,7 +148,11 @@ where
 
     /// Forward `event` (call `on()`) on component `id` and return a `Msg` if any.
     /// Returns error if the component doesn't exist
-    pub(crate) fn forward(&mut self, id: &K, event: Event<UserEvent>) -> ViewResult<Option<Msg>> {
+    pub(crate) fn forward(
+        &mut self,
+        id: &ComponentId,
+        event: Event<UserEvent>,
+    ) -> ViewResult<Option<Msg>> {
         match self.components.get_mut(id) {
             None => Err(ViewError::ComponentNotFound),
             Some(c) => Ok(c.on(event)),
@@ -154,7 +162,7 @@ where
     /// Query view component for a certain `AttrValue`
     /// Returns error if the component doesn't exist
     /// Returns None if the attribute doesn't exist.
-    pub fn query(&self, id: &K, query: Attribute) -> ViewResult<Option<AttrValue>> {
+    pub fn query(&self, id: &ComponentId, query: Attribute) -> ViewResult<Option<AttrValue>> {
         match self.components.get(id) {
             None => Err(ViewError::ComponentNotFound),
             Some(c) => Ok(c.query(query)),
@@ -163,7 +171,7 @@ where
 
     /// Set attribute for component `id`
     /// Returns error if the component doesn't exist
-    pub fn attr(&mut self, id: &K, attr: Attribute, value: AttrValue) -> ViewResult<()> {
+    pub fn attr(&mut self, id: &ComponentId, attr: Attribute, value: AttrValue) -> ViewResult<()> {
         if let Some(c) = self.components.get_mut(id) {
             c.attr(attr, value);
             Ok(())
@@ -174,7 +182,7 @@ where
 
     /// Get state for component `id`.
     /// Returns `Err` if component doesn't exist
-    pub fn state(&self, id: &K) -> ViewResult<State> {
+    pub fn state(&self, id: &ComponentId) -> ViewResult<State> {
         self.components
             .get(id)
             .map(|c| c.state())
@@ -189,7 +197,7 @@ where
     /// Returns error: if component doesn't exist. Use `mounted()` to check if component exists
     ///
     /// > NOTE: users should always use this function to give focus to components.
-    pub fn active(&mut self, id: &K) -> ViewResult<()> {
+    pub fn active(&mut self, id: &ComponentId) -> ViewResult<()> {
         self.set_focus(id, true)?;
         self.change_focus(id);
         Ok(())
@@ -214,7 +222,7 @@ where
     // -- injectors
 
     /// Add an injector to the view
-    pub fn add_injector(&mut self, injector: Box<dyn Injector<K>>) {
+    pub fn add_injector(&mut self, injector: Box<dyn Injector<ComponentId>>) {
         self.injectors.push(injector);
     }
 
@@ -223,18 +231,18 @@ where
     /// Push component `id` to focus stack
     /// In case it is already in the focus stack,
     /// it will be first removed from it.
-    fn push_to_stack(&mut self, id: K) {
+    fn push_to_stack(&mut self, id: ComponentId) {
         self.pop_from_stack(&id);
         self.focus_stack.push(id);
     }
 
     /// Pop component `id` from focus stack
-    fn pop_from_stack(&mut self, id: &K) {
+    fn pop_from_stack(&mut self, id: &ComponentId) {
         self.focus_stack.retain(|x| x != id);
     }
 
     /// Returns whether `who` has focus
-    pub(crate) fn has_focus(&self, who: &K) -> bool {
+    pub(crate) fn has_focus(&self, who: &ComponentId) -> bool {
         match self.focus.as_ref() {
             None => false,
             Some(id) => who == id,
@@ -245,7 +253,7 @@ where
     /// Then pop from stack `new_focus` and set it to current `focus`.
     ///
     /// > Panics if `new_focus` doesn't exist in components
-    fn change_focus(&mut self, new_focus: &K) {
+    fn change_focus(&mut self, new_focus: &ComponentId) {
         if let Some(focus) = self.focus.take() {
             // Remove focus (can't return error)
             let _ = self.set_focus(&focus, false);
@@ -266,12 +274,12 @@ where
     }
 
     /// Take last element from stack if any
-    fn take_last_from_stack(&mut self) -> Option<K> {
+    fn take_last_from_stack(&mut self) -> Option<ComponentId> {
         self.focus_stack.pop()
     }
 
     /// Set focus value for component
-    fn set_focus(&mut self, id: &K, value: bool) -> ViewResult<()> {
+    fn set_focus(&mut self, id: &ComponentId, value: bool) -> ViewResult<()> {
         if let Some(c) = self.components.get_mut(id) {
             c.attr(Attribute::Focus, AttrValue::Flag(value));
             Ok(())
@@ -281,7 +289,7 @@ where
     }
 
     /// Inject properties for `id` using view injectors
-    fn inject(&mut self, id: &K) -> ViewResult<()> {
+    fn inject(&mut self, id: &ComponentId) -> ViewResult<()> {
         for (attr, value) in self.properties_to_inject(id) {
             self.attr(id, attr, value)?;
         }
@@ -289,7 +297,7 @@ where
     }
 
     /// Collect properties to inject for component `K`
-    fn properties_to_inject(&self, id: &K) -> Vec<(Attribute, AttrValue)> {
+    fn properties_to_inject(&self, id: &ComponentId) -> Vec<(Attribute, AttrValue)> {
         self.injectors.iter().flat_map(|x| x.inject(id)).collect()
     }
 }

--- a/src/core/view.rs
+++ b/src/core/view.rs
@@ -37,7 +37,7 @@ pub struct View<ComponentId, Msg, UserEvent>
 where
     ComponentId: Eq + PartialEq + Clone + Hash,
     Msg: PartialEq,
-    UserEvent: Eq + PartialEq + Clone + PartialOrd,
+    UserEvent: Eq + PartialEq + Clone,
 {
     /// Components Mounted onto View
     components: HashMap<ComponentId, WrappedComponent<Msg, UserEvent>>,
@@ -53,7 +53,7 @@ impl<K, Msg, UserEvent> Default for View<K, Msg, UserEvent>
 where
     K: Eq + PartialEq + Clone + Hash,
     Msg: PartialEq,
-    UserEvent: Eq + PartialEq + Clone + PartialOrd,
+    UserEvent: Eq + PartialEq + Clone,
 {
     fn default() -> Self {
         Self {
@@ -69,7 +69,7 @@ impl<K, Msg, UserEvent> View<K, Msg, UserEvent>
 where
     K: Eq + PartialEq + Clone + Hash,
     Msg: PartialEq,
-    UserEvent: Eq + PartialEq + Clone + PartialOrd,
+    UserEvent: Eq + PartialEq + Clone,
 {
     /// Mount component on View.
     /// Returns error if the component is already mounted

--- a/src/listener/async_ticker.rs
+++ b/src/listener/async_ticker.rs
@@ -16,7 +16,7 @@ impl AsyncTicker {
 #[async_trait::async_trait]
 impl<U> PollAsync<U> for AsyncTicker
 where
-    U: Eq + PartialEq + Clone + PartialOrd + Send + 'static,
+    U: Eq + PartialEq + Clone + Send + 'static,
 {
     async fn poll(&mut self) -> ListenerResult<Option<Event<U>>> {
         Ok(Some(Event::Tick))

--- a/src/listener/async_ticker.rs
+++ b/src/listener/async_ticker.rs
@@ -14,11 +14,11 @@ impl AsyncTicker {
 }
 
 #[async_trait::async_trait]
-impl<U> PollAsync<U> for AsyncTicker
+impl<UserEvent> PollAsync<UserEvent> for AsyncTicker
 where
-    U: Eq + PartialEq + Clone + Send + 'static,
+    UserEvent: Eq + PartialEq + Clone + Send + 'static,
 {
-    async fn poll(&mut self) -> ListenerResult<Option<Event<U>>> {
+    async fn poll(&mut self) -> ListenerResult<Option<Event<UserEvent>>> {
         Ok(Some(Event::Tick))
     }
 }

--- a/src/listener/builder.rs
+++ b/src/listener/builder.rs
@@ -14,7 +14,7 @@ use super::{Duration, EventListener, ListenerError, Poll, SyncPort};
 /// will be returned.
 pub struct EventListenerCfg<U>
 where
-    U: Eq + PartialEq + Clone + PartialOrd + Send,
+    U: Eq + PartialEq + Clone + Send,
 {
     sync_ports: Vec<SyncPort<U>>,
     #[cfg(feature = "async-ports")]
@@ -29,7 +29,7 @@ where
 
 impl<U> Default for EventListenerCfg<U>
 where
-    U: Eq + PartialEq + Clone + PartialOrd + Send,
+    U: Eq + PartialEq + Clone + Send,
 {
     fn default() -> Self {
         Self {
@@ -48,7 +48,7 @@ where
 
 impl<U> EventListenerCfg<U>
 where
-    U: Eq + PartialEq + Clone + PartialOrd + Send + 'static,
+    U: Eq + PartialEq + Clone + Send + 'static,
 {
     /// Create the event listener with the parameters provided and start the workers.
     ///
@@ -173,7 +173,7 @@ where
 /// Implementations for feature `async-ports`
 impl<U> EventListenerCfg<U>
 where
-    U: Eq + PartialEq + Clone + PartialOrd + Send + 'static,
+    U: Eq + PartialEq + Clone + Send + 'static,
 {
     /// Add a new [`AsyncPort`] (Poll, Interval) to the the event listener.
     ///

--- a/src/listener/builder.rs
+++ b/src/listener/builder.rs
@@ -140,9 +140,7 @@ where
     /// The max_poll is the maximum amount of times the port should be polled in a `interval`.
     pub fn crossterm_input_listener(self, interval: Duration, max_poll: usize) -> Self {
         self.add_port(
-            Box::new(crate::terminal::CrosstermInputListener::<UserEvent>::new(
-                interval,
-            )),
+            Box::new(crate::terminal::CrosstermInputListener::new(interval)),
             interval,
             max_poll,
         )
@@ -170,9 +168,7 @@ where
     /// The max_poll is the maximum amount of times the port should be polled in a `interval`.
     pub fn termion_input_listener(self, interval: Duration, max_poll: usize) -> Self {
         self.add_port(
-            Box::new(crate::terminal::TermionInputListener::<UserEvent>::new(
-                interval,
-            )),
+            Box::new(crate::terminal::TermionInputListener::new(interval)),
             interval,
             max_poll,
         )

--- a/src/listener/builder.rs
+++ b/src/listener/builder.rs
@@ -12,13 +12,13 @@ use super::{Duration, EventListener, ListenerError, Poll, SyncPort};
 /// The event listener configurator is used to setup an event listener.
 /// Once you're done with configuration just call `EventListenerCfg::start` and the event listener will start and the listener
 /// will be returned.
-pub struct EventListenerCfg<U>
+pub struct EventListenerCfg<UserEvent>
 where
-    U: Eq + PartialEq + Clone + Send,
+    UserEvent: Eq + PartialEq + Clone + Send,
 {
-    sync_ports: Vec<SyncPort<U>>,
+    sync_ports: Vec<SyncPort<UserEvent>>,
     #[cfg(feature = "async-ports")]
-    async_ports: Vec<AsyncPort<U>>,
+    async_ports: Vec<AsyncPort<UserEvent>>,
     #[cfg(feature = "async-ports")]
     handle: Option<Handle>,
     tick_interval: Option<Duration>,
@@ -27,9 +27,9 @@ where
     poll_timeout: Duration,
 }
 
-impl<U> Default for EventListenerCfg<U>
+impl<UserEvent> Default for EventListenerCfg<UserEvent>
 where
-    U: Eq + PartialEq + Clone + Send,
+    UserEvent: Eq + PartialEq + Clone + Send,
 {
     fn default() -> Self {
         Self {
@@ -46,9 +46,9 @@ where
     }
 }
 
-impl<U> EventListenerCfg<U>
+impl<UserEvent> EventListenerCfg<UserEvent>
 where
-    U: Eq + PartialEq + Clone + Send + 'static,
+    UserEvent: Eq + PartialEq + Clone + Send + 'static,
 {
     /// Create the event listener with the parameters provided and start the workers.
     ///
@@ -56,7 +56,7 @@ where
     ///
     /// - if there are async ports defined, but no handle is set.
     #[allow(unused_mut)] // mutability is necessary when "async-ports" is active
-    pub(crate) fn start(mut self) -> Result<EventListener<U>, ListenerError> {
+    pub(crate) fn start(mut self) -> Result<EventListener<UserEvent>, ListenerError> {
         #[cfg(feature = "async-ports")]
         let start_async =
             !self.async_ports.is_empty() || (self.async_tick && self.tick_interval.is_some());
@@ -116,14 +116,19 @@ where
     ///
     /// The interval is the amount of time between each [`Poll::poll`] call.
     /// The max_poll is the maximum amount of times the port should be polled in a single poll.
-    pub fn add_port(self, poll: Box<dyn Poll<U>>, interval: Duration, max_poll: usize) -> Self {
+    pub fn add_port(
+        self,
+        poll: Box<dyn Poll<UserEvent>>,
+        interval: Duration,
+        max_poll: usize,
+    ) -> Self {
         self.port(SyncPort::new(poll, interval, max_poll))
     }
 
     /// Add a new [`SyncPort`] to the the event listener
     ///
     /// The [`SyncPort`] needs to be manually constructed, unlike [`Self::add_port`]
-    pub fn port(mut self, port: SyncPort<U>) -> Self {
+    pub fn port(mut self, port: SyncPort<UserEvent>) -> Self {
         self.sync_ports.push(port);
         self
     }
@@ -135,7 +140,9 @@ where
     /// The max_poll is the maximum amount of times the port should be polled in a `interval`.
     pub fn crossterm_input_listener(self, interval: Duration, max_poll: usize) -> Self {
         self.add_port(
-            Box::new(crate::terminal::CrosstermInputListener::<U>::new(interval)),
+            Box::new(crate::terminal::CrosstermInputListener::<UserEvent>::new(
+                interval,
+            )),
             interval,
             max_poll,
         )
@@ -163,7 +170,9 @@ where
     /// The max_poll is the maximum amount of times the port should be polled in a `interval`.
     pub fn termion_input_listener(self, interval: Duration, max_poll: usize) -> Self {
         self.add_port(
-            Box::new(crate::terminal::TermionInputListener::<U>::new(interval)),
+            Box::new(crate::terminal::TermionInputListener::<UserEvent>::new(
+                interval,
+            )),
             interval,
             max_poll,
         )
@@ -171,9 +180,9 @@ where
 }
 
 /// Implementations for feature `async-ports`
-impl<U> EventListenerCfg<U>
+impl<UserEvent> EventListenerCfg<UserEvent>
 where
-    U: Eq + PartialEq + Clone + Send + 'static,
+    UserEvent: Eq + PartialEq + Clone + Send + 'static,
 {
     /// Add a new [`AsyncPort`] (Poll, Interval) to the the event listener.
     ///
@@ -183,7 +192,7 @@ where
     #[cfg_attr(docsrs, doc(cfg(feature = "async-ports")))]
     pub fn add_async_port(
         self,
-        poll: Box<dyn super::PollAsync<U>>,
+        poll: Box<dyn super::PollAsync<UserEvent>>,
         interval: Duration,
         max_poll: usize,
     ) -> Self {
@@ -195,7 +204,7 @@ where
     /// The [`AsyncPort`] needs to be manually constructed, unlike [`Self::add_async_port`].
     #[cfg(feature = "async-ports")]
     #[cfg_attr(docsrs, doc(cfg(feature = "async-ports")))]
-    pub fn async_port(mut self, port: AsyncPort<U>) -> Self {
+    pub fn async_port(mut self, port: AsyncPort<UserEvent>) -> Self {
         self.async_ports.push(port);
         self
     }

--- a/src/listener/mod.rs
+++ b/src/listener/mod.rs
@@ -53,7 +53,7 @@ pub enum ListenerError {
 /// dedicated thread to poll for events if you use a [`SyncPort`].
 pub trait Poll<UserEvent>: Send
 where
-    UserEvent: Eq + PartialEq + Clone + 'static,
+    UserEvent: Eq + PartialEq + Clone + Send + 'static,
 {
     /// Poll for an event from user or from another source (e.g. Network).
     /// This function mustn't be blocking, and will be called within the configured interval of the event listener.

--- a/src/listener/mod.rs
+++ b/src/listener/mod.rs
@@ -53,7 +53,7 @@ pub enum ListenerError {
 /// dedicated thread to poll for events if you use a [`SyncPort`].
 pub trait Poll<UserEvent>: Send
 where
-    UserEvent: Eq + PartialEq + Clone + PartialOrd + 'static,
+    UserEvent: Eq + PartialEq + Clone + 'static,
 {
     /// Poll for an event from user or from another source (e.g. Network).
     /// This function mustn't be blocking, and will be called within the configured interval of the event listener.
@@ -71,7 +71,7 @@ where
 #[async_trait::async_trait]
 pub trait PollAsync<UserEvent>: Send
 where
-    UserEvent: Eq + PartialEq + Clone + PartialOrd + Send + 'static,
+    UserEvent: Eq + PartialEq + Clone + Send + 'static,
 {
     /// Poll for an with the possibility to do it asynchronously, from user or from another source (e.g. Network).
     /// This function mustn't be blocking, and will be called within the configured interval of the event listener.
@@ -88,7 +88,7 @@ where
 #[derive(Debug)]
 pub(crate) struct EventListener<U>
 where
-    U: Eq + PartialEq + Clone + PartialOrd + Send + 'static,
+    U: Eq + PartialEq + Clone + Send + 'static,
 {
     /// Max Time to wait when calling `recv()` on thread receiver
     poll_timeout: Duration,
@@ -111,7 +111,7 @@ where
 
 impl<U> EventListener<U>
 where
-    U: Eq + PartialEq + Clone + PartialOrd + Send + 'static,
+    U: Eq + PartialEq + Clone + Send + 'static,
 {
     /// Create a new [`EventListener`].
     /// - `poll_interval` is the interval to poll for input events. It should always be at least a poll time used by `poll`
@@ -283,7 +283,7 @@ async fn poll_task<U>(
     paused: Arc<AtomicBool>,
 ) -> Result<(), mpsc::SendError<ListenerMsg<U>>>
 where
-    U: Eq + PartialEq + Clone + PartialOrd + Send + 'static,
+    U: Eq + PartialEq + Clone + Send + 'static,
 {
     let mut times_remaining = port.max_poll();
     loop {
@@ -314,7 +314,7 @@ where
 
 impl<U> Drop for EventListener<U>
 where
-    U: Eq + PartialEq + Clone + PartialOrd + Send + 'static,
+    U: Eq + PartialEq + Clone + Send + 'static,
 {
     fn drop(&mut self) {
         let _ = self.stop();
@@ -326,7 +326,7 @@ where
 /// Listener message is returned by the listener thread
 enum ListenerMsg<U>
 where
-    U: Eq + PartialEq + Clone + PartialOrd + Send,
+    U: Eq + PartialEq + Clone + Send,
 {
     Error(ListenerError),
     Tick,
@@ -335,7 +335,7 @@ where
 
 impl<U> From<ListenerMsg<U>> for ListenerResult<Option<Event<U>>>
 where
-    U: Eq + PartialEq + Clone + PartialOrd + Send,
+    U: Eq + PartialEq + Clone + Send,
 {
     fn from(msg: ListenerMsg<U>) -> Self {
         match msg {

--- a/src/listener/port/async_p.rs
+++ b/src/listener/port/async_p.rs
@@ -9,19 +9,19 @@ use crate::listener::{ListenerResult, PollAsync};
 /// Its purpose is to listen for incoming events of a user-defined type
 ///
 /// [`AsyncPort`] has the possibility to run
-pub struct AsyncPort<U>
+pub struct AsyncPort<UserEvent>
 where
-    U: Eq + PartialEq + Clone + Send,
+    UserEvent: Eq + PartialEq + Clone + Send,
 {
-    poll: Box<dyn PollAsync<U>>,
+    poll: Box<dyn PollAsync<UserEvent>>,
     interval: Duration,
     next_poll: Instant,
     max_poll: usize,
 }
 
-impl<U> AsyncPort<U>
+impl<UserEvent> AsyncPort<UserEvent>
 where
-    U: Eq + PartialEq + Clone + Send + 'static,
+    UserEvent: Eq + PartialEq + Clone + Send + 'static,
 {
     /// Define a new [`AsyncPort`]
     ///
@@ -31,7 +31,7 @@ where
     /// * `interval` - The interval between each poll
     /// * `max_poll` - The maximum amount of times the port should be polled in a single poll
     /// * `runtime` - The tokio runtime to use for async polling
-    pub fn new(poll: Box<dyn PollAsync<U>>, interval: Duration, max_poll: usize) -> Self {
+    pub fn new(poll: Box<dyn PollAsync<UserEvent>>, interval: Duration, max_poll: usize) -> Self {
         Self {
             poll,
             interval,
@@ -61,7 +61,7 @@ where
     }
 
     /// Calls [`PollAsync::poll`] on the inner [`PollAsync`] trait object.
-    pub async fn poll(&mut self) -> ListenerResult<Option<Event<U>>> {
+    pub async fn poll(&mut self) -> ListenerResult<Option<Event<UserEvent>>> {
         self.poll.poll().await
     }
 

--- a/src/listener/port/async_p.rs
+++ b/src/listener/port/async_p.rs
@@ -11,7 +11,7 @@ use crate::listener::{ListenerResult, PollAsync};
 /// [`AsyncPort`] has the possibility to run
 pub struct AsyncPort<U>
 where
-    U: Eq + PartialEq + Clone + PartialOrd + Send,
+    U: Eq + PartialEq + Clone + Send,
 {
     poll: Box<dyn PollAsync<U>>,
     interval: Duration,
@@ -21,7 +21,7 @@ where
 
 impl<U> AsyncPort<U>
 where
-    U: Eq + PartialEq + Clone + PartialOrd + Send + 'static,
+    U: Eq + PartialEq + Clone + Send + 'static,
 {
     /// Define a new [`AsyncPort`]
     ///

--- a/src/listener/port/sync.rs
+++ b/src/listener/port/sync.rs
@@ -7,19 +7,19 @@ use crate::listener::{ListenerResult, Poll};
 /// A port is a wrapper around the poll trait object, which also defines an interval, which defines
 /// the amount of time between each [`Poll::poll`] call.
 /// Its purpose is to listen for incoming events of a user-defined type
-pub struct SyncPort<U>
+pub struct SyncPort<UserEvent>
 where
-    U: Eq + PartialEq + Clone + Send,
+    UserEvent: Eq + PartialEq + Clone + Send,
 {
-    poll: Box<dyn Poll<U>>,
+    poll: Box<dyn Poll<UserEvent>>,
     interval: Duration,
     next_poll: Instant,
     max_poll: usize,
 }
 
-impl<U> SyncPort<U>
+impl<UserEvent> SyncPort<UserEvent>
 where
-    U: Eq + PartialEq + Clone + Send + 'static,
+    UserEvent: Eq + PartialEq + Clone + Send + 'static,
 {
     /// Define a new [`SyncPort`]
     ///
@@ -28,7 +28,7 @@ where
     /// * `poll` - The poll trait object
     /// * `interval` - The interval between each poll
     /// * `max_poll` - The maximum amount of times the port should be polled in a single poll
-    pub fn new(poll: Box<dyn Poll<U>>, interval: Duration, max_poll: usize) -> Self {
+    pub fn new(poll: Box<dyn Poll<UserEvent>>, interval: Duration, max_poll: usize) -> Self {
         Self {
             poll,
             interval,
@@ -58,7 +58,7 @@ where
     }
 
     /// Calls [`Poll::poll`] on the inner [`Poll`] trait object.
-    pub fn poll(&mut self) -> ListenerResult<Option<Event<U>>> {
+    pub fn poll(&mut self) -> ListenerResult<Option<Event<UserEvent>>> {
         self.poll.poll()
     }
 

--- a/src/listener/port/sync.rs
+++ b/src/listener/port/sync.rs
@@ -9,7 +9,7 @@ use crate::listener::{ListenerResult, Poll};
 /// Its purpose is to listen for incoming events of a user-defined type
 pub struct SyncPort<U>
 where
-    U: Eq + PartialEq + Clone + PartialOrd + Send,
+    U: Eq + PartialEq + Clone + Send,
 {
     poll: Box<dyn Poll<U>>,
     interval: Duration,
@@ -19,7 +19,7 @@ where
 
 impl<U> SyncPort<U>
 where
-    U: Eq + PartialEq + Clone + PartialOrd + Send + 'static,
+    U: Eq + PartialEq + Clone + Send + 'static,
 {
     /// Define a new [`SyncPort`]
     ///

--- a/src/listener/worker.rs
+++ b/src/listener/worker.rs
@@ -15,7 +15,7 @@ use super::{ListenerMsg, SyncPort};
 /// worker for event listener
 pub(super) struct EventListenerWorker<U>
 where
-    U: Eq + PartialEq + Clone + PartialOrd + Send,
+    U: Eq + PartialEq + Clone + Send,
 {
     ports: Vec<SyncPort<U>>,
     sender: mpsc::Sender<ListenerMsg<U>>,
@@ -27,7 +27,7 @@ where
 
 impl<U> EventListenerWorker<U>
 where
-    U: Eq + PartialEq + Clone + PartialOrd + Send + 'static,
+    U: Eq + PartialEq + Clone + Send + 'static,
 {
     /// Create a new Worker.
     ///

--- a/src/listener/worker.rs
+++ b/src/listener/worker.rs
@@ -13,29 +13,29 @@ use super::{ListenerMsg, SyncPort};
 // -- worker
 
 /// worker for event listener
-pub(super) struct EventListenerWorker<U>
+pub(super) struct EventListenerWorker<UserEvent>
 where
-    U: Eq + PartialEq + Clone + Send,
+    UserEvent: Eq + PartialEq + Clone + Send,
 {
-    ports: Vec<SyncPort<U>>,
-    sender: mpsc::Sender<ListenerMsg<U>>,
+    ports: Vec<SyncPort<UserEvent>>,
+    sender: mpsc::Sender<ListenerMsg<UserEvent>>,
     paused: Arc<AtomicBool>,
     running: Arc<AtomicBool>,
     next_tick: Instant,
     tick_interval: Option<Duration>,
 }
 
-impl<U> EventListenerWorker<U>
+impl<UserEvent> EventListenerWorker<UserEvent>
 where
-    U: Eq + PartialEq + Clone + Send + 'static,
+    UserEvent: Eq + PartialEq + Clone + Send + 'static,
 {
     /// Create a new Worker.
     ///
     /// If `tick_interval` is [`None`], no [`Event::Tick`](crate::Event::Tick) will be sent and a fallback interval time will be used.
     /// If `tick_interval` is [`Some`], [`Event::Tick`](crate::Event::Tick) will be sent and be used as the interval time.
     pub(super) fn new(
-        ports: Vec<SyncPort<U>>,
-        sender: mpsc::Sender<ListenerMsg<U>>,
+        ports: Vec<SyncPort<UserEvent>>,
+        sender: mpsc::Sender<ListenerMsg<UserEvent>>,
         paused: Arc<AtomicBool>,
         running: Arc<AtomicBool>,
         tick_interval: Option<Duration>,
@@ -102,7 +102,7 @@ where
     }
 
     /// Send tick to listener and calc next tick
-    fn send_tick(&mut self) -> Result<(), mpsc::SendError<ListenerMsg<U>>> {
+    fn send_tick(&mut self) -> Result<(), mpsc::SendError<ListenerMsg<UserEvent>>> {
         // Send tick
         self.sender.send(ListenerMsg::Tick)?;
         // Calc next tick
@@ -112,7 +112,7 @@ where
 
     /// Poll and send poll to listener. Calc next poll.
     /// Returns only the messages, while the None returned by poll are discarded
-    fn poll(&mut self) -> Result<(), mpsc::SendError<ListenerMsg<U>>> {
+    fn poll(&mut self) -> Result<(), mpsc::SendError<ListenerMsg<UserEvent>>> {
         let port_iter = self.ports.iter_mut().filter(|port| port.should_poll());
 
         for port in port_iter {

--- a/src/mock/mod.rs
+++ b/src/mock/mod.rs
@@ -35,17 +35,17 @@ pub enum MockComponentId {
 // -- poll
 
 /// Mock poll implementation
-pub struct MockPoll<U: Eq + PartialEq + Clone + PartialOrd + Send> {
+pub struct MockPoll<U: Eq + PartialEq + Clone + Send> {
     ghost: PhantomData<U>,
 }
 
-impl<U: Eq + PartialEq + Clone + PartialOrd + Send> Default for MockPoll<U> {
+impl<U: Eq + PartialEq + Clone + Send> Default for MockPoll<U> {
     fn default() -> Self {
         Self { ghost: PhantomData }
     }
 }
 
-impl<U: Eq + PartialEq + Clone + PartialOrd + Send + 'static> Poll<U> for MockPoll<U> {
+impl<U: Eq + PartialEq + Clone + Send + 'static> Poll<U> for MockPoll<U> {
     fn poll(&mut self) -> ListenerResult<Option<Event<U>>> {
         Ok(Some(Event::Keyboard(KeyEvent::from(Key::Enter))))
     }
@@ -57,9 +57,7 @@ pub struct MockPollAsync();
 
 #[cfg(feature = "async-ports")]
 #[async_trait::async_trait]
-impl<U: Eq + PartialEq + Clone + PartialOrd + Send + 'static> crate::listener::PollAsync<U>
-    for MockPollAsync
-{
+impl<U: Eq + PartialEq + Clone + Send + 'static> crate::listener::PollAsync<U> for MockPollAsync {
     async fn poll(&mut self) -> ListenerResult<Option<Event<U>>> {
         let tempfile = tempfile::NamedTempFile::new().expect("tempfile");
         let _file = tokio::fs::File::open(tempfile.path()).await.expect("file");

--- a/src/mock/mod.rs
+++ b/src/mock/mod.rs
@@ -35,18 +35,27 @@ pub enum MockComponentId {
 // -- poll
 
 /// Mock poll implementation
-pub struct MockPoll<U: Eq + PartialEq + Clone + Send> {
-    ghost: PhantomData<U>,
+pub struct MockPoll<UserEvent>
+where
+    UserEvent: Eq + PartialEq + Clone + Send,
+{
+    ghost: PhantomData<UserEvent>,
 }
 
-impl<U: Eq + PartialEq + Clone + Send> Default for MockPoll<U> {
+impl<UserEvent> Default for MockPoll<UserEvent>
+where
+    UserEvent: Eq + PartialEq + Clone + Send,
+{
     fn default() -> Self {
         Self { ghost: PhantomData }
     }
 }
 
-impl<U: Eq + PartialEq + Clone + Send + 'static> Poll<U> for MockPoll<U> {
-    fn poll(&mut self) -> ListenerResult<Option<Event<U>>> {
+impl<UserEvent> Poll<UserEvent> for MockPoll<UserEvent>
+where
+    UserEvent: Eq + PartialEq + Clone + Send + 'static,
+{
+    fn poll(&mut self) -> ListenerResult<Option<Event<UserEvent>>> {
         Ok(Some(Event::Keyboard(KeyEvent::from(Key::Enter))))
     }
 }
@@ -57,8 +66,11 @@ pub struct MockPollAsync();
 
 #[cfg(feature = "async-ports")]
 #[async_trait::async_trait]
-impl<U: Eq + PartialEq + Clone + Send + 'static> crate::listener::PollAsync<U> for MockPollAsync {
-    async fn poll(&mut self) -> ListenerResult<Option<Event<U>>> {
+impl<UserEvent> crate::listener::PollAsync<UserEvent> for MockPollAsync
+where
+    UserEvent: Eq + PartialEq + Clone + Send + 'static,
+{
+    async fn poll(&mut self) -> ListenerResult<Option<Event<UserEvent>>> {
         let tempfile = tempfile::NamedTempFile::new().expect("tempfile");
         let _file = tokio::fs::File::open(tempfile.path()).await.expect("file");
 

--- a/src/terminal/event_listener/crossterm.rs
+++ b/src/terminal/event_listener/crossterm.rs
@@ -19,17 +19,17 @@ use crate::listener::{ListenerResult, Poll};
 /// If crossterm is enabled, this will already be exported as `InputEventListener` in the `adapter` module
 /// or you can use it directly in the event listener, calling [`EventListenerCfg::crossterm_input_listener()`](crate::EventListenerCfg::crossterm_input_listener)
 #[doc(alias = "InputEventListener")]
-pub struct CrosstermInputListener<U>
+pub struct CrosstermInputListener<UserEvent>
 where
-    U: Eq + PartialEq + Clone + Send,
+    UserEvent: Eq + PartialEq + Clone + Send,
 {
-    ghost: PhantomData<U>,
+    ghost: PhantomData<UserEvent>,
     interval: Duration,
 }
 
-impl<U> CrosstermInputListener<U>
+impl<UserEvent> CrosstermInputListener<UserEvent>
 where
-    U: Eq + PartialEq + Clone + Send,
+    UserEvent: Eq + PartialEq + Clone + Send,
 {
     pub fn new(interval: Duration) -> Self {
         Self {
@@ -39,11 +39,11 @@ where
     }
 }
 
-impl<U> Poll<U> for CrosstermInputListener<U>
+impl<UserEvent> Poll<UserEvent> for CrosstermInputListener<UserEvent>
 where
-    U: Eq + PartialEq + Clone + Send + 'static,
+    UserEvent: Eq + PartialEq + Clone + Send + 'static,
 {
-    fn poll(&mut self) -> ListenerResult<Option<Event<U>>> {
+    fn poll(&mut self) -> ListenerResult<Option<Event<UserEvent>>> {
         match xterm::poll(self.interval) {
             Ok(true) => xterm::read()
                 .map(|x| Some(Event::from(x)))
@@ -54,9 +54,9 @@ where
     }
 }
 
-impl<U> From<XtermEvent> for Event<U>
+impl<UserEvent> From<XtermEvent> for Event<UserEvent>
 where
-    U: Eq + PartialEq + Clone + Send,
+    UserEvent: Eq + PartialEq + Clone + Send,
 {
     fn from(e: XtermEvent) -> Self {
         match e {

--- a/src/terminal/event_listener/crossterm.rs
+++ b/src/terminal/event_listener/crossterm.rs
@@ -1,4 +1,3 @@
-use std::marker::PhantomData;
 use std::time::Duration;
 
 use crossterm::event::{
@@ -19,27 +18,19 @@ use crate::listener::{ListenerResult, Poll};
 /// If crossterm is enabled, this will already be exported as `InputEventListener` in the `adapter` module
 /// or you can use it directly in the event listener, calling [`EventListenerCfg::crossterm_input_listener()`](crate::EventListenerCfg::crossterm_input_listener)
 #[doc(alias = "InputEventListener")]
-pub struct CrosstermInputListener<UserEvent>
-where
-    UserEvent: Eq + PartialEq + Clone + Send,
-{
-    ghost: PhantomData<UserEvent>,
+pub struct CrosstermInputListener {
     interval: Duration,
 }
 
-impl<UserEvent> CrosstermInputListener<UserEvent>
-where
-    UserEvent: Eq + PartialEq + Clone + Send,
-{
+impl CrosstermInputListener {
     pub fn new(interval: Duration) -> Self {
         Self {
-            ghost: PhantomData,
             interval: interval / 2,
         }
     }
 }
 
-impl<UserEvent> Poll<UserEvent> for CrosstermInputListener<UserEvent>
+impl<UserEvent> Poll<UserEvent> for CrosstermInputListener
 where
     UserEvent: Eq + PartialEq + Clone + Send + 'static,
 {

--- a/src/terminal/event_listener/crossterm.rs
+++ b/src/terminal/event_listener/crossterm.rs
@@ -21,7 +21,7 @@ use crate::listener::{ListenerResult, Poll};
 #[doc(alias = "InputEventListener")]
 pub struct CrosstermInputListener<U>
 where
-    U: Eq + PartialEq + Clone + PartialOrd + Send,
+    U: Eq + PartialEq + Clone + Send,
 {
     ghost: PhantomData<U>,
     interval: Duration,
@@ -29,7 +29,7 @@ where
 
 impl<U> CrosstermInputListener<U>
 where
-    U: Eq + PartialEq + Clone + PartialOrd + Send,
+    U: Eq + PartialEq + Clone + Send,
 {
     pub fn new(interval: Duration) -> Self {
         Self {
@@ -41,7 +41,7 @@ where
 
 impl<U> Poll<U> for CrosstermInputListener<U>
 where
-    U: Eq + PartialEq + Clone + PartialOrd + Send + 'static,
+    U: Eq + PartialEq + Clone + Send + 'static,
 {
     fn poll(&mut self) -> ListenerResult<Option<Event<U>>> {
         match xterm::poll(self.interval) {
@@ -56,7 +56,7 @@ where
 
 impl<U> From<XtermEvent> for Event<U>
 where
-    U: Eq + PartialEq + Clone + PartialOrd + Send,
+    U: Eq + PartialEq + Clone + Send,
 {
     fn from(e: XtermEvent) -> Self {
         match e {

--- a/src/terminal/event_listener/crossterm_async.rs
+++ b/src/terminal/event_listener/crossterm_async.rs
@@ -29,9 +29,7 @@ impl Default for CrosstermAsyncStream {
 }
 
 #[async_trait::async_trait]
-impl<U: Eq + PartialEq + Clone + PartialOrd + Send + 'static> PollAsync<U>
-    for CrosstermAsyncStream
-{
+impl<U: Eq + PartialEq + Clone + Send + 'static> PollAsync<U> for CrosstermAsyncStream {
     async fn poll(&mut self) -> ListenerResult<Option<Event<U>>> {
         let res = match self.stream.next().await {
             Some(Ok(event)) => event,

--- a/src/terminal/event_listener/crossterm_async.rs
+++ b/src/terminal/event_listener/crossterm_async.rs
@@ -29,8 +29,11 @@ impl Default for CrosstermAsyncStream {
 }
 
 #[async_trait::async_trait]
-impl<U: Eq + PartialEq + Clone + Send + 'static> PollAsync<U> for CrosstermAsyncStream {
-    async fn poll(&mut self) -> ListenerResult<Option<Event<U>>> {
+impl<UserEvent> PollAsync<UserEvent> for CrosstermAsyncStream
+where
+    UserEvent: Eq + PartialEq + Clone + Send + 'static,
+{
+    async fn poll(&mut self) -> ListenerResult<Option<Event<UserEvent>>> {
         let res = match self.stream.next().await {
             Some(Ok(event)) => event,
             Some(Err(_err)) => return Err(ListenerError::PollFailed),

--- a/src/terminal/event_listener/termion.rs
+++ b/src/terminal/event_listener/termion.rs
@@ -1,4 +1,3 @@
-use std::marker::PhantomData;
 use std::time::Duration;
 
 use termion::event::{Event as TonEvent, Key as TonKey};
@@ -11,23 +10,16 @@ use crate::listener::{ListenerResult, Poll};
 
 /// The input listener for [`termion`].
 #[doc(alias = "InputEventListener")]
-pub struct TermionInputListener<UserEvent>
-where
-    UserEvent: Eq + PartialEq + Clone + Send,
-{
-    ghost: PhantomData<UserEvent>,
-}
+#[derive(Default)]
+pub struct TermionInputListener;
 
-impl<UserEvent> TermionInputListener<UserEvent>
-where
-    UserEvent: Eq + PartialEq + Clone + Send,
-{
+impl TermionInputListener {
     pub fn new(_interval: Duration) -> Self {
-        Self { ghost: PhantomData }
+        Self
     }
 }
 
-impl<UserEvent> Poll<UserEvent> for TermionInputListener<UserEvent>
+impl<UserEvent> Poll<UserEvent> for TermionInputListener
 where
     UserEvent: Eq + PartialEq + Clone + Send + 'static,
 {

--- a/src/terminal/event_listener/termion.rs
+++ b/src/terminal/event_listener/termion.rs
@@ -13,14 +13,14 @@ use crate::listener::{ListenerResult, Poll};
 #[doc(alias = "InputEventListener")]
 pub struct TermionInputListener<U>
 where
-    U: Eq + PartialEq + Clone + PartialOrd + Send,
+    U: Eq + PartialEq + Clone + Send,
 {
     ghost: PhantomData<U>,
 }
 
 impl<U> TermionInputListener<U>
 where
-    U: Eq + PartialEq + Clone + PartialOrd + Send,
+    U: Eq + PartialEq + Clone + Send,
 {
     pub fn new(_interval: Duration) -> Self {
         Self { ghost: PhantomData }
@@ -29,7 +29,7 @@ where
 
 impl<U> Poll<U> for TermionInputListener<U>
 where
-    U: Eq + PartialEq + Clone + PartialOrd + Send + 'static,
+    U: Eq + PartialEq + Clone + Send + 'static,
 {
     fn poll(&mut self) -> ListenerResult<Option<Event<U>>> {
         match std::io::stdin().events().next() {
@@ -42,7 +42,7 @@ where
 
 impl<U> From<TonEvent> for Event<U>
 where
-    U: Eq + PartialEq + Clone + PartialOrd + Send,
+    U: Eq + PartialEq + Clone + Send,
 {
     fn from(e: TonEvent) -> Self {
         match e {

--- a/src/terminal/event_listener/termion.rs
+++ b/src/terminal/event_listener/termion.rs
@@ -11,27 +11,27 @@ use crate::listener::{ListenerResult, Poll};
 
 /// The input listener for [`termion`].
 #[doc(alias = "InputEventListener")]
-pub struct TermionInputListener<U>
+pub struct TermionInputListener<UserEvent>
 where
-    U: Eq + PartialEq + Clone + Send,
+    UserEvent: Eq + PartialEq + Clone + Send,
 {
-    ghost: PhantomData<U>,
+    ghost: PhantomData<UserEvent>,
 }
 
-impl<U> TermionInputListener<U>
+impl<UserEvent> TermionInputListener<UserEvent>
 where
-    U: Eq + PartialEq + Clone + Send,
+    UserEvent: Eq + PartialEq + Clone + Send,
 {
     pub fn new(_interval: Duration) -> Self {
         Self { ghost: PhantomData }
     }
 }
 
-impl<U> Poll<U> for TermionInputListener<U>
+impl<UserEvent> Poll<UserEvent> for TermionInputListener<UserEvent>
 where
-    U: Eq + PartialEq + Clone + Send + 'static,
+    UserEvent: Eq + PartialEq + Clone + Send + 'static,
 {
-    fn poll(&mut self) -> ListenerResult<Option<Event<U>>> {
+    fn poll(&mut self) -> ListenerResult<Option<Event<UserEvent>>> {
         match std::io::stdin().events().next() {
             Some(Ok(ev)) => Ok(Some(Event::from(ev))),
             Some(Err(_)) => Err(ListenerError::PollFailed),
@@ -40,9 +40,9 @@ where
     }
 }
 
-impl<U> From<TonEvent> for Event<U>
+impl<UserEvent> From<TonEvent> for Event<UserEvent>
 where
-    U: Eq + PartialEq + Clone + Send,
+    UserEvent: Eq + PartialEq + Clone + Send,
 {
     fn from(e: TonEvent) -> Self {
         match e {


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

None

## Description

This PR removes bound `PartialOrd` from `UserEvent` as it, to my knowledge, is completely unused.
Additionally, i also did:
- add missing `Send` bound to `Poll` for `UserEvent`, which was already required for `SyncPort`
- changed generic names to be consistent
- fixed a typo in `subscription` documentation
- removed usage of `PhantomData` for all Input Listeners

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
