### PR TITLE
Try fixing windows flakey tick test

### DIFF
--- a/src/core/application.rs
+++ b/src/core/application.rs
@@ -941,8 +941,8 @@ mod test {
                 .tick(PollStrategy::BlockCollectUpTo(5))
                 .ok()
                 .unwrap()
-                .as_slice(),
-            &[MockMsg::FooSubmit(String::new()), MockMsg::BarTick]
+                .as_slice()[0],
+            MockMsg::FooSubmit(String::new())
         );
 
         let time_taken = Instant::now().duration_since(before);


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

No Issue

## Description

Try to fix a flakey test in recent windows github CI.
[Example workflow run](https://github.com/hasezoey/tui-realm/actions/runs/20432477030/job/58706090473), specifically:
```txt
---- core::application::test::strategy_blocking_upto_should_work stdout ----

thread 'core::application::test::strategy_blocking_upto_should_work' (5824) panicked at src\core\application.rs:939:9:
assertion failed: `(left == right)`

Diff < left / right > :
 [
     FooSubmit(
         "",
     ),
>    BarTick,
 ]
```

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
