### PR TITLE
re-add `PropPayload::Tup2`

### DIFF
--- a/docs/en/migrating-4.0.md
+++ b/docs/en/migrating-4.0.md
@@ -27,6 +27,10 @@ The `3` and `4` tuple variants of `PropPayload` have been removed as they were b
 
 If multiple types are still necessary, consider either using `PropPayload::Vec` or for more descriptive fields use a custom struct in `PropPayload::Any`.
 
+### Rename `PropPayload::Tup2` to `Pair`
+
+As other tuple variants are now removed, it is more descriptive to rename `Tup2` to `Pair`.
+
 ### `Component::on` parameter `Event` is now a reference
 
 With 4.0, `Component::on`'s `Event` parameter is now a reference. This allowed us to remove clones in-between that had always been done

--- a/src/core/props/value.rs
+++ b/src/core/props/value.rs
@@ -16,7 +16,7 @@ use crate::props::AnyPropBox;
 #[derive(Debug, PartialEq, Clone)]
 pub enum PropPayload {
     One(PropValue),
-    Tup2((PropValue, PropValue)),
+    Pair((PropValue, PropValue)),
     Vec(Vec<PropValue>),
     Map(HashMap<String, PropValue>),
     Linked(LinkedList<PropPayload>),
@@ -67,11 +67,11 @@ impl PropPayload {
         }
     }
 
-    /// Unwrap a Tup2 value from PropPayload
-    pub fn unwrap_tup2(self) -> (PropValue, PropValue) {
+    /// Unwrap a Pair value from PropPayload
+    pub fn unwrap_pair(self) -> (PropValue, PropValue) {
         match self {
-            PropPayload::Tup2(t) => t,
-            _ => panic!("Called `unwrap_tup2` on a bad value"),
+            PropPayload::Pair(t) => t,
+            _ => panic!("Called `unwrap_pair` on a bad value"),
         }
     }
 
@@ -117,10 +117,10 @@ impl PropPayload {
         }
     }
 
-    /// Get a Tup2 value from PropPayload, or None
-    pub fn as_tup2(&self) -> Option<&(PropValue, PropValue)> {
+    /// Get a Pair value from PropPayload, or None
+    pub fn as_pair(&self) -> Option<&(PropValue, PropValue)> {
         match self {
-            PropPayload::Tup2(v) => Some(v),
+            PropPayload::Pair(v) => Some(v),
             _ => None,
         }
     }
@@ -167,10 +167,10 @@ impl PropPayload {
         }
     }
 
-    /// Get a Tup2 value from PropPayload, or None
-    pub fn as_tup2_mut(&mut self) -> Option<&mut (PropValue, PropValue)> {
+    /// Get a Pair value from PropPayload, or None
+    pub fn as_pair_mut(&mut self) -> Option<&mut (PropValue, PropValue)> {
         match self {
-            PropPayload::Tup2(v) => Some(v),
+            PropPayload::Pair(v) => Some(v),
             _ => None,
         }
     }
@@ -846,7 +846,7 @@ mod tests {
     fn prop_values() {
         // test that values can be created without compile errors
         let _ = PropPayload::One(PropValue::Usize(2));
-        let _ = PropPayload::Tup2((PropValue::Bool(true), PropValue::Usize(128)));
+        let _ = PropPayload::Pair((PropValue::Bool(true), PropValue::Usize(128)));
         let _ = PropPayload::Vec(vec![
             PropValue::U16(1),
             PropValue::U32(2),
@@ -928,7 +928,7 @@ mod tests {
         let _ = PropPayload::Map(map);
         let mut link: LinkedList<PropPayload> = LinkedList::new();
         link.push_back(PropPayload::One(PropValue::Usize(1)));
-        link.push_back(PropPayload::Tup2((
+        link.push_back(PropPayload::Pair((
             PropValue::Usize(2),
             PropValue::Usize(4),
         )));
@@ -1199,7 +1199,7 @@ mod tests {
                 .unwrap_bool(),
         );
         assert_eq!(
-            PropPayload::Tup2((PropValue::Bool(false), PropValue::Bool(false))).unwrap_tup2(),
+            PropPayload::Pair((PropValue::Bool(false), PropValue::Bool(false))).unwrap_pair(),
             (PropValue::Bool(false), PropValue::Bool(false))
         );
         assert_eq!(
@@ -1217,10 +1217,10 @@ mod tests {
         assert_eq!(PropPayload::None.as_one(), None);
 
         assert_eq!(
-            PropPayload::Tup2((PropValue::Bool(true), PropValue::Bool(true))).as_tup2(),
+            PropPayload::Pair((PropValue::Bool(true), PropValue::Bool(true))).as_pair(),
             Some(&(PropValue::Bool(true), PropValue::Bool(true)))
         );
-        assert_eq!(PropPayload::None.as_tup2(), None);
+        assert_eq!(PropPayload::None.as_pair(), None);
 
         assert_eq!(
             PropPayload::Vec(vec![PropValue::Bool(true)]).as_vec(),
@@ -1257,10 +1257,10 @@ mod tests {
         assert_eq!(PropPayload::None.as_one_mut(), None);
 
         assert_eq!(
-            PropPayload::Tup2((PropValue::Bool(true), PropValue::Bool(true))).as_tup2_mut(),
+            PropPayload::Pair((PropValue::Bool(true), PropValue::Bool(true))).as_pair_mut(),
             Some(&mut (PropValue::Bool(true), PropValue::Bool(true)))
         );
-        assert_eq!(PropPayload::None.as_tup2_mut(), None);
+        assert_eq!(PropPayload::None.as_pair_mut(), None);
 
         assert_eq!(
             PropPayload::Vec(vec![PropValue::Bool(true)]).as_vec_mut(),


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

Re https://github.com/veeso/tui-realm/pull/134#issuecomment-3682555267

## Description

This PR re-adds `PropPayload::Tup2` variant again as it did see some common usage in stdlib, which i forgot to check (i checked the most up-to-date projects, but not the stdlib...)

For now this increases the size of `PropPayload` from `64` to `128`.

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
