### PR TITLE
Move timeout to `PollStrategy`

### DIFF
--- a/docs/en/get-started.md
+++ b/docs/en/get-started.md
@@ -879,13 +879,12 @@ fn init_app() -> Application<Id, Msg, NoUserEvent> {
     let mut app: Application<Id, Msg, NoUserEvent> = Application::init(
         EventListenerCfg::default()
             .default_input_listener(Duration::from_millis(20))
-            .poll_timeout(Duration::from_millis(10))
             .tick_interval(Duration::from_secs(1)),
     );
 }
 ```
 
-The app requires the configuration for the `EventListener` which will poll `Ports`. We're telling the event listener to use the default input listener for our backend. `default_input_listener` will setup the default input listener for crossterm/termion/termwiz or the backend you chose. Then we also define the `poll_timeout`, which describes the interval between each poll to the listener thread.
+The app requires the configuration for the `EventListener` which will poll `Ports`. We're telling the event listener to use the default input listener for our backend. `default_input_listener` will setup the default input listener for crossterm/termion/termwiz or the backend you chose.
 
 > ❗ Here we could also define other Ports thanks to the method `port()` or setup the `Tick` producer with `tick_interval()`
 
@@ -928,7 +927,7 @@ and we can finally implement the **main loop**:
 ```rust
 while !model.quit {
     // Tick
-    match app.tick(&mut model, PollStrategy::Once) {
+    match app.tick(&mut model, PollStrategy::Once(Duration::from_millis(10))) {
         Err(err) => {
             // Handle error...
         }
@@ -952,7 +951,7 @@ while !model.quit {
 }
 ```
 
-On each cycle we call `tick()` on our application, with strategy `Once` and we ask the model to redraw the view only if at least one message has been processed (otherwise there shouldn't be any change to display).
+On each cycle we call `tick()` on our application, with strategy `Once` with a `10ms` timeout and we ask the model to redraw the view only if at least one message has been processed (otherwise there shouldn't be any change to display).
 
 Once `quit` becomes true, the application terminates, but don't forget to finalize the terminal:
 

--- a/docs/en/migrating-4.0.md
+++ b/docs/en/migrating-4.0.md
@@ -76,3 +76,8 @@ This is due to `ListenerError`'s variants being meant to be mostly internal.
 ### Separate Error types for `poll`
 
 In addition to the [`*Poll::poll` return type changes](#change-of-poll-return-types), `ApplicationError` got a specific `Poll` variant over it being combined with Listener start / stop errors.
+
+### Poll timeout moved to be in `PollStrategy`
+
+The timeout that was previously stored on the `EventListener(Cfg|Builder)` has been moved to be stored on the `PollStrategy` instead.
+This has been done due to some strategies not using a timeout alltogether, and some have different meanings for the duration specified.

--- a/examples/arbitrary_data.rs
+++ b/examples/arbitrary_data.rs
@@ -34,7 +34,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // NOTE: loop until quit; quit is set in update if AppClose is received from counter
     while !model.quit {
         // Tick
-        match model.app.tick(PollStrategy::Once) {
+        match model
+            .app
+            .tick(PollStrategy::Once(Duration::from_millis(10)))
+        {
             Err(err) => {
                 panic!("application error {err}");
             }

--- a/examples/async_ports.rs
+++ b/examples/async_ports.rs
@@ -44,7 +44,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // NOTE: loop until quit; quit is set in update if AppClose is received from counter
     while !model.quit {
         // Tick
-        match model.app.tick(PollStrategy::Once) {
+        match model
+            .app
+            .tick(PollStrategy::Once(Duration::from_millis(10)))
+        {
             Err(err) => {
                 panic!("application error {err}");
             }

--- a/examples/demo/app/model.rs
+++ b/examples/demo/app/model.rs
@@ -79,7 +79,6 @@ where
         let mut app: Application<Id, Msg, NoUserEvent> = Application::init(
             EventListenerCfg::default()
                 .crossterm_input_listener(Duration::from_millis(20), 3)
-                .poll_timeout(Duration::from_millis(10))
                 .tick_interval(Duration::from_secs(1)),
         );
         // Mount components

--- a/examples/demo/demo.rs
+++ b/examples/demo/demo.rs
@@ -4,6 +4,8 @@
 
 extern crate tuirealm;
 
+use std::time::Duration;
+
 use tuirealm::application::PollStrategy;
 use tuirealm::{AttrValue, Attribute, Update};
 // -- internal
@@ -41,7 +43,10 @@ fn main() {
     // NOTE: loop until quit; quit is set in update if AppClose is received from counter
     while !model.quit {
         // Tick
-        match model.app.tick(PollStrategy::Once) {
+        match model
+            .app
+            .tick(PollStrategy::Once(Duration::from_millis(10)))
+        {
             Err(err) => {
                 assert!(
                     model

--- a/examples/user_events/user_events.rs
+++ b/examples/user_events/user_events.rs
@@ -90,7 +90,10 @@ fn main() {
     // NOTE: loop until quit; quit is set in update if AppClose is received from counter
     while !model.quit {
         // Tick
-        match model.app.tick(PollStrategy::Once) {
+        match model
+            .app
+            .tick(PollStrategy::Once(Duration::from_millis(10)))
+        {
             Err(err) => {
                 panic!("application error {err}");
             }


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

No issue

## Description

This PR does 2 things:
- update `PollStrategy` documentation to be more coherent (not necessarily reference other strategies to understand the current one)
- remove `poll_timeout` property from `EventListener` and instead have it be part of `PollStrategy`'s variants, where necessary

I think this is for the better, due to some Strategies not even having a need for a timeout, or have a different meaning for the duration passed-in.
This also allows changing the timeout dynamically, if wanted.

The only downside i found is that the `TryFor` strategy basically is now busy-looping in 10ms intervals (unconfigurably), due to `recv_deadline` still being unstable and now not having a global timeout anymore.
Should i add a parameter to `TryFor` to configure that timeout, or is the static 10ms enough as a trade-off?

PS: i hope i updated all documentation places referencing `poll_timeout`.

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
