### PR TITLE
Dont run codeberg mirror on forks

### DIFF
--- a/.github/workflows/codeberg-mirror.yml
+++ b/.github/workflows/codeberg-mirror.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   mirror:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'veeso'
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

No issue

## Description

This changes the codeberg mirror workflows to only run on the main repository, as that is commonly the only one set-up to do it, where as in works the workflow will error with "missing secrets" (which is annoying due to the emails, on every push)

Alternatively, it could maybe check for the presence of `secrets.GIT_SSH_PRIVATE_KEY` instead, though that would also required changes to the `remote`

This is done on the `job` level, due to not being able (to my knowledge) to do it on a `on` level.

PS: maybe only specific branches actually need to be mirrored too, and instead of `on: push`, maybe it should instead do it on a schedule?

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
