### PR TITLE
docs: translate docs into Simplified Chinese

### DIFF
--- a/docs/en/advanced.md
+++ b/docs/en/advanced.md
@@ -1,3 +1,5 @@
+📍<u>**English**</u> | <a href="../zh-cn/advanced.md">简体中文</a>
+
 # Advanced concepts
 
 - [Advanced concepts](#advanced-concepts)

--- a/docs/en/get-started.md
+++ b/docs/en/get-started.md
@@ -1,3 +1,5 @@
+📍<u>**English**</u> | <a href="../zh-cn/get-started.md">简体中文</a>
+
 # Get Started 🏁
 
 - [Get Started 🏁](#get-started-)

--- a/docs/en/migrating-legacy.md
+++ b/docs/en/migrating-legacy.md
@@ -1,3 +1,5 @@
+📍<u>**English**</u> | <a href="../zh-cn/migrating-legacy.md">简体中文</a>
+
 # Migrating from tui-realm 0.x
 
 - [Migrating from tui-realm 0.x](#migrating-from-tui-realm-0x)

--- a/docs/zh-cn/advanced.md
+++ b/docs/zh-cn/advanced.md
@@ -1,0 +1,523 @@
+📍<u>**简体中文**</u> | <a href="../en/advanced.md">English</a>
+
+# 高级概念
+
+- [高级概念](#高级概念)
+  - [简介](#简介)
+  - [订阅 (Subscriptions)](#订阅 (Subscriptions))
+    - [处理订阅](#处理订阅)
+    - [事件子句 (Event clauses) 详解](#事件子句 (Event clauses) 详解)
+    - [订阅子句 (Sub clauses) 详解](#订阅子句 (Sub clauses) 详解)
+    - [订阅锁](#订阅锁)
+  - [Tick 事件](#tick-事件)
+  - [端口](#端口)
+  - [实现新组件](#实现新组件)
+    - [组件应该是什么样子](#组件应该是什么样子)
+    - [定义组件属性](#定义组件属性)
+    - [定义组件状态](#定义组件状态)
+    - [定义 Cmd API](#定义-cmd-api)
+    - [渲染组件](#渲染组件)
+  - [属性注入器](#属性注入器)
+  - [下一步](#下一步)
+
+---
+
+## 简介
+
+本指南将向您介绍 tui-realm 的所有高级概念，这些概念在[入门指南](get-started.md)中未涵盖。尽管 tui-realm 相当简单，但它也可以变得非常强大，这得益于我们将在本文档中介绍的所有这些功能。
+
+您将学习到：
+
+- 如何处理订阅 (Subscriptions)，使某些组件在特定情况下监听特定事件
+- 什么是 `Event::Tick`
+- 如何通过 `Ports` 使用自定义事件源
+- 如何实现新组件
+
+---
+
+## 订阅 (Subscriptions)
+
+> 订阅是一个规则集，它告诉**应用程序**基于某些规则将事件转发给其他组件，即使它们不处于活动状态。
+
+正如我们在 tui-realm 的基本概念中已经介绍的，应用负责将事件从端口转发到组件。
+默认情况下，事件仅转发给当前活动组件，但这可能相当烦人：
+
+- 首先，我们可能需要一个组件始终监听传入事件。想象一些轮询远程服务器的加载器。它们不能仅在获得焦点时更新，它们可能需要在*事件监听器*每次接收到来自*端口*的事件时更新。没有*订阅*，这将是不可能的。
+- 有时这只是"太无聊"和范围的问题：在示例中我有两个计数器，它们都监听 `<ESC>` 键来退出应用并返回 `AppClose` 消息。但是告诉应用是否应该终止是它们的责任吗？我的意思是，它们只是计数器，所以它们不应该知道是否关闭应用，对吧？除此之外，为每个组件编写 `<ESC>` 的情况来返回 `AppClose` 也非常烦人。有一个不可见的组件始终监听 `<ESC>` 来返回 `AppClose` 会舒服得多。
+
+那么订阅实际上是什么，我们如何创建它们？
+
+订阅定义为：
+
+```rust
+pub struct Sub<UserEvent>(EventClause<UserEvent>, SubClause)
+where
+    UserEvent: Eq + PartialEq + Clone + PartialOrd;
+```
+
+所以它是一个元组结构，接受一个 `EventClause` 和一个 `SubClause`，让我们深入了解：
+
+- **事件子句**是传入事件必须满足的匹配子句。正如我们之前所说，应用必须知道是否将某个*事件*转发给某个组件。所以它必须检查的第一件事是它是否正在监听那种事件。
+
+    事件子句声明如下：
+
+    ```rust
+    pub enum EventClause<UserEvent>
+    where
+        UserEvent: Eq + PartialEq + Clone + PartialOrd,
+    {
+        /// 无论何种事件都转发
+        Any,
+        /// 检查是否按下了某个键
+        Keyboard(KeyEvent),
+        /// 检查窗口是否已调整大小
+        WindowResize,
+        /// 在 tick 时转发事件
+        Tick,
+        /// 在此特定用户事件时转发事件。
+        /// 用户事件的匹配方式取决于其 partialEq 实现
+        User(UserEvent),
+    }
+    ```
+
+- **订阅子句**是必须由与订阅关联的组件满足的附加条件，以便转发事件：
+
+    ```rust
+    pub enum SubClause {
+        /// 始终将事件转发给组件
+        Always,
+        /// 如果目标组件具有提供的属性和提供的值，则转发事件
+        /// 如果组件上不存在该属性，结果始终为 `false`。
+        HasAttrValue(Attribute, AttrValue),
+        /// 如果目标组件具有提供的状态，则转发事件
+        HasState(State),
+        /// 如果内部子句为 `false`，则转发事件
+        Not(Box<SubClause>),
+        /// 如果两个内部子句都为 `true`，则转发事件
+        And(Box<SubClause>, Box<SubClause>),
+        /// 如果至少一个内部子句为 `true`，则转发事件
+        Or(Box<SubClause>, Box<SubClause>),
+    }
+    ```
+
+因此，当接收到事件时，如果一个**不活动**的组件满足事件子句和订阅子句，那么事件也将转发给该组件。
+
+> ❗ 为了转发事件，必须同时满足 `EventClause` 和 `SubClause`
+
+让我们详细看看如何处理订阅以及如何使用子句。
+
+### 处理订阅
+
+您可以在组件挂载时和任何时候创建订阅。
+
+要在 `mount` 时订阅组件，只需向 `mount()` 提供 `Sub` 向量：
+
+```rust
+app.mount(
+    Id::Clock,
+    Box::new(
+        Clock::new(SystemTime::now())
+            .alignment(Alignment::Center)
+            .background(Color::Reset)
+            .foreground(Color::Cyan)
+            .modifiers(TextModifiers::BOLD)
+    ),
+    vec![Sub::new(SubEventClause::Tick, SubClause::Always)]
+);
+```
+
+或者您可以在任何时候创建新订阅：
+
+```rust
+app.subscribe(&Id::Clock, Sub::new(SubEventClause::Tick, SubClause::Always));
+```
+
+如果您需要删除订阅，可以简单地取消订阅：
+
+```rust
+app.unsubscribe(&Id::Clock, SubEventClause::Tick);
+```
+
+### 事件子句 (Event clauses) 详解
+
+事件子句用于定义应为哪种事件设置订阅。
+一旦应用检查是否要转发事件，它必须首先检查事件子句并验证其是否满足与传入事件的边界。事件子句有：
+
+- `Any`：事件子句被满足，无论是什么类型的事件。一切都取决于 `SubClause` 的结果。
+- `Keyboard(KeyEvent)`：为了满足子句，传入事件必须是 `Keyboard` 类型，并且 `KeyEvent` 必须完全相同。
+- `WindowResize`：为了满足子句，传入事件必须是 `WindowResize` 类型，无论窗口大小如何。
+- `Tick`：为了满足子句，传入事件必须是 `Tick` 类型。
+- `User(UserEvent)`：为了被满足，传入事件必须是 `User` 类型。`UserEvent` 的值必须匹配，根据为此类型实现 `PartialEq` 的方式。
+
+### 订阅子句 (Sub clauses) 详解
+
+订阅子句在事件子句满足后验证，它们定义了一些必须由**目标**组件（与订阅关联的组件）满足的子句。
+特别是订阅子句有：
+
+- `Always`：子句始终满足
+- `HasAttrValue(Id, Attribute, AttrValue)`：如果目标组件（在 `Id` 中定义）在其 `Props` 中具有 `Attribute` 和 `AttrValue`，则满足子句。
+- `HasState(Id, State)`：如果目标组件（在 `Id` 中定义）具有等于提供状态的 `State`，则满足子句。
+- `IsMounted(Id)`：如果目标组件（在 `Id` 中定义）已挂载到视图中，则满足子句。
+
+除了这些，还可以使用表达式组合订阅子句：
+
+- `Not(SubClause)`：如果内部子句不满足，则满足子句（取反结果）
+- `And(SubClause, SubClause)`：如果两个子句都满足，则满足子句
+- `Or(SubClause, SubClause)`：如果至少一个子句满足，则满足子句。
+
+使用 `And` 和 `Or`，您甚至可以创建长表达式，请记住它们是递归评估的，例如：
+
+`And(Or(A, And(B, C)), And(D, Or(E, F)))` 被评估为 `(A || (B && C)) && (D && (E || F))`
+
+### 订阅锁
+
+可以暂时禁用订阅传播。
+为此，您只需要调用 `application.lock_subs()`。
+
+无论何时想要恢复事件传播，只需调用 `application.unlock_subs()`。
+
+---
+
+## Tick 事件
+
+Tick 事件是一种特殊的事件，由**应用**以指定的间隔引发。
+每当初始化**应用**时，您可以指定 tick 间隔，如以下示例所示：
+
+```rust
+let mut app: Application<Id, Msg, NoUserEvent> = Application::init(
+    EventListenerCfg::default()
+        .tick_interval(Duration::from_secs(1)),
+);
+```
+
+使用 `tick_interval()` 方法，我们指定 tick 间隔。
+每次 tick 间隔过去时，应用运行时将抛出一个 `Event::Tick`，它将在 `tick()` 时转发给当前活动组件和所有订阅了 `Tick` 事件的组件。
+
+Tick 事件的目的是基于某个间隔调度操作。
+
+---
+
+## 端口
+
+端口基本上是**事件生产者**，由应用*事件监听器*处理。
+通常，tui-realm 应用只会消费输入事件或 tick 事件，但如果我们需要*更多*事件怎么办？
+
+例如，我们可能需要一个工作器来获取远程服务器的数据。端口允许您创建自动化的工作器，这些工作器将产生事件，如果您正确设置了一切，您的模型和组件将被更新。
+
+现在让我们看看如何设置*端口*：
+
+1. 首先我们需要为我们的应用定义 `UserEvent` 类型：
+
+    ```rust
+    #[derive(PartialEq, Clone, PartialOrd)]
+    pub enum UserEvent {
+        GotData(Data)
+        // ... 如果您需要，其他事件
+    }
+
+    impl Eq for UserEvent {}
+    ```
+
+2. 实现*端口*，我命名为 `MyHttpClient`
+
+    ```rust
+    pub struct MyHttpClient {
+        // ...
+    }
+    ```
+
+    现在我们需要为*端口*实现 `Poll` trait。
+    Poll trait 告诉应用事件监听器如何在*端口*上轮询事件：
+
+    ```rust
+    impl Poll<UserEvent> for MyHttpClient {
+        fn poll(&mut self) -> ListenerResult<Option<Event<UserEvent>>> {
+            // ... 做点什么 ...
+            Ok(Some(Event::User(UserEvent::GotData(data))))
+        }
+    }
+    ```
+
+3. 应用中的端口设置
+
+    ```rust
+    let mut app: Application<Id, Msg, UserEvent> = Application::init(
+        EventListenerCfg::default()
+            .default_input_listener(Duration::from_millis(10))
+            .port(
+                Box::new(MyHttpClient::new(/* ... */)),
+                Duration::from_millis(100),
+            ),
+    );
+    ```
+
+    在事件监听器构造函数中，您可以定义任意数量的端口。当您声明一个端口时，您需要传递一个包含实现*Poll* trait 的类型的 box 和一个间隔。
+    间隔定义了每次轮询端口之间的间隔。
+
+---
+
+## 实现新组件
+
+在 tui-realm 中实现新组件实际上相当简单，但要求您至少对**tui-rs widgets**有基本的了解。
+
+除了 tui-rs 知识，您还应该记住*MockComponent*和*Component*之间的区别，以免实现糟糕的组件。
+
+说了这些，让我们看看如何实现一个组件。对于这个示例，我将实现 stdlib 中 `Radio` 组件的简化版本。
+
+### 组件应该是什么样子
+
+我们需要定义的第一件事是组件应该是什么样子。
+在这种情况下，组件是一个包含选项列表的框，您可以选择一个，这是用户的选择。
+用户将能够在不同的选择之间移动并提交一个。
+
+### 定义组件属性
+
+一旦我们定义了组件的样子，我们就可以开始定义组件属性：
+
+- `Background(Color)`：将定义组件的背景颜色
+- `Borders(Borders)`：将定义组件的边框属性
+- `Foreground(Color)`：将定义组件的前景颜色
+- `Content(Payload(Vec(String)))`：将定义单选组的可能选项
+- `Title(Title)`：将定义框标题
+- `Value(Payload(One(Usize)))`：将作为属性工作，但也会更新状态，用于当前选定的选项。
+
+```rust
+pub struct Radio {
+    props: Props,
+    // ...
+}
+
+impl Radio {
+
+    // 构造函数...
+
+    pub fn foreground(mut self, fg: Color) -> Self {
+        self.attr(Attribute::Foreground, AttrValue::Color(fg));
+        self
+    }
+
+    // ...
+}
+
+impl MockComponent for Radio {
+
+    // ...
+
+    fn query(&self, attr: Attribute) -> Option<AttrValue> {
+        self.props.get(attr)
+    }
+
+    fn attr(&mut self, attr: Attribute, value: AttrValue) {
+        match attr {
+            Attribute::Content => {
+                // 重置选择
+                let choices: Vec<String> = value
+                    .unwrap_payload()
+                    .unwrap_vec()
+                    .iter()
+                    .map(|x| x.clone().unwrap_str())
+                    .collect();
+                self.states.set_choices(&choices);
+            }
+            Attribute::Value => {
+                self.states
+                    .select(value.unwrap_payload().unwrap_one().unwrap_usize());
+            }
+            attr => {
+                self.props.set(attr, value);
+            }
+        }
+    }
+
+    // ...
+
+}
+```
+
+### 定义组件状态
+
+由于此组件可以是交互式的，并且用户必须能够选择某个选项，我们必须实现一些状态。
+组件状态必须跟踪当前选定的项。出于实际原因，我们还使用可用选择作为状态。
+
+```rust
+struct OwnStates {
+    choice: usize,        // 选定的选项
+    choices: Vec<String>, // 可用选择
+}
+
+impl OwnStates {
+
+    /// 将选择索引移动到下一个选择
+    pub fn next_choice(&mut self) {
+        if self.choice + 1 < self.choices.len() {
+            self.choice += 1;
+        }
+    }
+
+
+    /// 将选择索引移动到上一个选择
+    pub fn prev_choice(&mut self) {
+        if self.choice > 0 {
+            self.choice -= 1;
+        }
+    }
+
+
+    /// 从文本跨度向量设置 OwnStates 选择
+    /// 此外重置当前选择，如果可能则保留索引，或将其设置为第一个可用值
+    pub fn set_choices(&mut self, spans: &[String]) {
+        self.choices = spans.to_vec();
+        // 如果可能则保留索引
+        if self.choice >= self.choices.len() {
+            self.choice = match self.choices.len() {
+                0 => 0,
+                l => l - 1,
+            };
+        }
+    }
+
+    pub fn select(&mut self, i: usize) {
+        if i < self.choices.len() {
+            self.choice = i;
+        }
+    }
+}
+```
+
+然后我们可以定义 `state()` 方法
+
+```rust
+impl MockComponent for Radio {
+
+    // ...
+
+    fn state(&self) -> State {
+        State::One(StateValue::Usize(self.states.choice))
+    }
+
+    // ...
+
+}
+```
+
+### 定义 Cmd API
+
+一旦我们定义了组件状态，我们就可以开始考虑命令 API。命令 API 定义了组件在面对传入命令时的行为方式以及它应该返回什么类型的结果。
+
+对于此组件，我们将处理以下命令：
+
+- 当用户向右移动时，当前选择递增
+- 当用户向左移动时，当前选择递减
+- 当用户提交时，返回当前选择
+
+```rust
+impl MockComponent for Radio {
+
+    // ...
+
+    fn perform(&mut self, cmd: Cmd) -> CmdResult {
+        match cmd {
+            Cmd::Move(Direction::Right) => {
+                // 递增选择
+                self.states.next_choice();
+                // 返回更改的 CmdResult
+                CmdResult::Changed(self.state())
+            }
+            Cmd::Move(Direction::Left) => {
+                // 递减选择
+                self.states.prev_choice();
+                // 返回更改的 CmdResult
+                CmdResult::Changed(self.state())
+            }
+            Cmd::Submit => {
+                // 返回提交
+                CmdResult::Submit(self.state())
+            }
+            _ => CmdResult::None,
+        }
+    }
+
+    // ...
+
+}
+```
+
+### 渲染组件
+
+最后，我们可以实现组件 `view()` 方法，该方法将渲染组件：
+
+```rust
+impl MockComponent for Radio {
+    fn view(&mut self, render: &mut Frame, area: Rect) {
+        if self.props.get_or(Attribute::Display, AttrValue::Flag(true)) == AttrValue::Flag(true) {
+            // 创建选择
+            let choices: Vec<Spans> = self
+                .states
+                .choices
+                .iter()
+                .map(|x| Spans::from(x.clone()))
+                .collect();
+            let foreground = self
+                .props
+                .get_or(Attribute::Foreground, AttrValue::Color(Color::Reset))
+                .unwrap_color();
+            let background = self
+                .props
+                .get_or(Attribute::Background, AttrValue::Color(Color::Reset))
+                .unwrap_color();
+            let borders = self
+                .props
+                .get_or(Attribute::Borders, AttrValue::Borders(Borders::default()))
+                .unwrap_borders();
+            let title = self.props.get(Attribute::Title).map(|x| x.unwrap_title());
+            let focus = self
+                .props
+                .get_or(Attribute::Focus, AttrValue::Flag(false))
+                .unwrap_flag();
+            let div = crate::utils::get_block(borders, title, focus, None);
+            // 创建颜色
+            let (bg, fg, block_color): (Color, Color, Color) = match focus {
+                true => (foreground, background, foreground),
+                false => (Color::Reset, foreground, Color::Reset),
+            };
+            let radio: Tabs = Tabs::new(choices)
+                .block(div)
+                .select(self.states.choice)
+                .style(Style::default().fg(block_color))
+                .highlight_style(Style::default().fg(fg).bg(bg));
+            render.render_widget(radio, area);
+        }
+    }
+
+    // ...
+}
+```
+
+---
+
+## 属性注入器
+
+属性注入器是 trait 对象，必须实现 `Injector` trait，可以在组件挂载时为其提供一些属性（定义为 `Attribute` 和 `AttrValue` 的元组）。
+Injector trait 定义如下：
+
+```rs
+pub trait Injector<ComponentId>
+where
+    ComponentId: Eq + PartialEq + Clone + Hash,
+{
+    fn inject(&self, id: &ComponentId) -> Vec<(Attribute, AttrValue)>;
+}
+```
+
+然后您可以使用 `add_injector()` 方法将注入器添加到您的应用中。
+
+无论何时将新组件挂载到视图中，都会为应用中定义的每个注入器调用 `inject()` 方法，提供挂载组件的 id 作为参数。
+
+---
+
+## 下一步
+
+如果您来自 tui-realm 0.x 并希望迁移到 tui-realm 1.x，有一个指南解释了[如何从 tui-realm 0.x 迁移到 1.x](migrating-legacy.md)。
+否则，我认为您现在就可以开始实现您的 tui-realm 应用了 😉。
+
+如果您有任何问题，请随时打开带有 `question` 标签的问题，我会尽快回答您 🙂。

--- a/docs/zh-cn/get-started.md
+++ b/docs/zh-cn/get-started.md
@@ -1,0 +1,571 @@
+📍<u>**简体中文**</u> | <a href="../en/get-started.md">English</a>
+
+# 快速入门 🏁
+
+- [快速入门 🏁](#快速入门-)
+  - [Realm 简介](#realm-简介)
+  - [核心概念](#核心概念)
+  - [原型组件 (MockComponent) 与 组件 (Component)](#原型组件 (MockComponent) 与 组件 (Component))
+    - [原型组件](#原型组件)
+    - [组件](#组件)
+    - [属性 (Properties) 与状态 (States)](#属性 (Properties) 与状态 (States))
+    - [事件 (Events) 与命令 (Commands)](#事件 (Events) 与命令 (Commands))
+  - [应用、模型和视图](#应用模型和视图)
+    - [视图 (View)](#视图 (View))
+      - [焦点](#焦点)
+    - [模型 (Model)](#模型 (Model))
+    - [应用](#应用)
+  - [生命周期（或 "tick"）](#生命周期或-tick)
+  - [我们的第一个应用](#我们的第一个应用)
+    - [实现计数器](#实现计数器)
+    - [定义消息类型](#定义消息类型)
+    - [定义组件标识符](#定义组件标识符)
+    - [实现两个计数器组件](#实现两个计数器组件)
+    - [实现模型](#实现模型)
+    - [应用设置和主循环](#应用设置和主循环)
+  - [下一步](#下一步)
+
+---
+
+## Realm 简介
+
+您将学习到：
+
+- tui-realm 的核心概念
+- 如何从零开始编写 tui-realm 应用
+- tui-realm 的亮点特性
+
+tui-realm 是一个 ratatui **框架**，提供了实现有状态应用的简便方法。
+首先，让我们看看 tui-realm 的主要特性以及为什么在构建终端用户界面时应选择此框架：
+
+- ⌨️ **事件驱动**
+
+    tui-realm 采用 Elm 架构的 `Event -> Msg` 模式。**事件**由称为 `Port` 的实体 (entities) 产生，这些实体作为事件监听器（如 stdin 读取器或 HTTP 客户端）工作，产生事件。这些事件随后被转发到**组件**，组件将产生一个**消息**。消息将根据其变体在您的应用模型中引起特定行为。
+    相当简单，您的应用中的所有内容都将围绕此逻辑工作，因此实现任何功能都非常容易。
+
+- ⚛️ 基于 **React** 和 **Elm**
+
+    tui-realm 基于 [React](https://reactjs.org/) 和 [Elm](https://elm-lang.org/)。这两种方法有些不同，但我决定从每种方法中取其精华，将它们结合到 **Realm** 中。从 React 中我采用了**组件**概念。在 realm 中，每个组件代表一个图形实例，可能包含一些子组件；每个组件都有一个**状态**和一些**属性**。
+    从 Elm 中我基本上采用了 Realm 中实现的每个其他概念。我真的很喜欢 Elm 作为一门语言，特别是 **TEA**（The Elm Architecture）。
+    实际上，与 Elm 一样，在 realm 中应用的生命周期是 `Event -> Msg -> Update -> View -> Event -> ...`
+
+- 🍲 **样板代码**
+
+    tui-realm 在开始时可能看起来很难使用，但过一段时间后您会开始意识到您正在实现的代码只是从先前组件复制的样板代码。
+
+- 🚀 快速设置
+
+    自从最新的 tui-realm API（1.x）以来，tui-realm 变得非常容易学习和设置，这得益于新的 `Application` 数据类型、事件监听器和 `Terminal` 辅助工具。
+
+- 🎯 单一的**焦点**和**状态**管理
+
+    在 realm 中，您不必自己管理焦点和状态，一切都由**视图**自动管理，所有组件都挂载在视图中。使用 realm，您不再需要担心应用状态和焦点了。
+
+- 🙂 易于学习
+
+    得益于向用户公开的少量数据类型和指南，即使您以前从未使用过 tui 或 Elm，学习 tui-realm 也非常容易。
+
+- 🤖 适应任何用例
+
+    正如您将通过本指南学到的，tui-realm 公开了一些高级概念来创建自己的事件监听器、处理自己的事件以及实现复杂的组件。
+
+---
+
+## 核心概念
+
+现在让我们看看 tui-realm 的核心概念。在简介中您可能已经读到了一些**粗体**的概念，但现在让我们详细看看它们。核心概念非常重要，幸运的是它们易于理解且数量不多：
+
+- **MockComponent**：原型组件代表一个可复用的 UI 组件，可以具有一些用于渲染或处理命令的**属性**。如果需要，它还可以有自己的**状态**。实际上，它是一个 trait，公开了一些方法来渲染和处理属性、状态和事件。我们将在下一章中详细讨论。
+- **Component**：组件是 原型组件的包装器，代表您应用中的单个组件。它直接接收事件并为应用消费者生成消息。在底层，它依赖其 原型组件进行属性/状态管理和渲染。
+- **State**：状态代表组件的当前状态（例如，文本输入框中的当前文本）。状态取决于用户（或其他来源）如何与组件交互（例如，用户按下 'a'，字符被推送到文本输入框）。
+- **Attribute**：属性描述组件中的单个属性。属性不应依赖于组件状态，而应仅在组件初始化时由用户配置。通常，原型组件公开许多要配置的属性，而使用 原型组件 的组件根据用户需求设置它们。
+- **Event**：事件是一个**原始**实体，主要描述由用户引起的事件（如按键操作），但也可能由外部源生成（我们将在"高级概念"中讨论这些）。
+- **Message**（通常称为 `Msg`）：消息是由组件在接收到**事件**后生成的逻辑事件。
+
+    事件是*原始*的（如按键操作），而消息是面向应用的。消息随后由**更新例程**消费。我认为一个例子可以更好地解释：假设我们有一个弹出窗口组件，当按下 `ESC` 时，它必须报告给应用以隐藏它。那么事件将是 `Key::Esc`，它将消费它，并返回一个 `PopupClose` 消息。消息完全由用户通过模板类型定义，但我们将在本指南后面看到这一点。
+
+- **Command**（通常称为 `Cmd`）：是由**组件**在接收到**事件**时生成的实体。组件使用它来操作其**MockComponent**。我们将在后面看到为什么需要这两个实体。
+- **View**：视图是存储所有组件的地方。视图基本上有三个任务：
+  
+  - **管理组件的挂载/卸载**：组件在创建时挂载到视图中。视图防止挂载重复的组件，并在您尝试操作不存在的组件时发出警告。
+  - **管理焦点**：视图保证一次只有一个组件处于活动状态。活动组件启用了一个专用属性（我们将在后面看到），所有事件都将转发给它。视图跟踪所有先前活动的组件，因此如果当前活动组件失去焦点，如果没有其他组件要激活，则先前活动的组件将变为活动状态。
+  - **提供操作组件的 API**：一旦组件挂载到视图中，它们必须以安全的方式对外部可访问。这得益于视图公开的桥接方法。由于每个组件必须唯一标识才能被访问，您需要为组件定义一些 ID。
+- **Model**：模型是您为应用定义的结构，用于实现**更新例程**。
+- **Subscription** 或 *Sub*：订阅是一个规则集，它告诉**应用**基于某些规则将事件转发给其他组件，即使它们不处于活动状态。我们将在高级概念中讨论订阅。
+- **Port**：Port 是一个事件监听器，它将使用名为 `Poll` 的 trait 来获取传入事件。Port 定义了要调用的 trait 和每次调用之间必须经过的时间间隔。事件随后被转发给订阅的组件。输入监听器是一个 port，但您也可以实现例如 HTTP 客户端来获取一些数据。无论如何，我们将在高级概念中看到 ports，因为它们不太常用。
+- **Event Listener**：这是一个线程，它轮询 ports 以读取传入事件。事件随后报告给**应用**。
+- **Application**：应用是围绕*视图*、*订阅* 和 *事件监听器* 的统一包装器。它公开了到视图的桥接、一些*订阅*的简写；但它的主要功能是 `tick()`。正如我们将在后面看到的，tick 是所有框架魔法发生的地方。
+- **Update routine**：更新例程是一个函数，必须由**模型**实现，是*Update trait*的一部分。这个函数既简单又重要。它以可变引用形式接收*模型*、可变引用形式的*视图*和传入的**消息**。基于*消息*的值，它会在模型或视图上引起特定行为。如果您问的话，它只是一个*match case*，并且可以返回一个*消息*，这将导致例程被应用递归调用。稍后，当我们看到示例时，您会看到这有多酷。
+
+---
+
+## 原型组件 (MockComponent) 与 组件 (Component)
+
+我们已经大致说过这两个实体是什么，但现在该在实践中看看它们了。
+我们应该记住的第一件事是，它们都是**Traits**，并且根据设计，一个*Component*也是一个*MockComponent*。
+让我们详细看看它们的定义：
+
+### 原型组件
+
+原型组件旨在*通用*（但不要太过）和*可重用*，但同时具有*单一职责*。
+例如：
+
+- ✅ 显示单行文本的 Label 是一个好的 原型组件。
+- ✅ 像 HTML 中的 `<input>` 这样的 Input 组件是一个好的 原型组件。即使它可以处理许多输入类型，它仍然具有单一职责，是通用的且可重用的。
+- ❌ 可以同时处理文本、单选按钮和复选框的输入是一个糟糕的 原型组件。它太通用了。
+- ❌ 接收服务器远程地址的输入是一个糟糕的 原型组件。它不通用。
+
+这些只是指南，但只是为了让您了解 原型组件是什么。
+
+原型组件还处理**状态**和**属性**，这些完全基于您的需求由用户定义。有时您甚至可能有没有任何状态的组件（例如标签）。
+
+实际上，原型组件是一个 trait，需要实现以下方法：
+
+```rust
+pub trait MockComponent {
+    fn view(&mut self, frame: &mut Frame, area: Rect);
+    fn query(&self, attr: Attribute) -> Option<AttrValue>;
+    fn attr(&mut self, attr: Attribute, value: AttrValue);
+    fn state(&self) -> State;
+    fn perform(&mut self, cmd: Cmd) -> CmdResult;
+}
+```
+
+trait 要求您实现：
+
+- *view*：在提供区域中渲染组件的方法。您必须使用 `ratatui` widgets 根据组件的属性和状态来渲染组件。
+- *query*：返回组件属性中某个属性的值。
+- *attr*：为组件属性分配某个属性。
+- *state*：获取当前组件状态。如果没有状态，则返回 `State::None`。
+- *perform*：对组件执行提供的**命令**。此方法由**组件**调用，我们将在后面看到。命令应更改组件状态。一旦操作处理完毕，它必须将 `CmdResult` 返回给**组件**。
+
+### 组件
+
+所以，显然 原型组件定义了我们需要处理属性、状态和渲染的所有内容。那么为什么我们还没有完成，还需要一个组件 trait 呢？
+
+1. MockComponent 必须是**通用的**：原型组件在库中分发（例如 `tui-realm-stdlib`），因此它们不能消费 `Event` 或产生 `Message`。
+2. 由于第 1 点，我们需要一个能够产生 `Msg` 并消费 `Event` 的实体。这两个实体完全或部分由用户定义，这意味着它们对于每个 realm 应用都是不同的。这意味着组件必须适应应用。
+3. **不可能满足所有人的需求**：我在 tui-realm 0.x 中尝试过，但这根本不可能。在某个时刻，我只是开始在其他属性中添加属性，但最终我不得不从头开始重新实现 stdlib 组件，只是为了获得一些不同的逻辑。原型组件很好，因为它们通用，但不要太过；它们必须对我们表现得像傻瓜一样。组件正是我们应用想要的。我们想要一个文本输入，但我们希望当我们输入 'a' 时它会改变颜色。您可以使用组件做到这一点，但不能使用 原型组件。哦，我几乎忘记了泛化 原型组件 最糟糕的事情：**键绑定**。
+
+这么说，什么是组件？
+
+组件是 原型组件 的应用特定唯一实现。让我们以表单为例，假设第一个字段是接收用户名的文本输入。如果我们用 HTML 来思考，它肯定是一个 `<input type="text" />` 对吧？您的网页中的许多其他组件也是如此。因此，文本输入将是 tui-realm 中的 `MockComponent`。但*那个*用户名输入字段将是您的**用户名文本输入**。`UsernameInput` 将包装一个 `Input` 原型组件，但基于传入事件，它将以不同方式操作 原型组件，并且如果与例如 `EmailInput` 相比，将产生不同的**消息**。
+
+所以，让我说明从现在开始您必须记住的最重要的事情：**组件是唯一的 ❗** 在您的应用中。您**永远不应多次使用相同的组件**。
+
+现在让我们看看组件在实践中是什么：
+
+```rust
+pub trait Component<Msg, UserEvent>: MockComponent
+where
+    Msg: PartialEq,
+    UserEvent: Eq + PartialEq + Clone + PartialOrd,
+{
+    fn on(&mut self, ev: Event<UserEvent>) -> Option<Msg>;
+}
+```
+
+相当简单吧？是的，我的意图是让它们尽可能轻量，因为您必须为视图中的每个组件实现一个。正如您可能注意到的，Component 需要实现 `MockComponent`，所以实际上我们也会有类似这样的东西：
+
+```rust
+pub struct UsernameInput {
+    component: Input, // 其中 Input 实现了 `MockComponent`
+}
+
+impl Component for UsernameInput { ... }
+```
+
+您可能注意到的另一件事，可能会吓到你们中的一些人，是 Component 采用的两个泛型类型。
+让我们看看这两种类型是什么：
+
+- `Msg`：定义您的应用将在**更新例程**中处理的**消息**类型。实际上，在 tui-realm 中，消息不是在库中定义的，而是由用户定义的。我们将在后面的"第一个应用的制作"中详细讨论这一点。对于 Message 的唯一要求是它必须实现 `PartialEq`，因为您必须能够在**更新**中匹配它。
+- `UserEvent`：用户事件定义了您的应用可以处理的自定义事件。正如我们之前所说，tui-realm 通常会发送有关用户输入或终端事件的事件，加上一个称为 `Tick` 的特殊事件（但我们将在后面讨论）。除了这些之外，我们已经看到还有其他称为 `Port` 的特殊实体，它们可能从其他源返回事件。由于 tui-realm 需要知道这些事件是什么，您需要提供您的 ports 将产生的类型。
+
+    如果我们看一下 `Event` 枚举，一切都会变得清晰。
+
+    ```rust
+    pub enum Event<UserEvent>
+    where
+        UserEvent: Eq + PartialEq + Clone + PartialOrd,
+    {
+        /// 键盘事件
+        Keyboard(KeyEvent),
+        /// 终端窗口调整大小后引发的事件
+        WindowResize(u16, u16),
+        /// UI tick 事件（应可配置）
+        Tick,
+        /// 未处理的事件；空事件
+        None,
+        /// 用户事件；不会被标准库或默认输入事件监听器使用；
+        /// 但可以在用户定义的 ports 中使用
+        User(UserEvent),
+    }
+    ```
+
+    如您所见，`Event` 有一个称为 `User` 的特殊变体，它接受一个特殊类型 `UserEvent`，确实可以用于使用用户定义的事件。
+
+    > ❗如果您的应用没有任何 `UserEvent`，您可以通过传递 `Event<NoUserEvent>` 来声明事件，这是一个空枚举
+
+### 属性 (Properties) 与状态 (States)
+
+所有组件都由属性描述，并且通常也由状态描述。但它们之间有什么区别？
+
+基本上**属性**描述组件如何渲染以及它应该如何行为。
+
+例如，属性是**样式**、**颜色**或一些属性，如"这个列表应该滚动吗？"。
+属性始终存在于组件中。
+
+另一方面，状态是可选的，并且*通常*仅由用户可以与之交互的组件使用。
+状态不会描述样式或组件的行为方式，而是组件的当前状态。状态通常也会在用户执行某个**命令**后更改。
+
+让我们看看如何区分组件上的属性和状态，假设这个组件是一个*复选框*：
+
+- 复选框的前景和背景是**属性**（在交互时不改变）
+- 复选框选项是**属性**
+- 当前选定的选项是**状态**。（它们在用户交互时改变）
+- 当前高亮项是**状态**。
+
+### 事件 (Events) 与命令 (Commands)
+
+我们已经几乎看到了组件背后的所有方面，但我们仍然需要讨论一个重要概念，即 `Event` 和 `Cmd` 之间的区别。
+
+如果我们看一下**组件** trait，我们会看到 `on()` 方法具有以下签名：
+
+```rust
+fn on(&mut self, ev: Event<UserEvent>) -> Option<Msg>;
+```
+
+并且我们知道 `Component::on()` 将调用其**MockComponent** 的 `perform()` 方法，以更新其状态。perform 方法具有以下签名：
+
+```rust
+fn perform(&mut self, cmd: Cmd) -> CmdResult;
+```
+
+如您所见，**组件**消费一个 `Event` 并产生一个 `Msg`，而由组件调用的 原型组件 消费一个 `Cmd` 并产生一个 `CmdResult`。
+
+如果我们看一下两种类型声明，我们会发现在范围方面存在差异，让我们看一下：
+
+```rust
+pub enum Event<UserEvent>
+where
+    UserEvent: Eq + PartialEq + Clone + PartialOrd,
+{
+    /// 键盘事件
+    Keyboard(KeyEvent),
+    /// 终端窗口调整大小后引发的事件
+    WindowResize(u16, u16),
+    /// UI tick 事件（应可配置）
+    Tick,
+    /// 未处理的事件；空事件
+    None,
+    /// 用户事件；不会被标准库或默认输入事件监听器使用；
+    /// 但可以在用户定义的 ports 中使用
+    User(UserEvent),
+}
+
+pub enum Cmd {
+    /// 描述用户"输入"了一个字符
+    Type(char),
+    /// 描述"光标"移动或其他类型的移动
+    Move(Direction),
+    /// `Move` 的扩展，定义滚动。步长应在属性中定义（如果有）。
+    Scroll(Direction),
+    /// 用户提交字段
+    Submit,
+    /// 用户"删除"了某些内容
+    Delete,
+    /// 用户切换了某些内容
+    Toggle,
+    /// 用户更改了某些内容
+    Change,
+    /// 用户定义的时间量已过，组件应更新
+    Tick,
+    /// 用户定义的命令类型。您不会在 stdlib 中找到这些类型的命令，但可以在自己的组件中使用它们。
+    Custom(&'static str),
+    /// `None` 不会做任何事情
+    None,
+}
+```
+
+在某些方面，它们看起来相似，但有些东西立即变得清晰：
+
+- Event 严格绑定到"硬件"，它接收键事件、终端事件或其他源的事件。
+- Cmd 完全独立于硬件和终端，它完全是关于 UI 逻辑的。我们仍然有 `KeyEvent`，但我们也有 `Type`、`Move`、`Submit`、自定义事件（但没有泛型）等等。
+
+---
+
+## 应用、模型和视图
+
+现在我们已经了解了组件是什么，让我们看看如何将它们组合在一起以创建我们的应用。
+正如我们在核心概念中看到的，应用由三个主要部分组成：
+
+- **模型**：代表应用状态的结构。
+- **视图**：存储所有组件并管理焦点的地方。
+- **应用**：包装视图、订阅和事件监听器的实体。
+
+让我们详细看看每一个。
+
+### 视图 (View)
+
+视图是存储所有组件的地方。视图基本上有三个任务：
+
+- **管理组件的挂载/卸载**：组件在创建时挂载到视图中。视图防止挂载重复的组件，并在您尝试操作不存在的组件时发出警告。
+- **管理焦点**：视图保证一次只有一个组件处于活动状态。活动组件启用了一个专用属性（我们将在后面看到），所有事件都将转发给它。视图跟踪所有先前活动的组件，因此如果当前活动组件失去焦点，如果没有其他组件要激活，则先前活动的组件将变为活动状态。
+- **提供操作组件的 API**：一旦组件挂载到视图中，它们必须以安全的方式对外部可访问。这得益于视图公开的桥接方法。由于每个组件必须唯一标识才能被访问，您需要为组件定义一些 ID。
+
+#### 焦点
+
+焦点是视图的一个重要方面。视图保证一次只有一个组件处于活动状态。活动组件是启用了一个称为 `Attribute::Focus` 的专用属性的组件。此属性用于以不同方式渲染活动组件（例如，更改边框颜色）。
+
+视图还跟踪所有先前活动的组件，因此如果当前活动组件失去焦点，如果没有其他组件要激活，则先前活动的组件将变为活动状态。
+
+### 模型 (Model)
+
+模型是您为应用定义的结构，用于实现**更新例程**。模型代表应用状态，并且通常包含应用需要跟踪的所有数据。
+
+模型必须实现 `Update` trait，该 trait 要求实现 `update()` 方法。此方法以可变引用形式接收模型、可变引用形式的视图和传入的消息。基于消息的值，它会在模型或视图上引起特定行为。
+
+### 应用
+
+应用是围绕*视图*、*订阅*和*事件监听器*的超级包装器。它公开了到视图的桥接、一些*订阅*的简写；但它的主要功能是 `tick()`。
+
+`tick()` 方法是所有框架魔法发生的地方。它执行以下操作：
+
+1. 从事件监听器获取传入事件
+2. 将事件转发给订阅的组件
+3. 调用组件的 `on()` 方法，该方法产生消息
+4. 调用模型的 `update()` 方法，传入消息
+5. 重复直到应用退出
+
+---
+
+## 生命周期（或 "tick"）
+
+tui-realm 应用的生命周期基于称为 "tick" 的概念。tick 是应用处理传入事件、更新模型和重新渲染视图的周期。
+
+生命周期如下：
+
+1. **事件**：事件由事件监听器从 ports 读取。事件随后被转发给订阅的组件。
+2. **消息**：组件消费事件并产生消息。消息随后传递给模型的更新例程。
+3. **更新**：模型的更新例程消费消息并更新模型状态或视图。
+4. **视图**：视图根据当前模型状态和组件状态重新渲染。
+5. **重复**：循环重复，直到应用退出。
+
+---
+
+## 我们的第一个应用
+
+现在我们已经了解了 tui-realm 的核心概念，让我们创建我们的第一个应用。我们将创建一个简单的计数器应用，其中有两个计数器：一个可以通过按 `+` 和 `-` 递增和递减，另一个可以通过按 `w` 和 `s` 递增和递减。
+
+### 实现计数器
+
+首先，让我们定义我们的消息类型。消息类型是枚举，将代表我们的应用可以处理的所有可能消息。
+
+### 定义消息类型
+
+```rust
+#[derive(PartialEq)]
+pub enum Msg {
+    AppClose,
+    CounterIncrement(usize),
+    CounterDecrement(usize),
+}
+```
+
+这里我们定义了三种消息：
+
+- `AppClose`：关闭应用
+- `CounterIncrement(usize)`：递增指定 ID 的计数器
+- `CounterDecrement(usize)`：递减指定 ID 的计数器
+
+### 定义组件标识符
+
+接下来，我们需要为我们的计数器定义标识符。由于每个组件必须唯一标识，我们将为每个计数器定义一个 ID。
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Id {
+    Counter1,
+    Counter2,
+}
+```
+
+### 实现两个计数器组件
+
+现在我们将实现两个计数器组件。每个计数器组件将包装一个 `Input` 原型组件，但基于传入事件，它将产生不同的消息。
+
+```rust
+pub struct Counter {
+    component: Input,
+    id: Id,
+}
+
+impl Counter {
+    pub fn new(id: Id) -> Self {
+        let mut component = Input::default()
+            .foreground(Color::Yellow)
+            .background(Color::Black)
+            .placeholder("0");
+        
+        component.attr(Attribute::Title, AttrValue::Title("Counter".into()));
+        
+        Self { component, id }
+    }
+}
+
+impl Component<Msg, NoUserEvent> for Counter {
+    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+        match ev {
+            Event::Keyboard(KeyEvent { code: KeyCode::Char('+'), .. }) => {
+                Some(Msg::CounterIncrement(self.id as usize))
+            }
+            Event::Keyboard(KeyEvent { code: KeyCode::Char('-'), .. }) => {
+                Some(Msg::CounterDecrement(self.id as usize))
+            }
+            Event::Keyboard(KeyEvent { code: KeyCode::Char('w'), .. }) if self.id == Id::Counter2 => {
+                Some(Msg::CounterIncrement(self.id as usize))
+            }
+            Event::Keyboard(KeyEvent { code: KeyCode::Char('s'), .. }) if self.id == Id::Counter2 => {
+                Some(Msg::CounterDecrement(self.id as usize))
+            }
+            Event::Keyboard(KeyEvent { code: KeyCode::Esc, .. }) => {
+                Some(Msg::AppClose)
+            }
+            _ => None,
+        }
+    }
+}
+
+impl MockComponent for Counter {
+    fn view(&mut self, frame: &mut Frame, area: Rect) {
+        self.component.view(frame, area);
+    }
+    
+    fn query(&self, attr: Attribute) -> Option<AttrValue> {
+        self.component.query(attr)
+    }
+    
+    fn attr(&mut self, attr: Attribute, value: AttrValue) {
+        self.component.attr(attr, value);
+    }
+    
+    fn state(&self) -> State {
+        self.component.state()
+    }
+    
+    fn perform(&mut self, cmd: Cmd) -> CmdResult {
+        self.component.perform(cmd)
+    }
+}
+```
+
+### 实现模型
+
+现在我们将实现我们的模型。模型将包含两个计数器的当前值。
+
+```rust
+pub struct Model {
+    counter1: i32,
+    counter2: i32,
+}
+
+impl Default for Model {
+    fn default() -> Self {
+        Self {
+            counter1: 0,
+            counter2: 0,
+        }
+    }
+}
+
+impl Update<Msg, NoUserEvent, ()> for Model {
+    fn update(&mut self, msg: Option<Msg>, view: &mut View<Msg, NoUserEvent, ()>) -> Option<Msg> {
+        match msg {
+            Some(Msg::AppClose) => {
+                // 退出应用
+                std::process::exit(0);
+            }
+            Some(Msg::CounterIncrement(id)) => {
+                if id == Id::Counter1 as usize {
+                    self.counter1 += 1;
+                    if let Some(mut counter) = view.data::<Counter>(Id::Counter1) {
+                        counter.attr(Attribute::Value, AttrValue::String(self.counter1.to_string()));
+                    }
+                } else if id == Id::Counter2 as usize {
+                    self.counter2 += 1;
+                    if let Some(mut counter) = view.data::<Counter>(Id::Counter2) {
+                        counter.attr(Attribute::Value, AttrValue::String(self.counter2.to_string()));
+                    }
+                }
+            }
+            Some(Msg::CounterDecrement(id)) => {
+                if id == Id::Counter1 as usize {
+                    self.counter1 -= 1;
+                    if let Some(mut counter) = view.data::<Counter>(Id::Counter1) {
+                        counter.attr(Attribute::Value, AttrValue::String(self.counter1.to_string()));
+                    }
+                } else if id == Id::Counter2 as usize {
+                    self.counter2 -= 1;
+                    if let Some(mut counter) = view.data::<Counter>(Id::Counter2) {
+                        counter.attr(Attribute::Value, AttrValue::String(self.counter2.to_string()));
+                    }
+                }
+            }
+            _ => {}
+        }
+        None
+    }
+}
+```
+
+### 应用设置和主循环
+
+最后，我们将设置我们的应用并运行主循环。
+
+```rust
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 初始化终端
+    let mut terminal = Terminal::new(CrosstermBackend::new(std::io::stdout()))?;
+    
+    // 创建模型和视图
+    let model = Model::default();
+    let mut view = View::new();
+    
+    // 创建计数器组件并挂载到视图
+    let counter1 = Counter::new(Id::Counter1);
+    let counter2 = Counter::new(Id::Counter2);
+    
+    view.mount(Id::Counter1, Box::new(counter1), None);
+    view.mount(Id::Counter2, Box::new(counter2), None);
+    
+    // 创建应用
+    let mut app = Application::new(model, view);
+    
+    // 运行主循环
+    loop {
+        terminal.draw(|f| {
+            app.view().render(f, f.size());
+        })?;
+        
+        if let Event::Keyboard(KeyEvent { code: KeyCode::Char('q'), .. }) = event::read()? {
+            break;
+        }
+        
+        app.tick()?;
+    }
+    
+    Ok(())
+}
+```
+
+---
+
+## 下一步
+
+恭喜！您已经创建了您的第一个 tui-realm 应用。您现在可以：
+
+- 探索[高级概念](advanced.md)以了解订阅、ports 和其他高级功能
+- 查看[从 tui-realm 0.x 迁移](migrating-legacy.md)指南，如果您有旧版应用
+- 开始构建您自己的应用！
+
+记住，tui-realm 旨在易于学习和使用，所以不要害怕尝试新事物。快乐编码！ 🚀

--- a/docs/zh-cn/migrating-legacy.md
+++ b/docs/zh-cn/migrating-legacy.md
@@ -1,0 +1,316 @@
+📍<u>**简体中文**</u> | <a href="../en/migrating-legacy.md">English</a>
+
+# 从 tui-realm 0.x 迁移
+
+- [从 tui-realm 0.x 迁移](#从-tui-realm-0x-迁移)
+  - [简介](#简介)
+  - [为什么选择 tui-realm 1.x 🤔](#为什么选择-tui-realm-1x-)
+    - [旧 API 的问题](#旧-api-的问题)
+  - [变化内容](#变化内容)
+  - [如何迁移到 tui-realm 1.x](#如何迁移到-tui-realm-1x)
+
+---
+
+## 简介
+
+本指南将逐步解释如何将 tui-realm 0.x 应用程序迁移到 1.x 版本。
+
+您将学习到：
+
+- 为什么应该迁移到 tui-realm 1.x
+- 什么是新的，什么已被弃用
+- 如何实际逐步迁移应用
+
+## 为什么选择 tui-realm 1.x 🤔
+
+可以说 tui-realm 1.x 一直是我的计划，自从 tui-realm 0.x 发布以来。
+我一直梦想为我的项目"termscp"创建一个事件驱动的框架，但问题基本上有两个：
+
+- 我真的没有清晰的想法如何实现这样的东西
+- 我真的不想在一个可能失败的框架上工作
+- tui-realm 一开始并不存在。它的第一个版本嵌入在 termscp 中，所以我甚至不想让它成为一个公共 crate
+
+但自那时以来，很多事情发生了变化：
+
+- 我对 Rust 变得更加自信，并且非常了解如何使用高级概念
+- 我的新工作让我进步了很多，现在我在编程和设计库方面更加出色
+- 我看到 tui-realm 实际上有效，不仅对我有效
+
+所以一切似乎都在说"你应该为 tui-realm 实现新的 api"，但这真的有必要吗？
+
+### 旧 API 的问题
+
+我希望我不是唯一一个这样想的人，但 tui-realm 的旧 API 真的很糟糕，特别是：
+
+- 缺乏事件抽象：组件直接处理键盘事件，这很糟糕。特别是对于 stdlib。如果用户想使用"WASD"而不是"箭头键"来移动，他必须重新实现整个组件才能有这种行为。这真的很糟糕。我本可以为组件实现 `keymap`。是的，但这只是另一个补丁。
+- 属性系统是个好主意，但在实现中很糟糕。它在可以存储的内容方面太有限了，我在每个版本中都更改了它，因为它**太有限了**。一开始有一些用于文本、对齐、样式等的静态属性。然后有一个 HashMap，最后是 `own` 属性，它是字符串和 `PropPayload` 的映射。你知道什么吗？它也很糟糕。我从未理解为什么我从未想过像 tui-realm 1.x 的新属性系统这样简单的东西。我几乎忘记了最糟糕的部分：属性构建器。实现起来真的很无聊，使用起来更糟糕。
+- Crossterm 0.20：当 crossterm 0.20 发布时，我真的疯了。他们从 `KeyEvent` 中移除了 `Eq`，这导致每个人都在更新例程中实现**可怕的**匹配案例。这可能是促使我实现 tui-realm 1.x 的最强点之一。
+- `Msg` 并非真正的消息：消息机制本身不错...  (当然，因为我从 Elm lang 搬运的！！！)，但实现过于静态，不是用户定义的，总体上无用。你最终只会得到巨大的更新函数来匹配它们。
+- 不支持其他后端：我甚至需要解释这一点吗？只支持 crossterm。我仍然认为 crossterm 很好，因为它可以在每个平台上运行。但但是，如果您不需要 Windows 支持，termion 要好得多。人们有品味。如果用户不喜欢 crossterm，该用户将不会使用 tui-realm。
+- 初始化配置过于繁琐：配置一个 realm 应用花费的时间太长了。
+
+---
+
+## 变化内容
+
+如果您阅读了之前的指南，您已经看到了新 api 的实体是什么，但不要惊慌，即使看起来不像，许多东西仍然有相同的用途，只是更花哨：
+
+- Props 仍然存在，但不是保存随机属性，而是现在保存 `Attribute` 和 `AttrValue` 的映射。这真的很像 CSS，我们都讨厌它，但我们都知道它工作得很好。
+- PropsBuilder 已被 原型组件 的构造函数取代
+- Msg 不再在 tui-realm 中定义，您为您自己的应用定义您自己的消息。不再有无用的消息在应用中传播。只有您实际需要的消息。
+- Event 和 KeyEvent 现在终于支持 Eq，因为我在 tui-realm 中包装了 crossterm 结构。
+- Crossterm 不再是强制性的，您终于可以使用 termion 和任何您喜欢的东西（实际上只实现了 termion，但您可以实现 tui 支持的其他后端。但是真的，还有人在使用 rustbox 吗？）
+- View 已被应用部分取代。我的意思是，仍然有一个视图，但您在程序中持有一个应用来处理视图。
+- **更新 trait** 现在是强制性的 (:feelsgood) 以便在应用上调用 `tick()` 方法。
+- Component 已被 MockComponent 取代（并且方法名称已更改）。
+- 您需要为 UI 中的所有元素实现一个 Component。
+
+---
+
+## 如何迁移到 tui-realm 1.x
+
+现在是时候看看如何做了。我会很快解释这一点，但不要指望这对您来说很快。
+
+我会对您诚实：迁移应用**不会**快，但会很容易，只是无聊。
+花时间迁移您的应用，在一个全新的分支上工作，真的：花时间。完成迁移可能需要几个小时，但相信我：当您完成时，您会真的感到满意，看到应用看起来有多好。
+
+现在让我们逐步看看如何执行迁移：
+
+1. 更新 Cargo.toml 中的依赖项
+
+    您仍然想使用 crossterm 还是想使用 termion？
+
+    如果您想继续使用 crossterm：
+
+    ```toml
+    tuirealm = "^1.0.0"
+    ```
+
+    如果您想选择 termion：
+
+    ```toml
+    tuirealm = { "version" = "^1.0.0", default-features = false, features = [ "derive", "with-termion" ] }
+    ```
+
+    不用担心将 crossterm 迁移到 termion。没有必要。我们稍后会看到原因。
+
+    哦，不要忘记迁移 stdlib（如果您使用它的话（我知道您使用它 😉））
+
+    ```toml
+    tui-realm-stdlib = "^1.0.0"
+    ```
+
+    或使用您喜欢的后端（必须与 tuirealm 匹配！）
+
+    ```toml
+    tui-realm-stdlib = { "version" = "^1.0.0", default-features = false, features = [ "with-termion" ] }
+    ```
+
+2. 删除所有终端构造函数！让我们使用 TerminalBridge
+
+    在 tui-realm 1.x 中，我实现了 `TerminalBridge` 以与终端有一个抽象层，以便在所有后端上具有相同的 API（我知道，这不应该在 realm 中实现，而应该在 tui-rs 中。但是...）。
+
+    所以首先删除所有进入/离开备用屏幕和切换原始模式的方法，并将上下文中的终端替换为：
+
+    ```rust
+    use tuirealm::terminal::TerminalBridge;
+    
+    Context {
+      // ...
+      terminal: TerminalBridge::new().expect("无法初始化终端"),
+    }
+    ```
+
+    终端桥是您与终端一起工作所需的一切，并在 termion 和 crossterm 或您使用的任何东西上提供相同的方法。
+
+3. 定义一个枚举，包含您使用的所有组件的 id
+
+    可能在 tui-realm 0.x 中，您使用一些常量作为组件的 id。在 tui-realm 1.x 中，我们需要使用一个类型作为组件的标识符，然后必须提供给应用才能工作。
+    您仍然可以使用字符串，但字符串很糟糕，枚举要好得多：
+
+    ```rust
+    #[derive(Debug, Eq, PartialEq, Clone, Hash)]
+    pub enum Id {
+        AddressInput,
+        PasswordInput,
+        ProtocolRadio,
+        GlobalListener,
+    }
+    ```
+
+4. 定义您的应用将处理的消息
+
+    花时间思考您的应用将处理哪种消息。
+    记住：消息是您的**模型**或**视图**需要关注的事件，而不是组件需要接收的内容。
+
+    ```rust
+    #[derive(Debug, PartialEq)]
+    pub enum Msg {
+        AppClose,
+        FormSubmit,
+        ProtocolChanged(FileTransferProtocol),
+        None,
+    }
+    ```
+
+5. 将模型与视图分开
+
+    在您当前的实现中，您可能有一个同时保存模型数据和视图的结构。这不再有效（不会构建）。您需要有一个结构来保存模型结构和应用：
+
+    然后：
+
+    ```rust
+    struct Activity {
+      context: Context,
+      protocol: FileTransferProtocol,
+      address: String,
+      view: View, // 在用户级别被应用替换
+    }
+    ```
+
+    现在：
+
+    ```rust
+    struct Activity {
+      model: Model,
+      application: Application<Id, Msg, NoUserEvent>,
+    }
+
+    struct Model {
+      context: Context,
+      protocol: FileTransferProtocol,
+      address: String,
+    }
+
+    impl Update for Model {
+      // ...（将使用应用传递的视图，这就是为什么模型不能持有视图）
+    }
+    ```
+
+6. 为您要使用的每个组件实现 Component trait
+
+    花时间做这件事，这将需要很长时间。基本上，您需要为应用中的所有组件实现一个 `Component`。
+    组件将始终具有 `component: impl MockComponent` 作为属性，它将使用由您或 stdlib 实现的原型组件。如果您使用 stdlib 组件，请记住使用命令 api 来匹配事件和结果。请记住，您不必为组件实现 `MockComponent`（除非您需要指定替代行为），有一个神奇的 `#[derive(MockComponent)]` 过程宏。
+    在组件的构造函数中，您将指定以前在属性构建器中设置的所有内容：
+
+    然后：
+
+    ```rust
+    InputPropsBuilder::default()
+      .with_foreground(fg)
+      .with_borders(Borders::ALL, BorderType::Rounded, fg)
+      .with_label(label, Alignment::Left)
+      .with_input(typ);
+    ```
+
+    现在：
+
+    ```rust
+    use tui_realm_stdlib::Input;
+
+    #[derive(MockComponent)]
+    pub struct AddressInput {
+        component: Input,
+    }
+
+    impl Default for AddressInput {
+        fn default() -> Self {
+            Self {
+                component: Input::default()
+                    .foreground(Color::LightBlue)
+                    .borders(
+                        Borders::default()
+                            .color(Color::LightBlue)
+                            .modifiers(BorderType::Rounded),
+                    )
+                    .input_type(InputType::Text)
+                    .placeholder(
+                        "192.168.1.10",
+                        Style::default().fg(Color::Rgb(120, 120, 120)),
+                    )
+                    .title("远程地址", Alignment::Left),
+            }
+        }
+    }
+
+    impl Component<Msg, NoUserEvent> for AddressInput {
+        fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+            let result = match ev {
+                Event::Keyboard(KeyEvent {
+                    code: Key::Enter,
+                    modifiers: KeyModifiers::NONE,
+                }) => return Some(Msg::FormSubmit),
+                Event::Keyboard(KeyEvent {
+                    code: Key::Char(ch),
+                    modifiers: KeyModifiers::NONE,
+                }) => self.perform(Cmd::Type(ch)),
+                Event::Keyboard(KeyEvent {
+                    code: Key::Left,
+                    modifiers: KeyModifiers::NONE,
+                }) => self.perform(Cmd::Move(Direction::Left)),
+                Event::Keyboard(KeyEvent {
+                    code: Key::Right,
+                    modifiers: KeyModifiers::NONE,
+                }) => self.perform(Cmd::Move(Direction::Right)),
+                Event::Keyboard(KeyEvent {
+                    code: Key::Home,
+                    modifiers: KeyModifiers::NONE,
+                }) => self.perform(Cmd::GoTo(Position::Begin)),
+                Event::Keyboard(KeyEvent {
+                    code: Key::End,
+                    modifiers: KeyModifiers::NONE,
+                }) => self.perform(Cmd::GoTo(Position::End)),
+                Event::Keyboard(KeyEvent {
+                    code: Key::Delete,
+                    modifiers: KeyModifiers::NONE,
+                }) => self.perform(Cmd::Cancel),
+                Event::Keyboard(KeyEvent {
+                    code: Key::Backspace,
+                    modifiers: KeyModifiers::NONE,
+                }) => self.perform(Cmd::Delete),
+                Event::Keyboard(KeyEvent {
+                    code: Key::Tab,
+                    modifiers: KeyModifiers::NONE,
+                }) => return Some(Msg::AddressInputBlur),
+                _ => return None,
+            };
+            Some(Msg::None)
+        }
+    }
+    ```
+
+7. 为您的模型实现更新例程
+
+    为 `Model` 实现 `Update` trait，匹配所有 `Msg` 并执行您需要执行的操作。
+
+    ```rust
+    impl Update<Id, Msg, NoUserEvent> for Model {
+        fn update(&mut self, view: &mut View<Id, Msg, NoUserEvent>, msg: Option<Msg>) -> Option<Msg> {
+            match msg.unwrap_or(Msg::None) {
+                Msg::AppClose => {
+                    self.quit = true;
+                    None
+                }
+                // ... 
+                Msg::None => None,
+            }
+        }
+    }
+    ```
+
+8. 更新您之前的 `on()` 调用：
+
+    ```rust
+    if let Ok(sz) = app.tick(&mut model, PollStrategy::Once) {
+        if sz > 0 {
+            // 注意：如果至少处理了一个消息，则重绘
+            model.redraw = true;
+        }
+    }
+    // 重绘
+    if model.redraw {
+        // 视图必须由您自己实现！
+        model.view(&mut app);
+        model.redraw = false;
+    }
+    ```


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

Closes #127 

## Description

translate the [documents](https://github.com/veeso/tui-realm/tree/main/docs/en) into Simplified Chinese and add a language switch option at the top of each document,

### Changes

- Add docs/zh-cn directory for Simplified Chinese documents
- Add a language switch bar at the top of each document (both English and Chinese versions)

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## Checklist

- [X] My code follows the contribution guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I formatted the code with `cargo fmt`
- [X] I checked my code using `cargo clippy` and reports no warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have introduced no new *C-bindings*
- [X] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [X] I increased or maintained the code coverage for the project, compared to the previous commit
