### PR TITLE
More Tests with listener barriers

### DIFF
--- a/src/core/application.rs
+++ b/src/core/application.rs
@@ -510,10 +510,22 @@ mod test {
 
     use super::*;
     use crate::event::{Key, KeyEvent};
+    use crate::listener::builder::test_utils::BarrierRx;
     use crate::mock::{
         MockBarInput, MockComponentId, MockEvent, MockFooInput, MockInjector, MockMsg, MockPoll,
     };
     use crate::{StateValue, SubClause};
+
+    /// Create a common Application with Tick that is configured to only happen once (high interval) and have the lister have a test barrier
+    fn create_app_tick_once_barrier()
+    -> (Application<MockComponentId, MockMsg, MockEvent>, BarrierRx) {
+        let mut listener = listener_config_with_tick(Duration::from_secs(60));
+        let barrier_rx = listener.with_test_barrier();
+        let application: Application<MockComponentId, MockMsg, MockEvent> =
+            Application::init(listener);
+
+        (application, barrier_rx)
+    }
 
     #[test]
     fn should_initialize_application() {
@@ -769,10 +781,8 @@ mod test {
 
     #[test]
     fn should_do_tick() {
-        let mut listener = listener_config_with_tick(Duration::from_secs(60));
-        let barrier_rx = listener.with_test_barrier();
-        let mut application: Application<MockComponentId, MockMsg, MockEvent> =
-            Application::init(listener);
+        let (mut application, barrier_rx) = create_app_tick_once_barrier();
+
         // Mount foo and bar
         assert!(
             application
@@ -916,11 +926,7 @@ mod test {
 
     #[test]
     fn strategy_blocking_upto_should_work() {
-        let mut listener = listener_config_with_tick(Duration::from_secs(60))
-            .poll_timeout(Duration::from_secs(60));
-        let barrier_rx = listener.with_test_barrier();
-        let mut application: Application<MockComponentId, MockMsg, MockEvent> =
-            Application::init(listener);
+        let (mut application, barrier_rx) = create_app_tick_once_barrier();
 
         // Mount foo and bar
         assert!(
@@ -974,10 +980,8 @@ mod test {
 
     #[test]
     fn should_not_propagate_event_when_subs_are_locked() {
-        let mut listener = listener_config_with_tick(Duration::from_secs(60));
-        let barrier_rx = listener.with_test_barrier();
-        let mut application: Application<MockComponentId, MockMsg, MockEvent> =
-            Application::init(listener);
+        let (mut application, barrier_rx) = create_app_tick_once_barrier();
+
         // Mount foo and bar
         assert!(
             application
@@ -1031,10 +1035,8 @@ mod test {
 
     #[test]
     fn should_not_propagate_events_if_has_attr_cond_is_not_satisfied() {
-        let mut listener = listener_config_with_tick(Duration::from_secs(60));
-        let barrier_rx = listener.with_test_barrier();
-        let mut application: Application<MockComponentId, MockMsg, MockEvent> =
-            Application::init(listener);
+        let (mut application, barrier_rx) = create_app_tick_once_barrier();
+
         // Mount foo and bar
         assert!(
             application
@@ -1079,10 +1081,8 @@ mod test {
 
     #[test]
     fn should_propagate_events_if_has_attr_cond_is_satisfied() {
-        let mut listener = listener_config_with_tick(Duration::from_secs(60));
-        let barrier_rx = listener.with_test_barrier();
-        let mut application: Application<MockComponentId, MockMsg, MockEvent> =
-            Application::init(listener);
+        let (mut application, barrier_rx) = create_app_tick_once_barrier();
+
         // Mount foo and bar
         assert!(
             application
@@ -1126,10 +1126,8 @@ mod test {
 
     #[test]
     fn should_not_propagate_events_if_has_state_cond_is_not_satisfied() {
-        let mut listener = listener_config_with_tick(Duration::from_secs(60));
-        let barrier_rx = listener.with_test_barrier();
-        let mut application: Application<MockComponentId, MockMsg, MockEvent> =
-            Application::init(listener);
+        let (mut application, barrier_rx) = create_app_tick_once_barrier();
+
         // Mount foo and bar
         assert!(
             application
@@ -1169,10 +1167,8 @@ mod test {
 
     #[test]
     fn should_propagate_events_if_has_state_cond_is_satisfied() {
-        let mut listener = listener_config_with_tick(Duration::from_secs(60));
-        let barrier_rx = listener.with_test_barrier();
-        let mut application: Application<MockComponentId, MockMsg, MockEvent> =
-            Application::init(listener);
+        let (mut application, barrier_rx) = create_app_tick_once_barrier();
+
         // Mount foo and bar
         assert!(
             application
@@ -1216,10 +1212,8 @@ mod test {
 
     #[test]
     fn should_not_propagate_events_if_is_mounted_cond_is_not_satisfied() {
-        let mut listener = listener_config_with_tick(Duration::from_secs(60));
-        let barrier_rx = listener.with_test_barrier();
-        let mut application: Application<MockComponentId, MockMsg, MockEvent> =
-            Application::init(listener);
+        let (mut application, barrier_rx) = create_app_tick_once_barrier();
+
         // Mount foo and bar
         assert!(
             application
@@ -1259,10 +1253,8 @@ mod test {
 
     #[test]
     fn should_propagate_events_if_is_mounted_cond_is_not_satisfied() {
-        let mut listener = listener_config_with_tick(Duration::from_secs(60));
-        let barrier_rx = listener.with_test_barrier();
-        let mut application: Application<MockComponentId, MockMsg, MockEvent> =
-            Application::init(listener);
+        let (mut application, barrier_rx) = create_app_tick_once_barrier();
+
         // Mount foo and bar
         assert!(
             application

--- a/src/listener/mod.rs
+++ b/src/listener/mod.rs
@@ -6,7 +6,7 @@
 // -- modules
 #[cfg(feature = "async-ports")]
 mod async_ticker;
-mod builder;
+pub(crate) mod builder;
 mod port;
 #[cfg(feature = "async-ports")]
 mod task_pool;


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

No issue.

## Description

Re #151, change more tests to use testing barriers. (still only affecting mac and windows)
My best guess is that the first event from the port is fetched (`Event(Key::Enter)`), but the listener has not yet progressed to sending the tick, but the waiting thread has seen there is one, but does not see more, so it does not wait more.
Now they will wait until the full listener cycle is through for those tests too.

<details>
<summary>See failures even though #151 is merged</summary>

```txt
---- core::application::test::should_propagate_events_if_is_mounted_cond_is_not_satisfied stdout ----

thread 'core::application::test::should_propagate_events_if_is_mounted_cond_is_not_satisfied' (10168) panicked at src\core\application.rs:1269:9:
assertion failed: `(left == right)`

Diff < left / right > :
 [
     FooSubmit(
         "",
     ),
>    BarTick,
 ]


---- core::application::test::should_propagate_events_if_has_state_cond_is_satisfied stdout ----

thread 'core::application::test::should_propagate_events_if_has_state_cond_is_satisfied' panicked at src/core/application.rs:1183:9:
assertion failed: `(left == right)`

error: test failed, to rerun pass `--lib`
Diff < left / right > :
error: 1 target failed:
 [
    `--lib`
     FooSubmit(
         "",
     ),
>    BarTick,
 ]


---- core::application::test::should_propagate_events_if_has_attr_cond_is_satisfied stdout ----

thread 'core::application::test::should_propagate_events_if_has_attr_cond_is_satisfied' (7377) panicked at src/core/application.rs:1103:9:
assertion failed: `(left == right)`

Diff < left / right > :
 [
     FooSubmit(
         "",
     ),
>    BarTick,
 ]
```

</details>

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
