### PR TITLE
chore: dont recommend "clear_screen" after "leave_alternate_screen"

### DIFF
--- a/docs/en/get-started.md
+++ b/docs/en/get-started.md
@@ -959,7 +959,6 @@ Once `quit` becomes true, the application terminates, but don't forget to finali
 ```rust
 let _ = model.terminal.leave_alternate_screen();
 let _ = model.terminal.disable_raw_mode();
-let _ = model.terminal.clear_screen();
 ```
 
 ---

--- a/examples/demo/demo.rs
+++ b/examples/demo/demo.rs
@@ -75,5 +75,4 @@ fn main() {
     // Terminate terminal
     let _ = model.terminal.leave_alternate_screen();
     let _ = model.terminal.disable_raw_mode();
-    let _ = model.terminal.clear_screen();
 }


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

No Issue

## Description

Dont recommend to run `clear_screen` after a `leave_alternate_screen` as otherwise on (most) terminals, there is a seemingly empty area added to the history. (alternate screens already take care of clearing content)

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
