### PR TITLE
chore: bump ratatui version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ crossterm = { version = "0.29", optional = true }
 dyn-clone = "1"
 futures-util = { version = "0.3", default-features = false, optional = true }
 lazy-regex = "3"
-ratatui = { version = "0.29", default-features = false }
+ratatui = { version = "0.30", default-features = false }
 serde = { version = "1", features = ["derive"], optional = true }
 termion = { version = "^4", optional = true }
 thiserror = "2"


### PR DESCRIPTION
# Just a chore

## Description

Bumped ratatui version to avoid version conflict when i am using ratatui-core and ratatui-macros as direct deps. 

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Chore (no tests break)

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have introduced no new *C-bindings*
- [ ] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [ ] I increased or maintained the code coverage for the project, compared to the previous commit
