### PR TITLE
Change title to be a struct instead of a tuple

### DIFF
--- a/docs/en/migrating-4.0.md
+++ b/docs/en/migrating-4.0.md
@@ -14,3 +14,9 @@ This document is a work in progress until 4.0 is released, listing the essential
 The previous `tuirealm::props::TextSpan` has been replaced with `ratatui::text::{Span, Line, Text}`.
 
 Because of the new types, new `AttrValue` and `PropValue` variants have been introduced: `TextSpan`, `TextLine` and `Text`.
+
+### Replace `(String, Alignment)` Titles with proper struct
+
+The previous `(String, Alignment)` Tuple has been replaced with a more feature-full `Title` struct.
+
+Due to the title now using `Line` under the hood, it is now possible to style individual characters in the title.

--- a/examples/demo/components/counter.rs
+++ b/examples/demo/components/counter.rs
@@ -4,7 +4,7 @@
 
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::event::{Key, KeyEvent, KeyModifiers};
-use tuirealm::props::{Alignment, Borders, Color, Style, TextModifiers};
+use tuirealm::props::{Alignment, Borders, Color, LineStatic, Style, TextModifiers, Title};
 use tuirealm::ratatui::layout::Rect;
 use tuirealm::ratatui::widgets::{BorderType, Paragraph};
 use tuirealm::{
@@ -24,11 +24,11 @@ struct Counter {
 impl Counter {
     pub fn label<S>(mut self, label: S) -> Self
     where
-        S: AsRef<str>,
+        S: Into<LineStatic>,
     {
         self.attr(
             Attribute::Title,
-            AttrValue::Title((label.as_ref().to_string(), Alignment::Center)),
+            AttrValue::Title(Title::from(label).alignment(Alignment::Center)),
         );
         self
     }
@@ -93,7 +93,7 @@ impl MockComponent for Counter {
                 .props
                 .get_or(
                     Attribute::Title,
-                    AttrValue::Title((String::default(), Alignment::Center)),
+                    AttrValue::Title(Title::default().alignment(Alignment::Center)),
                 )
                 .unwrap_title();
             let borders = self

--- a/examples/demo/components/mod.rs
+++ b/examples/demo/components/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! demo example components
 
-use tuirealm::props::{Alignment, Borders, Color, Style};
+use tuirealm::props::{Borders, Color, Style, Title};
 use tuirealm::ratatui::widgets::Block;
 
 use super::Msg;
@@ -20,15 +20,18 @@ pub use label::Label;
 /// ### `get_block`
 ///
 /// Get block
-pub(crate) fn get_block<'a>(props: Borders, title: (String, Alignment), focus: bool) -> Block<'a> {
-    Block::default()
+pub(crate) fn get_block<'a>(props: Borders, title: Title, focus: bool) -> Block<'a> {
+    let block = Block::default()
         .borders(props.sides)
         .border_style(if focus {
             props.style()
         } else {
             Style::default().fg(Color::Reset).bg(Color::Reset)
         })
-        .border_type(props.modifiers)
-        .title(title.0)
-        .title_alignment(title.1)
+        .border_type(props.modifiers);
+
+    match title.position {
+        ratatui::widgets::block::Position::Top => block.title_top(title.content),
+        ratatui::widgets::block::Position::Bottom => block.title_bottom(title.content),
+    }
 }

--- a/src/core/props/mod.rs
+++ b/src/core/props/mod.rs
@@ -23,7 +23,7 @@ pub use direction::Direction;
 pub use input_type::InputType;
 pub use layout::Layout;
 pub use shape::Shape;
-pub use texts::{LineStatic, SpanStatic, Table, TableBuilder, TextStatic};
+pub use texts::{LineStatic, SpanStatic, Table, TableBuilder, TextStatic, Title};
 pub use value::{PropPayload, PropValue};
 
 pub use crate::ratatui::layout::Alignment;
@@ -169,7 +169,7 @@ pub enum AttrValue {
     TextLine(LineStatic),
     Text(TextStatic),
     TextModifiers(TextModifiers),
-    Title((String, Alignment)),
+    Title(Title),
     /// User defined complex attribute value
     Payload(PropPayload),
 }
@@ -329,8 +329,8 @@ impl AttrValue {
         }
     }
 
-    /// Get the inner Title value from AttrValue, or panic.
-    pub fn unwrap_title(self) -> (String, Alignment) {
+    /// Get the inner [`Title`] value from AttrValue, or panic.
+    pub fn unwrap_title(self) -> Title {
         match self {
             AttrValue::Title(x) => x,
             _ => panic!("AttrValue is not Title"),
@@ -508,8 +508,8 @@ impl AttrValue {
         }
     }
 
-    /// Get a Title value from AttrValue, or None
-    pub fn as_title(&self) -> Option<&(String, Alignment)> {
+    /// Get a [`Title`] value from AttrValue, or None
+    pub fn as_title(&self) -> Option<&Title> {
         match self {
             AttrValue::Title(v) => Some(v),
             _ => None,
@@ -678,8 +678,8 @@ impl AttrValue {
         }
     }
 
-    /// Get a Title value from AttrValue, or None
-    pub fn as_title_mut(&mut self) -> Option<&mut (String, Alignment)> {
+    /// Get a [`Title`] value from AttrValue, or None
+    pub fn as_title_mut(&mut self) -> Option<&mut Title> {
         match self {
             AttrValue::Title(v) => Some(v),
             _ => None,
@@ -804,8 +804,9 @@ mod test {
             TextModifiers::BOLD
         );
         assert_eq!(
-            AttrValue::Title((String::from("pippo"), Alignment::Left)).unwrap_title(),
-            (String::from("pippo"), Alignment::Left)
+            AttrValue::Title(Title::from(String::from("pippo")).alignment(Alignment::Left))
+                .unwrap_title(),
+            (Title::from(String::from("pippo")).alignment(Alignment::Left))
         );
         assert_eq!(
             AttrValue::Payload(PropPayload::None).unwrap_payload(),
@@ -917,8 +918,8 @@ mod test {
         );
 
         assert_eq!(
-            AttrValue::Title(("hello".into(), Alignment::Center)).as_title(),
-            Some(&("hello".into(), Alignment::Center))
+            AttrValue::Title(Title::from("hello").alignment(Alignment::Center)).as_title(),
+            Some(&Title::from("hello").alignment(Alignment::Center))
         );
         assert_eq!(AttrValue::Alignment(Alignment::Center).as_title(), None);
 
@@ -1057,8 +1058,8 @@ mod test {
         );
 
         assert_eq!(
-            AttrValue::Title(("hello".into(), Alignment::Center)).as_title_mut(),
-            Some(&mut ("hello".into(), Alignment::Center))
+            AttrValue::Title(Title::from("hello").alignment(Alignment::Right)).as_title_mut(),
+            Some(&mut Title::from("hello").alignment(Alignment::Right))
         );
         assert_eq!(AttrValue::Alignment(Alignment::Center).as_title_mut(), None);
 

--- a/src/core/props/texts.rs
+++ b/src/core/props/texts.rs
@@ -3,9 +3,58 @@
 //! `Texts` is the module which defines the texts properties for components.
 //! It also provides some helpers and builders to facilitate the use of builders.
 
+use crate::ratatui::layout::Alignment;
+use crate::ratatui::widgets::block::Position;
+
 pub type SpanStatic = crate::ratatui::text::Span<'static>;
 pub type LineStatic = crate::ratatui::text::Line<'static>;
 pub type TextStatic = crate::ratatui::text::Text<'static>;
+
+// Note that we cannot use "ratatui::widgets::block::Title" as that is deprecated.
+#[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
+pub struct Title {
+    /// The text and styling content of the title
+    pub content: LineStatic,
+    /// The Position the title should be in.
+    ///
+    /// This will determine if [`Block::title_top`](crate::ratatui::widgets::Block::title_top) or [`Block::title_bottom`](crate::ratatui::widgets::Block::title_bottom) is called.
+    pub position: Position,
+}
+
+impl Title {
+    /// Set a specific [`Alignment`] on the underlying [`Line`].
+    pub fn alignment(mut self, alignment: Alignment) -> Self {
+        self.content.alignment = Some(alignment);
+
+        self
+    }
+
+    /// Set a specific position the title should be in.
+    pub fn position(mut self, position: Position) -> Self {
+        self.position = position;
+
+        self
+    }
+
+    /// Overwrite the content of the title.
+    pub fn content(mut self, line: LineStatic) -> Self {
+        self.content = line;
+
+        self
+    }
+}
+
+impl<T> From<T> for Title
+where
+    T: Into<LineStatic>,
+{
+    fn from(value: T) -> Self {
+        Self {
+            content: value.into(),
+            ..Default::default()
+        }
+    }
+}
 
 /// Table represents a list of rows with a list of columns of text spans
 pub type Table = Vec<Vec<LineStatic>>;
@@ -93,5 +142,53 @@ mod test {
             .add_col(LineStatic::from("Line"))
             .add_col("simple str")
             .add_col(SpanStatic::from("span"));
+    }
+
+    #[test]
+    fn title_from() {
+        assert_eq!(
+            Title::from("simple str").content,
+            LineStatic::from("simple str")
+        );
+        assert_eq!(
+            Title::from(String::from("owned string")).content,
+            LineStatic::from(String::from("owned string"))
+        );
+        assert_eq!(
+            Title::from(LineStatic::from("Line")).content,
+            LineStatic::from("Line")
+        );
+    }
+
+    #[test]
+    fn title_builder() {
+        assert_eq!(Title::from("test").position, Position::Top);
+        assert_eq!(
+            Title::from("test").position(Position::Bottom).position,
+            Position::Bottom
+        );
+
+        assert_eq!(Title::from("test").content.alignment, None);
+        assert_eq!(
+            Title::from("test")
+                .alignment(Alignment::Left)
+                .content
+                .alignment,
+            Some(Alignment::Left)
+        );
+        assert_eq!(
+            Title::from("test")
+                .alignment(Alignment::Right)
+                .content
+                .alignment,
+            Some(Alignment::Right)
+        );
+        assert_eq!(
+            Title::from("test")
+                .alignment(Alignment::Center)
+                .content
+                .alignment,
+            Some(Alignment::Center)
+        );
     }
 }


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

Fixes https://github.com/veeso/tui-realm-stdlib/issues/45

## Description

This PR changes the previous title tuple `(String, Alignment)` to be a struct that encapsulated a `ratatui::text::Line`, similar to [`ratatui::widgets::block::Title`](https://docs.rs/ratatui/0.29.0/ratatui/widgets/block/title/struct.Title.html), but it couldnt be used directly as it is deprecated in ratatui itself.

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

---

This *might* conflict with #131
