### PR TITLE
Reduce `PropPayload` Size by removing all `Tup` fields

### DIFF
--- a/docs/en/migrating-4.0.md
+++ b/docs/en/migrating-4.0.md
@@ -20,3 +20,9 @@ Because of the new types, new `AttrValue` and `PropValue` variants have been int
 The previous `(String, Alignment)` Tuple has been replaced with a more feature-full `Title` struct.
 
 Due to the title now using `Line` under the hood, it is now possible to style individual characters in the title.
+
+### Removal of `PropPayload::Tup*` variants
+
+The tuple variants of `PropPayload` have been removed as they were blowing up the size of `PropPayload` in general.
+
+If multiple types are still necessary, consider either using `PropPayload::Vec` or for more descriptive fields use a custom struct in `PropPayload::Any`.

--- a/src/core/props/value.rs
+++ b/src/core/props/value.rs
@@ -16,9 +16,6 @@ use crate::props::AnyPropBox;
 #[derive(Debug, PartialEq, Clone)]
 pub enum PropPayload {
     One(PropValue),
-    Tup2((PropValue, PropValue)),
-    Tup3((PropValue, PropValue, PropValue)),
-    Tup4((PropValue, PropValue, PropValue, PropValue)),
     Vec(Vec<PropValue>),
     Map(HashMap<String, PropValue>),
     Linked(LinkedList<PropPayload>),
@@ -69,30 +66,6 @@ impl PropPayload {
         }
     }
 
-    /// Unwrap a Tup2 value from PropPayload
-    pub fn unwrap_tup2(self) -> (PropValue, PropValue) {
-        match self {
-            PropPayload::Tup2(t) => t,
-            _ => panic!("Called `unwrap_tup2` on a bad value"),
-        }
-    }
-
-    /// Unwrap a Tup3 value from PropPayload
-    pub fn unwrap_tup3(self) -> (PropValue, PropValue, PropValue) {
-        match self {
-            PropPayload::Tup3(t) => t,
-            _ => panic!("Called `unwrap_tup3` on a bad value"),
-        }
-    }
-
-    /// Unwrap a Tup4 value from PropPayload
-    pub fn unwrap_tup4(self) -> (PropValue, PropValue, PropValue, PropValue) {
-        match self {
-            PropPayload::Tup4(t) => t,
-            _ => panic!("Called `unwrap_tup4` on a bad value"),
-        }
-    }
-
     /// Unwrap a Vec value from PropPayload
     pub fn unwrap_vec(self) -> Vec<PropValue> {
         match self {
@@ -135,30 +108,6 @@ impl PropPayload {
         }
     }
 
-    /// Get a Tup2 value from PropPayload, or None
-    pub fn as_tup2(&self) -> Option<&(PropValue, PropValue)> {
-        match self {
-            PropPayload::Tup2(v) => Some(v),
-            _ => None,
-        }
-    }
-
-    /// Get a Tup3 value from PropPayload, or None
-    pub fn as_tup3(&self) -> Option<&(PropValue, PropValue, PropValue)> {
-        match self {
-            PropPayload::Tup3(v) => Some(v),
-            _ => None,
-        }
-    }
-
-    /// Get a Tup4 value from PropPayload, or None
-    pub fn as_tup4(&self) -> Option<&(PropValue, PropValue, PropValue, PropValue)> {
-        match self {
-            PropPayload::Tup4(v) => Some(v),
-            _ => None,
-        }
-    }
-
     /// Get a Vec value from PropPayload, or None
     pub fn as_vec(&self) -> Option<&Vec<PropValue>> {
         match self {
@@ -197,30 +146,6 @@ impl PropPayload {
     pub fn as_one_mut(&mut self) -> Option<&mut PropValue> {
         match self {
             PropPayload::One(v) => Some(v),
-            _ => None,
-        }
-    }
-
-    /// Get a Tup2 value from PropPayload, or None
-    pub fn as_tup2_mut(&mut self) -> Option<&mut (PropValue, PropValue)> {
-        match self {
-            PropPayload::Tup2(v) => Some(v),
-            _ => None,
-        }
-    }
-
-    /// Get a Tup3 value from PropPayload, or None
-    pub fn as_tup3_mut(&mut self) -> Option<&mut (PropValue, PropValue, PropValue)> {
-        match self {
-            PropPayload::Tup3(v) => Some(v),
-            _ => None,
-        }
-    }
-
-    /// Get a Tup4 value from PropPayload, or None
-    pub fn as_tup4_mut(&mut self) -> Option<&mut (PropValue, PropValue, PropValue, PropValue)> {
-        match self {
-            PropPayload::Tup4(v) => Some(v),
             _ => None,
         }
     }
@@ -896,18 +821,6 @@ mod tests {
     fn prop_values() {
         // test that values can be created without compile errors
         let _ = PropPayload::One(PropValue::Usize(2));
-        let _ = PropPayload::Tup2((PropValue::Bool(true), PropValue::Usize(128)));
-        let _ = PropPayload::Tup3((
-            PropValue::Bool(true),
-            PropValue::Usize(128),
-            PropValue::Str(String::from("omar")),
-        ));
-        let _ = PropPayload::Tup4((
-            PropValue::Bool(true),
-            PropValue::U8(128),
-            PropValue::Str(String::from("pippo")),
-            PropValue::Isize(-2),
-        ));
         let _ = PropPayload::Vec(vec![
             PropValue::U16(1),
             PropValue::U32(2),
@@ -989,10 +902,6 @@ mod tests {
         let _ = PropPayload::Map(map);
         let mut link: LinkedList<PropPayload> = LinkedList::new();
         link.push_back(PropPayload::One(PropValue::Usize(1)));
-        link.push_back(PropPayload::Tup2((
-            PropValue::Usize(2),
-            PropValue::Usize(4),
-        )));
         let _ = PropPayload::Linked(link);
     }
 
@@ -1260,38 +1169,6 @@ mod tests {
                 .unwrap_bool(),
         );
         assert_eq!(
-            PropPayload::Tup2((PropValue::Bool(false), PropValue::Bool(false))).unwrap_tup2(),
-            (PropValue::Bool(false), PropValue::Bool(false))
-        );
-        assert_eq!(
-            PropPayload::Tup3((
-                PropValue::Bool(false),
-                PropValue::Bool(false),
-                PropValue::Bool(false)
-            ))
-            .unwrap_tup3(),
-            (
-                PropValue::Bool(false),
-                PropValue::Bool(false),
-                PropValue::Bool(false)
-            )
-        );
-        assert_eq!(
-            PropPayload::Tup4((
-                PropValue::Bool(false),
-                PropValue::Bool(false),
-                PropValue::Bool(false),
-                PropValue::Bool(false)
-            ))
-            .unwrap_tup4(),
-            (
-                PropValue::Bool(false),
-                PropValue::Bool(false),
-                PropValue::Bool(false),
-                PropValue::Bool(false)
-            )
-        );
-        assert_eq!(
             PropPayload::Vec(vec![PropValue::Bool(false), PropValue::Bool(false)]).unwrap_vec(),
             &[PropValue::Bool(false), PropValue::Bool(false)]
         );
@@ -1304,44 +1181,6 @@ mod tests {
             Some(&PropValue::Bool(true))
         );
         assert_eq!(PropPayload::None.as_one(), None);
-
-        assert_eq!(
-            PropPayload::Tup2((PropValue::Bool(true), PropValue::Bool(true))).as_tup2(),
-            Some(&(PropValue::Bool(true), PropValue::Bool(true)))
-        );
-        assert_eq!(PropPayload::None.as_tup2(), None);
-
-        assert_eq!(
-            PropPayload::Tup3((
-                PropValue::Bool(true),
-                PropValue::Bool(true),
-                PropValue::Bool(true)
-            ))
-            .as_tup3(),
-            Some(&(
-                PropValue::Bool(true),
-                PropValue::Bool(true),
-                PropValue::Bool(true)
-            ))
-        );
-        assert_eq!(PropPayload::None.as_tup3(), None);
-
-        assert_eq!(
-            PropPayload::Tup4((
-                PropValue::Bool(true),
-                PropValue::Bool(true),
-                PropValue::Bool(true),
-                PropValue::Bool(true)
-            ))
-            .as_tup4(),
-            Some(&(
-                PropValue::Bool(true),
-                PropValue::Bool(true),
-                PropValue::Bool(true),
-                PropValue::Bool(true)
-            ))
-        );
-        assert_eq!(PropPayload::None.as_tup4(), None);
 
         assert_eq!(
             PropPayload::Vec(vec![PropValue::Bool(true)]).as_vec(),
@@ -1376,44 +1215,6 @@ mod tests {
             Some(&mut PropValue::Bool(true))
         );
         assert_eq!(PropPayload::None.as_one_mut(), None);
-
-        assert_eq!(
-            PropPayload::Tup2((PropValue::Bool(true), PropValue::Bool(true))).as_tup2_mut(),
-            Some(&mut (PropValue::Bool(true), PropValue::Bool(true)))
-        );
-        assert_eq!(PropPayload::None.as_tup2_mut(), None);
-
-        assert_eq!(
-            PropPayload::Tup3((
-                PropValue::Bool(true),
-                PropValue::Bool(true),
-                PropValue::Bool(true)
-            ))
-            .as_tup3_mut(),
-            Some(&mut (
-                PropValue::Bool(true),
-                PropValue::Bool(true),
-                PropValue::Bool(true)
-            ))
-        );
-        assert_eq!(PropPayload::None.as_tup3_mut(), None);
-
-        assert_eq!(
-            PropPayload::Tup4((
-                PropValue::Bool(true),
-                PropValue::Bool(true),
-                PropValue::Bool(true),
-                PropValue::Bool(true)
-            ))
-            .as_tup4_mut(),
-            Some(&mut (
-                PropValue::Bool(true),
-                PropValue::Bool(true),
-                PropValue::Bool(true),
-                PropValue::Bool(true)
-            ))
-        );
-        assert_eq!(PropPayload::None.as_tup4_mut(), None);
 
         assert_eq!(
             PropPayload::Vec(vec![PropValue::Bool(true)]).as_vec_mut(),


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

No Issue

## Description

Remove the `PropPayload::Tup*` variants as they were blowing the enum's size up to 256. With the removal the size is now just 64. (Reduces `AttrValue` size from 256 to 80)
Remember that the full size has to be paid for *each* variant.

The only project i found that made use of at least *one* tuple variant is [`tuifeed`](https://github.com/veeso/tuifeed/blob/869090c29707049af19721a4b712dcbee86bbf03/src/ui/view.rs#L211), practically no-one else made use of them, and arguably that case could be better described with a custom struct and `PropPayload::Any`.

Now the biggest Variant is `PropValue` is `DataSet`, which arguably should also be a `Any` struct.

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
