### PR TITLE
Remove `State::Tup3` & `State::Tup4`, rename `State::Tup2` to `Pair`

### DIFF
--- a/docs/en/migrating-4.0.md
+++ b/docs/en/migrating-4.0.md
@@ -27,7 +27,7 @@ The `3` and `4` tuple variants of `PropPayload` and `State` have been removed as
 
 If multiple types are still necessary, consider either using `PropPayload::Vec` or for more descriptive fields use a custom struct in `PropPayload::Any`.
 
-### Rename `PropPayload::Tup2` to `Pair`
+### Rename `PropPayload` and `State` variant `Tup2` to `Pair`
 
 As other tuple variants are now removed, it is more descriptive to rename `Tup2` to `Pair`.
 

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -11,7 +11,7 @@ use crate::utils::{Email, PhoneNumber};
 #[derive(Debug, PartialEq, Clone)]
 pub enum State {
     One(StateValue),
-    Tup2((StateValue, StateValue)),
+    Pair((StateValue, StateValue)),
     Vec(Vec<StateValue>),
     Map(HashMap<String, StateValue>),
     Linked(LinkedList<State>),
@@ -52,10 +52,10 @@ impl State {
         }
     }
 
-    pub fn unwrap_tup2(self) -> (StateValue, StateValue) {
+    pub fn unwrap_pair(self) -> (StateValue, StateValue) {
         match self {
-            Self::Tup2(val) => val,
-            state => panic!("Could not unwrap {state:?} as `Tup2`"),
+            Self::Pair(val) => val,
+            state => panic!("Could not unwrap {state:?} as `Pair`"),
         }
     }
 


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

Re #134, #138

## Description

This PR brings `State` to be more inline with the changes done to `PropPayload`, bringing the size down from `256` to `128`

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

---

DRAFT until #138 is resolved as it could cause conflicts and there is still one open question.