### PR TITLE
Improve Poll documentation and add more strategies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Unreleased
 - Add `Send` bound for `UserEvent` to trait `Poll`, as was already required for adding it to `SyncPort`.
 - Remove unnecessary bounds on Input Event Listeners.
 - Improve documentation for `PollAsync` and `Poll`.
+- Add `PollStrategy::UpToNoWait` which is practially the same as `PollStrategy::UpTo`, just that it does not block again after the first event.
 
 ## 3.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Unreleased
 - Remove unnecessary bounds on Input Event Listeners.
 - Improve documentation for `PollAsync` and `Poll`.
 - Add `PollStrategy::UpToNoWait` which is practially the same as `PollStrategy::UpTo`, just that it does not block again after the first event.
+- Add `PollStrategy::BlockCollectUpTo` to block until there is at least one event available, then collect up to `n` events, if available without blocking again.
 
 ## 3.0.1
 

--- a/src/listener/builder.rs
+++ b/src/listener/builder.rs
@@ -329,6 +329,6 @@ mod test {
         sleep(Duration::from_millis(25)).await; // wait for at least 1 event
 
         listener.stop().unwrap();
-        assert_eq!(listener.poll(), Ok(Some(Event::Tick)));
+        assert_eq!(listener.poll_timeout(), Ok(Some(Event::Tick)));
     }
 }

--- a/src/listener/worker.rs
+++ b/src/listener/worker.rs
@@ -224,7 +224,7 @@ mod test {
         assert!(worker.next_event() <= Duration::from_secs(5));
         // Receive
         assert_eq!(
-            ListenerResult::from(rx.recv().ok().unwrap()).ok().unwrap(),
+            ListenerResult::<Option<_>>::from(rx.recv().unwrap()).unwrap(),
             Some(Event::Keyboard(KeyEvent::from(Key::Enter)))
         );
     }
@@ -251,7 +251,7 @@ mod test {
         assert!(worker.next_tick > Instant::now());
         // Receive
         assert_eq!(
-            ListenerResult::from(rx.recv().ok().unwrap()).ok().unwrap(),
+            ListenerResult::<Option<_>>::from(rx.recv().unwrap()).unwrap(),
             Some(Event::Tick)
         );
     }


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

No issue

## Description

This PR improves documentation around polling (timeout usage, time taken, blocking behavior) and adds 2 new poll strategies

List here your changes

- improve existing documentation
- rename (internal) functions to better distinguish between the new functions
- add strategy `PollStrategy::UpToNoWait`, which polls with timeout only once, and if there are events available does not use the timeout again (instead of waiting for the timeout to finish on the last message in `UpTo`)
- add strategy `PollStrategy::BlockCollectUpTo`, which ignores the set timeout and blocks until there is a message available, then collects up to `n` messages (without timeout or blocking again), if available similar to `UpToNowait`

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

---

In the future (next major) we could make `UpToNoWait` the default `UpTo`. I didnt want to do this from the get-go as this could be a breaking change and i dont know if this project wants to rather wait for a major version for this or if a minor would be enough.
(if it should *not* become the default in the future, the comment in the code should likely be removed)

As for why `BlockCollectUpTo` is added, it is great for apps which are fully event driven and dont need to needlessly busy-loop just because a timeout happened. (example: https://github.com/tramhao/termusic/pull/558)

I have noticed that any poll with `times` (`UpTo`, `UpToNowait`, `BlockingCollectUpTo`) should likely take a [`NonZeroUsize`](https://doc.rust-lang.org/std/num/type.NonZeroUsize.html) as otherwise it would be practically useless, but this would be a breaking API change.
Another improvement could be to send the timeout for the poll with the strategy instead of setting it in the `EventListener(Cfg)`, so it could be potentially dynamic and not set for strategies that dont need it.