### PR TITLE
Change `Component::on` parameter `Event` to be a reference

### DIFF
--- a/docs/en/migrating-4.0.md
+++ b/docs/en/migrating-4.0.md
@@ -26,3 +26,8 @@ Due to the title now using `Line` under the hood, it is now possible to style in
 The tuple variants of `PropPayload` have been removed as they were blowing up the size of `PropPayload` in general.
 
 If multiple types are still necessary, consider either using `PropPayload::Vec` or for more descriptive fields use a custom struct in `PropPayload::Any`.
+
+### `Component::on` parameter `Event` is now a reference
+
+With 4.0, `Component::on`'s `Event` parameter is now a reference. This allowed us to remove clones in-between that had always been done
+but now it is up to the user if a clone is actually necessary.

--- a/examples/arbitrary_data.rs
+++ b/examples/arbitrary_data.rs
@@ -260,7 +260,7 @@ struct OurLabel {
 }
 
 impl Component<Msg, NoUserEvent> for OurLabel {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         // Does nothing
         match ev {
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => Some(Msg::AppClose),

--- a/examples/async_ports.rs
+++ b/examples/async_ports.rs
@@ -265,7 +265,7 @@ impl MockComponent for Label {
 }
 
 impl Component<Msg, UserEvent> for Label {
-    fn on(&mut self, ev: Event<UserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<UserEvent>) -> Option<Msg> {
         // Does nothing
         match ev {
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => Some(Msg::AppClose),

--- a/examples/demo/components/clock.rs
+++ b/examples/demo/components/clock.rs
@@ -93,7 +93,7 @@ impl MockComponent for Clock {
 }
 
 impl Component<Msg, NoUserEvent> for Clock {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         if let Event::Tick = ev {
             self.states.tick();
             // Set text

--- a/examples/demo/components/counter.rs
+++ b/examples/demo/components/counter.rs
@@ -180,7 +180,7 @@ impl LetterCounter {
 }
 
 impl Component<Msg, NoUserEvent> for LetterCounter {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         // Get command
         let cmd = match ev {
             Event::Keyboard(KeyEvent {
@@ -232,7 +232,7 @@ impl DigitCounter {
 }
 
 impl Component<Msg, NoUserEvent> for DigitCounter {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         // Get command
         let cmd = match ev {
             Event::Keyboard(KeyEvent {

--- a/examples/demo/components/label.rs
+++ b/examples/demo/components/label.rs
@@ -110,7 +110,7 @@ impl MockComponent for Label {
 }
 
 impl Component<Msg, NoUserEvent> for Label {
-    fn on(&mut self, _: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, _: &Event<NoUserEvent>) -> Option<Msg> {
         // Does nothing
         None
     }

--- a/examples/user_events/components/label.rs
+++ b/examples/user_events/components/label.rs
@@ -81,7 +81,7 @@ impl MockComponent for Label {
 }
 
 impl Component<Msg, UserEvent> for Label {
-    fn on(&mut self, ev: Event<UserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<UserEvent>) -> Option<Msg> {
         // Does nothing
         match ev {
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => Some(Msg::AppClose),

--- a/src/core/application.rs
+++ b/src/core/application.rs
@@ -97,7 +97,7 @@ where
         // Forward to active element
         let mut messages: Vec<Msg> = events
             .iter()
-            .filter_map(|x| self.forward_to_active_component(x.clone()))
+            .filter_map(|x| self.forward_to_active_component(x))
             .collect();
         // Forward to subscriptions and extend vector
         if !self.sub_lock {
@@ -408,7 +408,7 @@ where
     }
 
     /// Forward event to current active component, if any.
-    fn forward_to_active_component(&mut self, ev: Event<UserEvent>) -> Option<Msg> {
+    fn forward_to_active_component(&mut self, ev: &Event<UserEvent>) -> Option<Msg> {
         self.view
             .focus()
             .cloned()
@@ -432,7 +432,7 @@ where
                 ) {
                     continue;
                 }
-                if let Some(msg) = self.view.forward(sub.target(), ev.clone()).ok().unwrap() {
+                if let Some(msg) = self.view.forward(sub.target(), ev).ok().unwrap() {
                     messages.push(msg);
                 }
             }

--- a/src/core/component.rs
+++ b/src/core/component.rs
@@ -60,5 +60,5 @@ where
     /// Handle input event and update internal states.
     /// Returns a Msg to the view.
     /// If [`None`] is returned it means there's no message to return for the provided event.
-    fn on(&mut self, ev: Event<UserEvent>) -> Option<Msg>;
+    fn on(&mut self, ev: &Event<UserEvent>) -> Option<Msg>;
 }

--- a/src/core/view.rs
+++ b/src/core/view.rs
@@ -151,7 +151,7 @@ where
     pub(crate) fn forward(
         &mut self,
         id: &ComponentId,
-        event: Event<UserEvent>,
+        event: &Event<UserEvent>,
     ) -> ViewResult<Option<Msg>> {
         match self.components.get_mut(id) {
             None => Err(ViewError::ComponentNotFound),
@@ -678,7 +678,7 @@ mod test {
         );
         let ev: Event<MockEvent> = Event::Keyboard(KeyEvent::from(Key::Char('a')));
         assert_eq!(
-            view.forward(&MockComponentId::InputFoo, ev)
+            view.forward(&MockComponentId::InputFoo, &ev)
                 .ok()
                 .unwrap()
                 .unwrap(),
@@ -686,7 +686,7 @@ mod test {
         );
         // To non-existing component
         assert!(
-            view.forward(&MockComponentId::InputBar, Event::Tick)
+            view.forward(&MockComponentId::InputBar, &Event::Tick)
                 .is_err()
         );
     }

--- a/src/mock/components.rs
+++ b/src/mock/components.rs
@@ -98,7 +98,7 @@ pub struct MockFooInput {
 }
 
 impl Component<MockMsg, MockEvent> for MockFooInput {
-    fn on(&mut self, ev: Event<MockEvent>) -> Option<MockMsg> {
+    fn on(&mut self, ev: &Event<MockEvent>) -> Option<MockMsg> {
         let cmd = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Left,
@@ -111,7 +111,7 @@ impl Component<MockMsg, MockEvent> for MockFooInput {
             Event::Keyboard(KeyEvent {
                 code: Key::Char(ch),
                 modifiers: KeyModifiers::NONE,
-            }) => Cmd::Type(ch),
+            }) => Cmd::Type(*ch),
             Event::Keyboard(KeyEvent {
                 code: Key::Enter,
                 modifiers: KeyModifiers::NONE,
@@ -133,7 +133,7 @@ pub struct MockBarInput {
 }
 
 impl Component<MockMsg, MockEvent> for MockBarInput {
-    fn on(&mut self, ev: Event<MockEvent>) -> Option<MockMsg> {
+    fn on(&mut self, ev: &Event<MockEvent>) -> Option<MockMsg> {
         let cmd = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Left,
@@ -146,7 +146,7 @@ impl Component<MockMsg, MockEvent> for MockBarInput {
             Event::Keyboard(KeyEvent {
                 code: Key::Char(ch),
                 modifiers: KeyModifiers::NONE,
-            }) => Cmd::Type(ch),
+            }) => Cmd::Type(*ch),
             Event::Keyboard(KeyEvent {
                 code: Key::Enter,
                 modifiers: KeyModifiers::NONE,


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

No issue

## Description

In previous versions i had already removed a bunch of clones from this codebase, but there were still some left that had to basically always run.

I know this is quite the intrusive change, but i think that we shouldnt need to always clone those events and instead make it up to the user to decide if a reference is enough, or if owned data is necessary.
If there is a better alternative, i am all ears.

I had already considered to change the event passing to require the component to consume a message, otherwise return it. But this would for example be annoying for something like `Tick` which many components *might* need, not just the first consumer.

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
