### PR TITLE
fix(treeview): backport upstream fixes

### DIFF
--- a/crates/extra/tui-realm-treeview/src/lib.rs
+++ b/crates/extra/tui-realm-treeview/src/lib.rs
@@ -22,17 +22,17 @@
 //!
 //! **Commands**:
 //!
-//! | Cmd                       | Result           | Behaviour                                            |
-//! |---------------------------|------------------|------------------------------------------------------|
-//! | `Custom($TREE_CMD_CLOSE)` | `None`           | Close selected node                                  |
-//! | `Custom($TREE_CMD_OPEN)`  | `None`           | Open selected node                                   |
-//! | `GoTo(Begin)`             | `Changed | None` | Move cursor to the top of the current tree node      |
-//! | `GoTo(End)`               | `Changed | None` | Move cursor to the bottom of the current tree node   |
-//! | `Move(Down)`              | `Changed | None` | Go to next element                                   |
-//! | `Move(Up)`                | `Changed | None` | Go to previous element                               |
-//! | `Scroll(Down)`            | `Changed | None` | Move cursor down by defined max steps or end of node |
-//! | `Scroll(Up)`              | `Changed | None` | Move cursor up by defined max steps or begin of node |
-//! | `Submit`                  | `Submit`         | Just returns submit result with current state        |
+//! | Cmd                       | Result            | Behaviour                                            |
+//! |---------------------------|-------------------|------------------------------------------------------|
+//! | `Custom($TREE_CMD_CLOSE)` | `None`            | Close selected node                                  |
+//! | `Custom($TREE_CMD_OPEN)`  | `None`            | Open selected node                                   |
+//! | `GoTo(Begin)`             | `Changed \| None` | Move cursor to the top of the current tree node      |
+//! | `GoTo(End)`               | `Changed \| None` | Move cursor to the bottom of the current tree node   |
+//! | `Move(Down)`              | `Changed \| None` | Go to next element                                   |
+//! | `Move(Up)`                | `Changed \| None` | Go to previous element                               |
+//! | `Scroll(Down)`            | `Changed \| None` | Move cursor down by defined max steps or end of node |
+//! | `Scroll(Up)`              | `Changed \| None` | Move cursor up by defined max steps or begin of node |
+//! | `Submit`                  | `Submit`          | Just returns submit result with current state        |
 //!
 //! **State**: the state returned is a `One(String)` containing the id of the selected node. If no node is selected `None` is returned.
 //!

--- a/crates/extra/tui-realm-treeview/src/tree_state.rs
+++ b/crates/extra/tui-realm-treeview/src/tree_state.rs
@@ -220,7 +220,11 @@ impl TreeState {
     fn get_last_open_heir<'a, V>(&self, node: &'a Node<V>) -> &'a Node<V> {
         if self.is_open(node) {
             // If node is open, get its last child and call this function recursively
-            self.get_last_open_heir(node.iter().last().unwrap())
+            if let Some(child) = node.iter().last() {
+                self.get_last_open_heir(child)
+            } else {
+                node
+            }
         } else {
             // Else return `node`
             node
@@ -594,5 +598,23 @@ mod test {
                 .as_str(),
             "aC0"
         );
+    }
+
+    #[test]
+    fn get_last_open_heir_0_children() {
+        let mut state = TreeState::default();
+        let mut tree = mock_tree();
+
+        state.select(tree.root(), tree.root());
+        state.open(tree.root());
+
+        let node = &tree.root().children()[0];
+        let node_id = node.id().to_string();
+        state.select(tree.root(), node);
+        state.open(tree.root());
+
+        tree.root_mut().query_mut(&node_id).unwrap().clear();
+
+        state.get_last_open_heir(&tree.root().children()[0]);
     }
 }


### PR DESCRIPTION
## Summary

- Fix doc table rendering: escape `|` in markdown table cells and align columns (backport of https://github.com/veeso/tui-realm-treeview/pull/16)
- Fix panic in `get_last_open_heir` when an open node has no children — falls back to current node instead of unwrapping `None` (backport of https://github.com/veeso/tui-realm-treeview/pull/17, fixes https://github.com/veeso/tui-realm-treeview/issues/15)

## Test plan

- [x] `cargo test -p tui-realm-treeview --all-features` — all 41 tests pass including new `get_last_open_heir_0_children` test