### PR TITLE
Remove trait `PropBoundExt`

### DIFF
--- a/docs/en/migrating-4.0.md
+++ b/docs/en/migrating-4.0.md
@@ -56,3 +56,7 @@ This effectively means that `new` does not exist anymore, but more specific new 
 - `new_mouse_raw`
 
 Additionally, `TerminalBridge::new_termion` and `init_termion` have been removed, instead use `TerminalBridge::new_init_termion` instead.
+
+### Removal of `PropBoundExt`
+
+The function `as_any` and `as_any_mut` are now directly implemented on `dyn PropBound`, not requiring another trait to be imported.

--- a/src/core/props/any.rs
+++ b/src/core/props/any.rs
@@ -64,31 +64,21 @@ dyn_clone::clone_trait_object!(PropBound);
 /// The outside type to use. It is also the type in [`PropPayload::Any`](super::PropPayload::Any).
 pub type AnyPropBox = Box<dyn PropBound>;
 
-/// Extra convenience functions for [`PropBound`].
-///
-/// This mainly exists because "negative trait implementations" are not stable / supported,
-/// so if we would add this to [`PropBound`]'s `impl _ for T`, it would implement the following functions
-/// for [`Box`] as well, causing `Box<_> as Any` instead of `Box<_>.deref() as Any`.
-pub trait PropBoundExt {
+impl dyn PropBound {
     /// Convenience function to cast to [`Any`].
-    fn as_any(&self) -> &dyn Any;
-    /// Convenience function to cast to [`Any`] mutably.
-    fn as_any_mut(&mut self) -> &mut dyn Any;
-}
-
-impl PropBoundExt for dyn PropBound {
-    fn as_any(&self) -> &dyn Any {
+    pub fn as_any(&self) -> &dyn Any {
         self
     }
 
-    fn as_any_mut(&mut self) -> &mut dyn Any {
+    /// Convenience function to cast to [`Any`] mutably.
+    pub fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::props::{PropBound, PropBoundExt};
+    use crate::props::PropBound;
 
     #[test]
     fn should_work_basic() {

--- a/src/core/props/mod.rs
+++ b/src/core/props/mod.rs
@@ -15,7 +15,7 @@ mod texts;
 mod value;
 
 // -- exports
-pub use any::{AnyPropBox, PropBound, PropBoundExt};
+pub use any::{AnyPropBox, PropBound};
 pub use borders::{BorderSides, BorderType, Borders};
 pub use direction::Direction;
 pub use input_type::InputType;

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -229,7 +229,7 @@ impl StateValue {
 #[cfg(test)]
 mod tests {
     use crate::State;
-    use crate::props::{PropBound, PropBoundExt};
+    use crate::props::PropBound;
 
     #[test]
     fn any() {


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

No issue

## Description

This PR removes the trait `PropBoundExt` that was introduced in #120, as those functions can be directly implemented on `dyn PropBound` as i have noticed in #125.
This means that no extra trait has to be imported to use `as_any` and `as_any_mut` on `dyn PropBound`.

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
