### PR TITLE
Share `SubClause`s across many `Sub`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Unreleased
 - Add `Send` bound for `UserEvent` to trait `Poll`, as was already required for adding it to `SyncPort`.
 - Remove unnecessary bounds on Input Event Listeners.
 - Improve documentation for `PollAsync` and `Poll`.
+- Allow sharing `SubClause`s in `Sub` by passing in a instance of `Arc<SubClause>`.
 
 ## 3.0.1
 

--- a/src/core/subscription.rs
+++ b/src/core/subscription.rs
@@ -174,7 +174,7 @@ where
 /// - [`SubClause::Not`]: Negates inner condition
 /// - [`SubClause::And`]: the AND of the two clauses must be `true`
 /// - [`SubClause::Or`]: the OR of the two clauses must be `true`
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum SubClause<ComponentId>
 where


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

None

## Description

I had noticed that for popups (and likely some other cases) it is quite common to have something along the lines of `no_popups_mounted_clause` for a bunch of global events, but each will need their own memory allocation, even though their content is the same. ([Real example code](https://github.com/tramhao/termusic/blob/081b66a19cb2fcf8a39d7f64a565e3e331a85be1/tui/src/ui/components/global_listener.rs#L140-L231))
This PR allows to share SubClauses by putting them in a `Arc` (as subs are never modified, only dropped) to lessen memory usage.
This still allows the old way of passing in `SubClause`s to `Sub::new` directly, so this is not a breaking change.
(it is also not a breaking change due to `SubClause`'s fields not being public).

I know this will likely not have much memory or speed, but it is still *some* and it is a easy change.

Additionally also derive `Clone` on `SubClause` as it is possible due to all involved types supporting it.

### Alternative

As a alternative, it could also be possible to modify `Sub` / `Subscription` to have a `Vec` of `EventClause`, though that would require a bit more code changes than this PR.

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
