### PR TITLE
feat(application): replace "PollStrategy::UpTo" with "PollStrategy::UpToNoWait"

### DIFF
--- a/docs/en/migrating-4.0.md
+++ b/docs/en/migrating-4.0.md
@@ -77,6 +77,13 @@ This is due to `ListenerError`'s variants being meant to be mostly internal.
 
 In addition to the [`*Poll::poll` return type changes](#change-of-poll-return-types), `ApplicationError` got a specific `Poll` variant over it being combined with Listener start / stop errors.
 
+### Change `PollStrategy::UpToNoWait` to be `PollStrategy::UpTo`
+
+The old `PollStrategy::UpTo` has been removed and replaced with previously known `PollStrategy::UpToNoWait`.
+
+This has been done as the behavior of "wait TIMEOUT for each N, if there was a event available" is not something that is useful to event-driven tui applications.
+(With the new `UpTo`, previously known as `UpToNoWait` will "wait TIMEOUT once, collect event, afterwards collect up to N-1 amount (without blocking again), as long as there are events")
+
 ### Poll timeout moved to be in `PollStrategy`
 
 The timeout that was previously stored on the `EventListener(Cfg|Builder)` has been moved to be stored on the `PollStrategy` instead.


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

No issue

## Description

This PR removes the old `PollStrategy::UpTo` and replaces it with `PollStrategy::UpToNoWait`, as i dont think the old behavior is something for a event-driven tui application.

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

---

FYI: along with #158, this is the last "planned" breaking change, unless something else comes up (like from updating stdlib)