### PR TITLE
refactor: cleanup exports, module-level only (#168)

### DIFF
--- a/crates/extra/tui-realm-textarea/examples/editor.rs
+++ b/crates/extra/tui-realm-textarea/examples/editor.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 
 // label
 #[cfg(feature = "search")]
-use tui_realm_stdlib::Input;
-use tui_realm_stdlib::Label;
+use tui_realm_stdlib::components::Input;
+use tui_realm_stdlib::components::Label;
 // textarea
 #[cfg(feature = "clipboard")]
 use tui_realm_textarea::TEXTAREA_CMD_PASTE;
@@ -17,18 +17,21 @@ use tui_realm_textarea::{
 use tui_realm_textarea::{
     TEXTAREA_CMD_SEARCH_BACK, TEXTAREA_CMD_SEARCH_FORWARD, TEXTAREA_SEARCH_PATTERN,
 };
-#[cfg(feature = "search")]
-use tuirealm::StateValue;
-use tuirealm::application::PollStrategy;
+use tuirealm::MockComponent;
+use tuirealm::application::{Application, PollStrategy};
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
-use tuirealm::event::{Event, Key, KeyEvent, KeyModifiers};
+use tuirealm::component::{Component, MockComponent};
+use tuirealm::event::{Event, Key, KeyEvent, KeyModifiers, NoUserEvent};
+use tuirealm::listener::EventListenerCfg;
 use tuirealm::props::{
     AttrValue, Attribute, BorderType, Borders, Color, HorizontalAlignment, Style, TextModifiers,
 };
 // tui
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
+use tuirealm::state::State;
+#[cfg(feature = "search")]
+use tuirealm::state::StateValue;
 use tuirealm::terminal::{CrosstermTerminalAdapter, TerminalAdapter};
-use tuirealm::{Application, Component, EventListenerCfg, MockComponent, NoUserEvent, State};
 
 // -- message
 #[derive(Debug, PartialEq)]
@@ -199,7 +202,11 @@ pub struct Editor {
 }
 
 impl MockComponent for Editor {
-    fn view(&mut self, frame: &mut tuirealm::Frame, area: tuirealm::ratatui::layout::Rect) {
+    fn view(
+        &mut self,
+        frame: &mut tuirealm::ratatui::Frame,
+        area: tuirealm::ratatui::layout::Rect,
+    ) {
         self.component.view(frame, area);
     }
 

--- a/crates/extra/tui-realm-textarea/examples/single_line.rs
+++ b/crates/extra/tui-realm-textarea/examples/single_line.rs
@@ -7,16 +7,18 @@ use tui_realm_textarea::{
     TEXTAREA_CMD_MOVE_WORD_BACK, TEXTAREA_CMD_MOVE_WORD_FORWARD, TEXTAREA_CMD_NEWLINE,
     TEXTAREA_CMD_REDO, TEXTAREA_CMD_UNDO, TextArea,
 };
-use tuirealm::application::PollStrategy;
+use tuirealm::application::{Application, PollStrategy};
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
-use tuirealm::event::{Event, Key, KeyEvent, KeyModifiers};
+use tuirealm::component::{Component, MockComponent};
+use tuirealm::event::{Event, Key, KeyEvent, KeyModifiers, NoUserEvent};
+use tuirealm::listener::EventListenerCfg;
 use tuirealm::props::{
     AttrValue, Attribute, BorderType, Borders, Color, HorizontalAlignment, Style, TextModifiers,
 };
 // tui
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
+use tuirealm::state::State;
 use tuirealm::terminal::{CrosstermTerminalAdapter, TerminalAdapter};
-use tuirealm::{Application, Component, EventListenerCfg, MockComponent, NoUserEvent, State};
 
 // -- message
 #[derive(Debug, PartialEq)]
@@ -135,7 +137,11 @@ pub struct Input {
 }
 
 impl MockComponent for Input {
-    fn view(&mut self, frame: &mut tuirealm::Frame, area: tuirealm::ratatui::layout::Rect) {
+    fn view(
+        &mut self,
+        frame: &mut tuirealm::ratatui::Frame,
+        area: tuirealm::ratatui::layout::Rect,
+    ) {
         self.component.view(frame, area);
     }
 

--- a/crates/extra/tui-realm-textarea/src/lib.rs
+++ b/crates/extra/tui-realm-textarea/src/lib.rs
@@ -94,13 +94,15 @@
 //!
 //! ```rust
 //! use std::{fs, io::{self, BufRead}};
-//! use tuirealm::{
-//!     application::PollStrategy,
-//!     command::{Cmd, CmdResult, Direction, Position},
-//!     event::{Event, Key, KeyEvent, KeyModifiers},
-//!     props::{HorizontalAlignment, AttrValue, Attribute, BorderType, Borders, Color, Style, TextModifiers},
-//!     Application, Component, EventListenerCfg, MockComponent, NoUserEvent, State, StateValue,
-//! };
+//! use tuirealm::application::PollStrategy;
+//! use tuirealm::command::{Cmd, CmdResult, Direction, Position};
+//! use tuirealm::component::MockComponent;
+//! use tuirealm::event::{Event, Key, KeyEvent, KeyModifiers, NoUserEvent};
+//! use tuirealm::props::{HorizontalAlignment, AttrValue, Attribute, BorderType, Borders, Color, Style, TextModifiers};
+//! use tuirealm::state::{State, StateValue};
+//! use tuirealm::application::Application;
+//! use tuirealm::listener::EventListenerCfg;
+//! use tuirealm::component::Component;
 //! use tui_realm_textarea::TextArea;
 //!
 //! let textarea = match fs::File::open("README.md") {
@@ -147,13 +149,15 @@ use cli_clipboard::{ClipboardContext, ClipboardProvider};
 use fmt::LineFmt;
 use tui_textarea::{CursorMove, TextArea as TextAreaWidget};
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
+use tuirealm::component::MockComponent;
 use tuirealm::props::{
     AttrValue, Attribute, Borders, HorizontalAlignment, PropPayload, PropValue, Props, Style,
     TextModifiers, Title,
 };
+use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout, Rect};
 use tuirealm::ratatui::widgets::{Block, Paragraph};
-use tuirealm::{Frame, MockComponent, State, StateValue};
+use tuirealm::state::{State, StateValue};
 
 // -- props
 pub const TEXTAREA_CURSOR_LINE_STYLE: &str = "cursor-line-style";

--- a/crates/extra/tui-realm-treeview/examples/demo.rs
+++ b/crates/extra/tui-realm-treeview/examples/demo.rs
@@ -1,22 +1,23 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use tui_realm_stdlib::{Input, Phantom};
+use tui_realm_stdlib::components::{Input, Phantom};
 // treeview
 use tui_realm_treeview::{Node, TREE_CMD_CLOSE, TREE_CMD_OPEN, Tree, TreeView};
-use tuirealm::application::PollStrategy;
+use tuirealm::MockComponent;
+use tuirealm::application::{Application, PollStrategy};
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
-use tuirealm::event::{Event, Key, KeyEvent, KeyModifiers};
+use tuirealm::component::{Component, MockComponent};
+use tuirealm::event::{Event, Key, KeyEvent, KeyModifiers, NoUserEvent};
+use tuirealm::listener::EventListenerCfg;
 use tuirealm::props::{
     AttrValue, Attribute, BorderType, Borders, Color, HorizontalAlignment, InputType, Style,
 };
 // tui
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
+use tuirealm::state::{State, StateValue};
+use tuirealm::subscription::{EventClause, Sub, SubClause};
 use tuirealm::terminal::{CrosstermTerminalAdapter, TerminalAdapter};
-use tuirealm::{
-    Application, Component, EventListenerCfg, MockComponent, NoUserEvent, State, StateValue, Sub,
-    SubClause, SubEventClause,
-};
 
 const MAX_DEPTH: usize = 3;
 
@@ -73,7 +74,7 @@ impl Model {
                 Id::GlobalListener,
                 Box::new(GlobalListener::default()),
                 vec![Sub::new(
-                    SubEventClause::Keyboard(KeyEvent {
+                    EventClause::Keyboard(KeyEvent {
                         code: Key::Esc,
                         modifiers: KeyModifiers::NONE,
                     }),

--- a/crates/extra/tui-realm-treeview/src/lib.rs
+++ b/crates/extra/tui-realm-treeview/src/lib.rs
@@ -78,12 +78,12 @@
 //! ## Setup a tree component
 //!
 //! ```rust
-//! use tuirealm::{
-//!     command::{Cmd, CmdResult, Direction, Position},
-//!     event::{Event, Key, KeyEvent, KeyModifiers},
-//!     props::{BorderType, Borders, Color, HorizontalAlignment, Style},
-//!     Component, MockComponent, NoUserEvent, State, StateValue,
-//! };
+//! use tuirealm::MockComponent;
+//! use tuirealm::command::{Cmd, CmdResult, Direction, Position};
+//! use tuirealm::component::{Component, MockComponent};
+//! use tuirealm::event::{Event, Key, KeyEvent, KeyModifiers, NoUserEvent};
+//! use tuirealm::props::{BorderType, Borders, Color, HorizontalAlignment, Style};
+//! use tuirealm::state::{State, StateValue};
 //! // treeview
 //! use tui_realm_treeview::{Node, Tree, TreeView, TREE_CMD_CLOSE, TREE_CMD_OPEN};
 //!
@@ -202,24 +202,26 @@
 #[cfg(test)]
 pub(crate) mod mock;
 // -- modules
-mod tree_state;
-mod widget;
+pub mod tree_state;
+pub mod widget;
 
 use std::iter;
 
 // deps
 pub use orange_trees::{Node as OrangeNode, Tree as OrangeTree};
-// internal
-pub use tree_state::TreeState;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
+use tuirealm::component::MockComponent;
 use tuirealm::props::{
     AttrValue, Attribute, Borders, Color, HorizontalAlignment, Props, Style, TextModifiers, Title,
 };
+use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
 use tuirealm::ratatui::text::Span;
 use tuirealm::ratatui::widgets::Block;
-use tuirealm::{Frame, MockComponent, State, StateValue};
-pub use widget::TreeWidget;
+use tuirealm::state::{State, StateValue};
+
+use self::tree_state::TreeState;
+use self::widget::TreeWidget;
 
 /// [`Tree`] node value.
 pub trait NodeValue: Default {

--- a/crates/tui-realm-stdlib/examples/bar_chart.rs
+++ b/crates/tui-realm-stdlib/examples/bar_chart.rs
@@ -1,13 +1,14 @@
 use std::error::Error;
 use std::time::Duration;
 
-use tui_realm_stdlib::BarChart;
+use tui_realm_stdlib::components::BarChart;
+use tuirealm::MockComponent;
 use tuirealm::application::PollStrategy;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
-use tuirealm::event::{Key, KeyEvent};
+use tuirealm::component::{Component, MockComponent};
+use tuirealm::event::{Event, Key, KeyEvent, NoUserEvent};
 use tuirealm::props::{BorderType, Borders, Color, HorizontalAlignment, Style, Title};
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
-use tuirealm::{Component, Event, MockComponent, NoUserEvent};
 
 mod utils;
 use utils::Model;

--- a/crates/tui-realm-stdlib/examples/canvas.rs
+++ b/crates/tui-realm-stdlib/examples/canvas.rs
@@ -3,14 +3,15 @@
 use std::error::Error;
 use std::time::Duration;
 
-use tui_realm_stdlib::Canvas;
+use tui_realm_stdlib::components::Canvas;
+use tuirealm::MockComponent;
 use tuirealm::application::PollStrategy;
-use tuirealm::event::{Key, KeyEvent};
+use tuirealm::component::Component;
+use tuirealm::event::{Event, Key, KeyEvent, NoUserEvent};
 use tuirealm::props::{Borders, Color, HorizontalAlignment, Shape, Title};
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
 use tuirealm::ratatui::symbols::Marker;
 use tuirealm::ratatui::widgets::canvas::{Line, Map, MapResolution, Rectangle};
-use tuirealm::{Component, Event, MockComponent, NoUserEvent};
 
 mod utils;
 use utils::Model;

--- a/crates/tui-realm-stdlib/examples/chart.rs
+++ b/crates/tui-realm-stdlib/examples/chart.rs
@@ -3,10 +3,12 @@
 use std::error::Error;
 use std::time::Duration;
 
-use tui_realm_stdlib::{Chart, ChartDataset};
+use tui_realm_stdlib::components::{Chart, ChartDataset};
+use tuirealm::MockComponent;
 use tuirealm::application::PollStrategy;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
-use tuirealm::event::{Key, KeyEvent};
+use tuirealm::component::{Component, MockComponent};
+use tuirealm::event::{Event, Key, KeyEvent};
 use tuirealm::listener::{Poll, PortResult, SyncPort};
 use tuirealm::props::{
     AttrValue, Attribute, BorderType, Borders, Color, HorizontalAlignment, PropPayload, Style,
@@ -15,7 +17,6 @@ use tuirealm::props::{
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
 use tuirealm::ratatui::symbols::Marker;
 use tuirealm::ratatui::widgets::GraphType;
-use tuirealm::{Component, Event, MockComponent};
 
 mod utils;
 use utils::{DataGen, Model};

--- a/crates/tui-realm-stdlib/examples/checkbox.rs
+++ b/crates/tui-realm-stdlib/examples/checkbox.rs
@@ -3,13 +3,14 @@
 use std::error::Error;
 use std::time::Duration;
 
-use tui_realm_stdlib::Checkbox;
+use tui_realm_stdlib::components::Checkbox;
+use tuirealm::MockComponent;
 use tuirealm::application::PollStrategy;
 use tuirealm::command::{Cmd, CmdResult, Direction};
-use tuirealm::event::{Key, KeyEvent};
+use tuirealm::component::{Component, MockComponent};
+use tuirealm::event::{Event, Key, KeyEvent, NoUserEvent};
 use tuirealm::props::{BorderType, Borders, Color, HorizontalAlignment, Title};
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
-use tuirealm::{Component, Event, MockComponent, NoUserEvent};
 
 mod utils;
 use utils::Model;

--- a/crates/tui-realm-stdlib/examples/container.rs
+++ b/crates/tui-realm-stdlib/examples/container.rs
@@ -3,16 +3,17 @@
 use std::error::Error;
 use std::time::Duration;
 
-use tui_realm_stdlib::{Container, Table};
+use tui_realm_stdlib::components::{Container, Table};
+use tuirealm::MockComponent;
 use tuirealm::application::PollStrategy;
 use tuirealm::command::CmdResult;
-use tuirealm::event::{Key, KeyEvent};
+use tuirealm::component::Component;
+use tuirealm::event::{Event, Key, KeyEvent, NoUserEvent};
 use tuirealm::props::{
     BorderType, Borders, Color, HorizontalAlignment, Layout, TableBuilder, Title,
 };
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout as TuiLayout};
 use tuirealm::ratatui::text::Line;
-use tuirealm::{Component, Event, MockComponent, NoUserEvent};
 
 mod utils;
 use utils::Model;

--- a/crates/tui-realm-stdlib/examples/gauge.rs
+++ b/crates/tui-realm-stdlib/examples/gauge.rs
@@ -3,17 +3,18 @@
 use std::error::Error;
 use std::time::Duration;
 
-use tui_realm_stdlib::{Gauge, Label};
+use tui_realm_stdlib::components::{Gauge, Label};
+use tuirealm::MockComponent;
 use tuirealm::application::PollStrategy;
 use tuirealm::command::CmdResult;
-use tuirealm::event::{Key, KeyEvent};
+use tuirealm::component::{Component, MockComponent};
+use tuirealm::event::{Event, Key, KeyEvent};
 use tuirealm::listener::{Poll, PortResult, SyncPort};
 use tuirealm::props::{
     AttrValue, Attribute, BorderType, Borders, Color, HorizontalAlignment, PropPayload, PropValue,
     Title,
 };
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
-use tuirealm::{Component, Event, MockComponent};
 
 mod utils;
 use utils::{Loader, Model};

--- a/crates/tui-realm-stdlib/examples/input.rs
+++ b/crates/tui-realm-stdlib/examples/input.rs
@@ -3,15 +3,17 @@
 use std::error::Error;
 use std::time::Duration;
 
-use tui_realm_stdlib::Input;
+use tui_realm_stdlib::components::Input;
+use tuirealm::MockComponent;
 use tuirealm::application::PollStrategy;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
-use tuirealm::event::{Key, KeyEvent, KeyModifiers};
+use tuirealm::component::{Component, MockComponent};
+use tuirealm::event::{Event, Key, KeyEvent, KeyModifiers, NoUserEvent};
 use tuirealm::props::{
     AttrValue, Attribute, BorderType, Borders, Color, HorizontalAlignment, InputType, Style, Title,
 };
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
-use tuirealm::{Component, Event, MockComponent, NoUserEvent, State, StateValue};
+use tuirealm::state::{State, StateValue};
 
 mod utils;
 use utils::Model;

--- a/crates/tui-realm-stdlib/examples/label.rs
+++ b/crates/tui-realm-stdlib/examples/label.rs
@@ -3,13 +3,14 @@
 use std::error::Error;
 use std::time::Duration;
 
-use tui_realm_stdlib::Label;
+use tui_realm_stdlib::components::Label;
+use tuirealm::MockComponent;
 use tuirealm::application::PollStrategy;
 use tuirealm::command::CmdResult;
-use tuirealm::event::{Key, KeyEvent};
+use tuirealm::component::Component;
+use tuirealm::event::{Event, Key, KeyEvent, NoUserEvent};
 use tuirealm::props::{Color, HorizontalAlignment, TextModifiers};
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
-use tuirealm::{Component, Event, MockComponent, NoUserEvent};
 
 mod utils;
 use utils::Model;

--- a/crates/tui-realm-stdlib/examples/line_gauge.rs
+++ b/crates/tui-realm-stdlib/examples/line_gauge.rs
@@ -3,10 +3,12 @@
 use std::error::Error;
 use std::time::Duration;
 
-use tui_realm_stdlib::LineGauge;
+use tui_realm_stdlib::components::LineGauge;
+use tuirealm::MockComponent;
 use tuirealm::application::PollStrategy;
 use tuirealm::command::CmdResult;
-use tuirealm::event::{Key, KeyEvent};
+use tuirealm::component::{Component, MockComponent};
+use tuirealm::event::{Event, Key, KeyEvent};
 use tuirealm::listener::{Poll, PortResult, SyncPort};
 use tuirealm::props::{
     AttrValue, Attribute, BorderType, Borders, Color, HorizontalAlignment, PropPayload, PropValue,
@@ -15,7 +17,6 @@ use tuirealm::props::{
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
 use tuirealm::ratatui::symbols::line::{HORIZONTAL, THICK_HORIZONTAL};
 use tuirealm::ratatui::text::Span;
-use tuirealm::{Component, Event, MockComponent};
 
 mod utils;
 use utils::{Loader, Model};

--- a/crates/tui-realm-stdlib/examples/list.rs
+++ b/crates/tui-realm-stdlib/examples/list.rs
@@ -3,15 +3,16 @@
 use std::error::Error;
 use std::time::Duration;
 
-use tui_realm_stdlib::List;
+use tui_realm_stdlib::components::List;
+use tuirealm::MockComponent;
 use tuirealm::application::PollStrategy;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
-use tuirealm::event::{Key, KeyEvent};
+use tuirealm::component::{Component, MockComponent};
+use tuirealm::event::{Event, Key, KeyEvent, NoUserEvent};
 use tuirealm::props::{BorderType, Borders, Color, HorizontalAlignment, Title};
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
 use tuirealm::ratatui::style::Stylize;
 use tuirealm::ratatui::text::Span;
-use tuirealm::{Component, Event, MockComponent, NoUserEvent};
 
 mod utils;
 use utils::Model;

--- a/crates/tui-realm-stdlib/examples/paragraph.rs
+++ b/crates/tui-realm-stdlib/examples/paragraph.rs
@@ -3,15 +3,16 @@
 use std::error::Error;
 use std::time::Duration;
 
-use tui_realm_stdlib::Paragraph;
+use tui_realm_stdlib::components::Paragraph;
+use tuirealm::MockComponent;
 use tuirealm::application::PollStrategy;
 use tuirealm::command::CmdResult;
-use tuirealm::event::{Key, KeyEvent};
+use tuirealm::component::Component;
+use tuirealm::event::{Event, Key, KeyEvent, NoUserEvent};
 use tuirealm::props::{BorderType, Borders, Color, HorizontalAlignment, Title};
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
 use tuirealm::ratatui::style::Stylize;
 use tuirealm::ratatui::text::Line;
-use tuirealm::{Component, Event, MockComponent, NoUserEvent};
 
 mod utils;
 use utils::Model;

--- a/crates/tui-realm-stdlib/examples/radio.rs
+++ b/crates/tui-realm-stdlib/examples/radio.rs
@@ -3,13 +3,14 @@
 use std::error::Error;
 use std::time::Duration;
 
-use tui_realm_stdlib::Radio;
+use tui_realm_stdlib::components::Radio;
+use tuirealm::MockComponent;
 use tuirealm::application::PollStrategy;
 use tuirealm::command::{Cmd, CmdResult, Direction};
-use tuirealm::event::{Key, KeyEvent};
+use tuirealm::component::{Component, MockComponent};
+use tuirealm::event::{Event, Key, KeyEvent, NoUserEvent};
 use tuirealm::props::{BorderType, Borders, Color, HorizontalAlignment, Title};
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
-use tuirealm::{Component, Event, MockComponent, NoUserEvent};
 
 mod utils;
 use utils::Model;

--- a/crates/tui-realm-stdlib/examples/select.rs
+++ b/crates/tui-realm-stdlib/examples/select.rs
@@ -3,13 +3,15 @@
 use std::error::Error;
 use std::time::Duration;
 
-use tui_realm_stdlib::Select;
+use tui_realm_stdlib::components::Select;
+use tuirealm::MockComponent;
 use tuirealm::application::PollStrategy;
 use tuirealm::command::{Cmd, CmdResult, Direction};
-use tuirealm::event::{Key, KeyEvent};
+use tuirealm::component::{Component, MockComponent};
+use tuirealm::event::{Event, Key, KeyEvent, NoUserEvent};
 use tuirealm::props::{BorderType, Borders, Color, HorizontalAlignment, Title};
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
-use tuirealm::{Component, Event, MockComponent, NoUserEvent, State};
+use tuirealm::state::State;
 
 mod utils;
 use utils::Model;

--- a/crates/tui-realm-stdlib/examples/span.rs
+++ b/crates/tui-realm-stdlib/examples/span.rs
@@ -3,15 +3,16 @@
 use std::error::Error;
 use std::time::Duration;
 
-use tui_realm_stdlib::Span;
+use tui_realm_stdlib::components::Span;
+use tuirealm::MockComponent;
 use tuirealm::application::PollStrategy;
 use tuirealm::command::CmdResult;
-use tuirealm::event::{Key, KeyEvent};
+use tuirealm::component::Component;
+use tuirealm::event::{Event, Key, KeyEvent, NoUserEvent};
 use tuirealm::props::{Color, HorizontalAlignment, TextModifiers};
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
 use tuirealm::ratatui::style::Stylize;
 use tuirealm::ratatui::text::Span as RSpan;
-use tuirealm::{Component, Event, MockComponent, NoUserEvent};
 
 mod utils;
 use utils::Model;

--- a/crates/tui-realm-stdlib/examples/sparkline.rs
+++ b/crates/tui-realm-stdlib/examples/sparkline.rs
@@ -3,17 +3,18 @@
 use std::error::Error;
 use std::time::Duration;
 
-use tui_realm_stdlib::Sparkline;
+use tui_realm_stdlib::components::Sparkline;
+use tuirealm::MockComponent;
 use tuirealm::application::PollStrategy;
 use tuirealm::command::CmdResult;
-use tuirealm::event::{Key, KeyEvent};
+use tuirealm::component::{Component, MockComponent};
+use tuirealm::event::{Event, Key, KeyEvent};
 use tuirealm::listener::{Poll, PortResult, SyncPort};
 use tuirealm::props::{
     AttrValue, Attribute, BorderType, Borders, Color, HorizontalAlignment, PropPayload, PropValue,
     Title,
 };
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
-use tuirealm::{Component, Event, MockComponent};
 
 mod utils;
 use utils::{DataGen, Model};

--- a/crates/tui-realm-stdlib/examples/spinner.rs
+++ b/crates/tui-realm-stdlib/examples/spinner.rs
@@ -3,15 +3,17 @@
 use std::error::Error;
 use std::time::Duration;
 
-use tui_realm_stdlib::{Span, Spinner};
+use tui_realm_stdlib::components::{Span, Spinner};
+use tuirealm::MockComponent;
 use tuirealm::application::PollStrategy;
 use tuirealm::command::CmdResult;
-use tuirealm::event::{Key, KeyEvent};
+use tuirealm::component::Component;
+use tuirealm::event::{Event, Key, KeyEvent, NoUserEvent};
 use tuirealm::props::{Color, HorizontalAlignment, TextModifiers};
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
 use tuirealm::ratatui::style::Stylize;
 use tuirealm::ratatui::text::Span as RSpan;
-use tuirealm::{Component, Event, MockComponent, NoUserEvent, Sub, SubClause, SubEventClause};
+use tuirealm::subscription::{EventClause, Sub, SubClause};
 
 mod utils;
 use utils::Model;
@@ -89,7 +91,7 @@ impl Model<Id, Msg> {
         self.app.mount(
             Id::SpinnerAlfa,
             Box::new(SpinnerAlfa::default()),
-            vec![Sub::new(SubEventClause::Tick, SubClause::Always)],
+            vec![Sub::new(EventClause::Tick, SubClause::Always)],
         )?;
         self.app
             .mount(Id::SpinnerBeta, Box::new(SpinnerBeta::default()), vec![])?;

--- a/crates/tui-realm-stdlib/examples/table.rs
+++ b/crates/tui-realm-stdlib/examples/table.rs
@@ -3,14 +3,15 @@
 use std::error::Error;
 use std::time::Duration;
 
-use tui_realm_stdlib::Table;
+use tui_realm_stdlib::components::Table;
+use tuirealm::MockComponent;
 use tuirealm::application::PollStrategy;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
-use tuirealm::event::{Key, KeyEvent};
+use tuirealm::component::{Component, MockComponent};
+use tuirealm::event::{Event, Key, KeyEvent, NoUserEvent};
 use tuirealm::props::{BorderType, Borders, Color, HorizontalAlignment, TableBuilder, Title};
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
 use tuirealm::ratatui::text::Line;
-use tuirealm::{Component, Event, MockComponent, NoUserEvent};
 
 mod utils;
 use utils::Model;

--- a/crates/tui-realm-stdlib/examples/textarea.rs
+++ b/crates/tui-realm-stdlib/examples/textarea.rs
@@ -3,15 +3,16 @@
 use std::error::Error;
 use std::time::Duration;
 
-use tui_realm_stdlib::Textarea;
+use tui_realm_stdlib::components::Textarea;
+use tuirealm::MockComponent;
 use tuirealm::application::PollStrategy;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
-use tuirealm::event::{Key, KeyEvent};
+use tuirealm::component::{Component, MockComponent};
+use tuirealm::event::{Event, Key, KeyEvent, NoUserEvent};
 use tuirealm::props::{BorderType, Borders, Color, HorizontalAlignment, Title};
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
 use tuirealm::ratatui::style::Stylize;
 use tuirealm::ratatui::text::Span;
-use tuirealm::{Component, Event, MockComponent, NoUserEvent};
 
 mod utils;
 use utils::Model;

--- a/crates/tui-realm-stdlib/examples/utils/model.rs
+++ b/crates/tui-realm-stdlib/examples/utils/model.rs
@@ -2,9 +2,10 @@ use std::error::Error;
 use std::hash::Hash;
 use std::time::Duration;
 
-use tuirealm::listener::SyncPort;
+use tuirealm::application::Application;
+use tuirealm::event::NoUserEvent;
+use tuirealm::listener::{EventListenerCfg, SyncPort};
 use tuirealm::terminal::{CrosstermTerminalAdapter, TerminalAdapter, TerminalResult};
-use tuirealm::{Application, EventListenerCfg, NoUserEvent};
 
 /// The main model that stores the global state of the application.
 pub struct Model<Id, Msg, UserEvent = NoUserEvent>

--- a/crates/tui-realm-stdlib/src/components/bar_chart.rs
+++ b/crates/tui-realm-stdlib/src/components/bar_chart.rs
@@ -3,13 +3,15 @@
 use std::collections::LinkedList;
 
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
+use tuirealm::component::MockComponent;
 use tuirealm::props::{
     AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style, TextModifiers,
     Title,
 };
+use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
 use tuirealm::ratatui::widgets::BarChart as TuiBarChart;
-use tuirealm::{Frame, MockComponent, State};
+use tuirealm::state::State;
 
 use super::props::{
     BAR_CHART_BARS_GAP, BAR_CHART_BARS_STYLE, BAR_CHART_LABEL_STYLE, BAR_CHART_MAX_BARS,

--- a/crates/tui-realm-stdlib/src/components/canvas.rs
+++ b/crates/tui-realm-stdlib/src/components/canvas.rs
@@ -1,15 +1,17 @@
 //! A canvas where you can draw more complex figures.
 
 use tuirealm::command::{Cmd, CmdResult};
+use tuirealm::component::MockComponent;
 use tuirealm::props::{
     AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Shape, Style,
     TextModifiers, Title,
 };
+use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
 use tuirealm::ratatui::symbols::Marker;
 use tuirealm::ratatui::text::{Line as Spans, Span};
 use tuirealm::ratatui::widgets::canvas::{Canvas as TuiCanvas, Context, Points};
-use tuirealm::{Frame, MockComponent, State};
+use tuirealm::state::State;
 
 // -- Props
 use super::props::{

--- a/crates/tui-realm-stdlib/src/components/chart/chart.rs
+++ b/crates/tui-realm-stdlib/src/components/chart/chart.rs
@@ -3,22 +3,24 @@
 use std::any::Any;
 
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
+use tuirealm::component::MockComponent;
 use tuirealm::props::{
     AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style, TextModifiers,
     Title,
 };
+use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
 use tuirealm::ratatui::text::{Line, Span};
 use tuirealm::ratatui::widgets::{Axis, Chart as TuiChart, Dataset as TuiDataset};
-use tuirealm::{Frame, MockComponent, State};
+use tuirealm::state::State;
 
 // -- Props
 use super::dataset::ChartDataset;
-use crate::prop_ext::CommonProps;
-use crate::props::{
+use crate::components::props::{
     CHART_X_BOUNDS, CHART_X_LABELS, CHART_X_STYLE, CHART_X_TITLE, CHART_Y_BOUNDS, CHART_Y_LABELS,
     CHART_Y_STYLE, CHART_Y_TITLE,
 };
+use crate::prop_ext::CommonProps;
 
 /// The state that needs to be kepts for the [`Chart`] component.
 #[derive(Default)]

--- a/crates/tui-realm-stdlib/src/components/checkbox.rs
+++ b/crates/tui-realm-stdlib/src/components/checkbox.rs
@@ -24,14 +24,16 @@
  * SOFTWARE.
  */
 use tuirealm::command::{Cmd, CmdResult, Direction};
+use tuirealm::component::MockComponent;
 use tuirealm::props::{
     AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style, TextModifiers,
     Title,
 };
+use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
 use tuirealm::ratatui::text::{Line as Spans, Span};
 use tuirealm::ratatui::widgets::Tabs;
-use tuirealm::{Frame, MockComponent, State, StateValue};
+use tuirealm::state::{State, StateValue};
 
 use crate::prop_ext::CommonProps;
 

--- a/crates/tui-realm-stdlib/src/components/container.rs
+++ b/crates/tui-realm-stdlib/src/components/container.rs
@@ -1,11 +1,13 @@
 //! `Container` represents an empty container where you can put other components into it.
 
 use tuirealm::command::{Cmd, CmdResult};
+use tuirealm::component::MockComponent;
 use tuirealm::props::{
     AttrValue, Attribute, Borders, Color, Layout, Props, Style, TextModifiers, Title,
 };
+use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
-use tuirealm::{Frame, MockComponent, State};
+use tuirealm::state::State;
 
 use crate::prop_ext::CommonProps;
 

--- a/crates/tui-realm-stdlib/src/components/gauge.rs
+++ b/crates/tui-realm-stdlib/src/components/gauge.rs
@@ -1,13 +1,15 @@
 //! `ProgressBar` provides a component which shows the progress. It is possible to set the style for the progress bar and the text shown above it.
 
 use tuirealm::command::{Cmd, CmdResult};
+use tuirealm::component::MockComponent;
 use tuirealm::props::{
     AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style, TextModifiers,
     Title,
 };
+use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
 use tuirealm::ratatui::widgets::Gauge as TuiGauge;
-use tuirealm::{Frame, MockComponent, State};
+use tuirealm::state::State;
 
 use crate::prop_ext::CommonProps;
 

--- a/crates/tui-realm-stdlib/src/components/input.rs
+++ b/crates/tui-realm-stdlib/src/components/input.rs
@@ -2,12 +2,14 @@
 //! and handles input events related to cursor position, backspace, canc, ...
 
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
+use tuirealm::component::MockComponent;
 use tuirealm::props::{
     AttrValue, Attribute, Borders, Color, InputType, Props, Style, TextModifiers, Title,
 };
+use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
 use tuirealm::ratatui::widgets::Paragraph;
-use tuirealm::{Frame, MockComponent, State, StateValue};
+use tuirealm::state::{State, StateValue};
 
 use super::props::{INPUT_INVALID_STYLE, INPUT_PLACEHOLDER, INPUT_PLACEHOLDER_STYLE};
 use crate::prop_ext::CommonProps;

--- a/crates/tui-realm-stdlib/src/components/label.rs
+++ b/crates/tui-realm-stdlib/src/components/label.rs
@@ -1,10 +1,12 @@
 use tuirealm::command::{Cmd, CmdResult};
+use tuirealm::component::MockComponent;
 use tuirealm::props::{
     AttrValue, Attribute, Color, HorizontalAlignment, Props, Style, TextModifiers,
 };
+use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
 use tuirealm::ratatui::widgets::Paragraph;
-use tuirealm::{Frame, MockComponent, State};
+use tuirealm::state::State;
 
 use crate::prop_ext::CommonProps;
 

--- a/crates/tui-realm-stdlib/src/components/line_gauge.rs
+++ b/crates/tui-realm-stdlib/src/components/line_gauge.rs
@@ -1,12 +1,14 @@
 use tuirealm::command::{Cmd, CmdResult};
+use tuirealm::component::MockComponent;
 use tuirealm::props::{
     AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, SpanStatic, Style,
     TextModifiers, Title,
 };
+use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
 use tuirealm::ratatui::text::Span;
 use tuirealm::ratatui::widgets::LineGauge as TuiLineGauge;
-use tuirealm::{Frame, MockComponent, State};
+use tuirealm::state::State;
 
 use crate::prop_ext::CommonProps;
 

--- a/crates/tui-realm-stdlib/src/components/list.rs
+++ b/crates/tui-realm-stdlib/src/components/list.rs
@@ -1,13 +1,15 @@
 //! `List` represents a read-only textual list component which can be scrollable through arrows or inactive.
 
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
+use tuirealm::component::MockComponent;
 use tuirealm::props::{
     AttrValue, Attribute, Borders, Color, LineStatic, PropPayload, PropValue, Props, Style,
     TextModifiers, Title,
 };
+use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
 use tuirealm::ratatui::widgets::{List as TuiList, ListItem, ListState};
-use tuirealm::{Frame, MockComponent, State, StateValue};
+use tuirealm::state::{State, StateValue};
 
 use crate::prop_ext::CommonProps;
 use crate::utils::{self, borrow_clone_line};

--- a/crates/tui-realm-stdlib/src/components/paragraph.rs
+++ b/crates/tui-realm-stdlib/src/components/paragraph.rs
@@ -1,11 +1,13 @@
 use tuirealm::command::{Cmd, CmdResult};
+use tuirealm::component::MockComponent;
 use tuirealm::props::{
     AttrValue, Attribute, Borders, Color, HorizontalAlignment, Props, Style, TextModifiers,
     TextStatic, Title,
 };
+use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
 use tuirealm::ratatui::widgets::{Paragraph as TuiParagraph, Wrap};
-use tuirealm::{Frame, MockComponent, State};
+use tuirealm::state::State;
 
 use crate::prop_ext::CommonProps;
 use crate::utils;

--- a/crates/tui-realm-stdlib/src/components/phantom.rs
+++ b/crates/tui-realm-stdlib/src/components/phantom.rs
@@ -1,7 +1,9 @@
 use tuirealm::command::{Cmd, CmdResult};
+use tuirealm::component::MockComponent;
 use tuirealm::props::{AttrValue, Attribute, Props};
+use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
-use tuirealm::{Frame, MockComponent, State};
+use tuirealm::state::State;
 
 /// [`Phantom`] is a component which is not rendered. It's only purpose is to become a global listener in a tui-realm application
 /// for some kind of events using subscriptions.

--- a/crates/tui-realm-stdlib/src/components/radio.rs
+++ b/crates/tui-realm-stdlib/src/components/radio.rs
@@ -24,14 +24,16 @@
  * SOFTWARE.
  */
 use tuirealm::command::{Cmd, CmdResult, Direction};
+use tuirealm::component::MockComponent;
 use tuirealm::props::{
     AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style, TextModifiers,
     Title,
 };
+use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
 use tuirealm::ratatui::text::Line as Spans;
 use tuirealm::ratatui::widgets::Tabs;
-use tuirealm::{Frame, MockComponent, State, StateValue};
+use tuirealm::state::{State, StateValue};
 
 use crate::prop_ext::CommonProps;
 

--- a/crates/tui-realm-stdlib/src/components/select.rs
+++ b/crates/tui-realm-stdlib/src/components/select.rs
@@ -2,14 +2,16 @@
 //! you want to display other options when opened (at least 3).
 
 use tuirealm::command::{Cmd, CmdResult, Direction};
+use tuirealm::component::MockComponent;
 use tuirealm::props::{
     AttrValue, Attribute, Borders, Color, LineStatic, PropPayload, PropValue, Props, Style,
     TextModifiers, Title,
 };
+use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout, Rect};
 use tuirealm::ratatui::text::Line as Spans;
 use tuirealm::ratatui::widgets::{List, ListItem, ListState, Paragraph};
-use tuirealm::{Frame, MockComponent, State, StateValue};
+use tuirealm::state::{State, StateValue};
 
 use crate::prop_ext::CommonProps;
 use crate::utils::borrow_clone_line;

--- a/crates/tui-realm-stdlib/src/components/span.rs
+++ b/crates/tui-realm-stdlib/src/components/span.rs
@@ -1,12 +1,14 @@
 use tuirealm::command::{Cmd, CmdResult};
+use tuirealm::component::MockComponent;
 use tuirealm::props::{
     AttrValue, Attribute, Color, HorizontalAlignment, PropPayload, PropValue, Props, SpanStatic,
     Style, TextModifiers,
 };
+use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
 use tuirealm::ratatui::text::{Line, Span as RSpan, Text};
 use tuirealm::ratatui::widgets::Paragraph;
-use tuirealm::{Frame, MockComponent, State};
+use tuirealm::state::State;
 
 use crate::prop_ext::CommonProps;
 use crate::utils;

--- a/crates/tui-realm-stdlib/src/components/sparkline.rs
+++ b/crates/tui-realm-stdlib/src/components/sparkline.rs
@@ -1,12 +1,14 @@
 //! A sparkline over more lines.
 
 use tuirealm::command::{Cmd, CmdResult};
+use tuirealm::component::MockComponent;
 use tuirealm::props::{
     AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style, Title,
 };
+use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
 use tuirealm::ratatui::widgets::Sparkline as TuiSparkline;
-use tuirealm::{Frame, MockComponent, State};
+use tuirealm::state::State;
 
 use crate::prop_ext::CommonProps;
 

--- a/crates/tui-realm-stdlib/src/components/spinner.rs
+++ b/crates/tui-realm-stdlib/src/components/spinner.rs
@@ -1,10 +1,12 @@
 //! A loading spinner. You can provide the "spinning sequence". At each `view()` call, the sequence step is increased
 
 use tuirealm::command::{Cmd, CmdResult};
+use tuirealm::component::MockComponent;
 use tuirealm::props::{AttrValue, Attribute, Color, HorizontalAlignment, Props, Style};
+use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
 use tuirealm::ratatui::widgets::Paragraph;
-use tuirealm::{Frame, MockComponent, State};
+use tuirealm::state::State;
 
 use crate::prop_ext::CommonProps;
 

--- a/crates/tui-realm-stdlib/src/components/table.rs
+++ b/crates/tui-realm-stdlib/src/components/table.rs
@@ -3,14 +3,16 @@
 use std::cmp::max;
 
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
+use tuirealm::component::MockComponent;
 use tuirealm::props::{
     AttrValue, Attribute, Borders, Color, LineStatic, PropPayload, PropValue, Props, Style,
     Table as PropTable, TextModifiers, Title,
 };
+use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::{Constraint, Rect};
 use tuirealm::ratatui::text::Line;
 use tuirealm::ratatui::widgets::{Cell, Row, Table as TuiTable, TableState};
-use tuirealm::{Frame, MockComponent, State, StateValue};
+use tuirealm::state::{State, StateValue};
 
 use super::props::TABLE_COLUMN_SPACING;
 use crate::prop_ext::CommonProps;

--- a/crates/tui-realm-stdlib/src/components/textarea.rs
+++ b/crates/tui-realm-stdlib/src/components/textarea.rs
@@ -1,11 +1,13 @@
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
+use tuirealm::component::MockComponent;
 use tuirealm::props::{
     AttrValue, Attribute, Borders, Color, LineStatic, PropPayload, PropValue, Props, SpanStatic,
     Style, TextModifiers, Title,
 };
+use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
 use tuirealm::ratatui::widgets::{List, ListItem, ListState};
-use tuirealm::{Frame, MockComponent, State};
+use tuirealm::state::State;
 
 use crate::prop_ext::CommonProps;
 use crate::utils::borrow_clone_line;

--- a/crates/tui-realm-stdlib/src/lib.rs
+++ b/crates/tui-realm-stdlib/src/lib.rs
@@ -21,8 +21,6 @@
     html_logo_url = "https://raw.githubusercontent.com/veeso/tui-realm-stdlib/main/docs/images/cargo/tui-realm-512.png"
 )]
 
-mod components;
+pub mod components;
 pub mod prop_ext;
 pub mod utils;
-
-pub use components::{props, *};

--- a/crates/tui-realm-stdlib/src/prop_ext.rs
+++ b/crates/tui-realm-stdlib/src/prop_ext.rs
@@ -1,8 +1,7 @@
 //! Extra extensions to handle Properties.
 
-use tuirealm::props::{Borders, Style, Title};
+use tuirealm::props::{AttrValue, Attribute, Borders, Style, Title};
 use tuirealm::ratatui::widgets::Block;
-use tuirealm::{AttrValue, Attribute};
 
 /// Prop Store for very common props.
 ///
@@ -116,11 +115,10 @@ impl CommonProps {
 mod tests {
     use pretty_assertions::assert_eq;
     use tuirealm::props::{
-        BorderSides, BorderType, Borders, Color, HorizontalAlignment, LineStatic, Style,
-        TextModifiers, Title,
+        AttrValue, Attribute, BorderSides, BorderType, Borders, Color, HorizontalAlignment,
+        LineStatic, Style, TextModifiers, Title,
     };
     use tuirealm::ratatui::widgets::{Block, TitlePosition};
-    use tuirealm::{AttrValue, Attribute};
 
     use crate::prop_ext::CommonProps;
 

--- a/crates/tuirealm/examples/arbitrary_data.rs
+++ b/crates/tuirealm/examples/arbitrary_data.rs
@@ -7,16 +7,21 @@
 
 use std::time::Duration;
 
+use tuirealm::MockComponent;
+use tuirealm::application::{Application, PollStrategy};
 use tuirealm::command::{Cmd, CmdResult};
-use tuirealm::event::{Key, KeyEvent};
-use tuirealm::props::{Color, HorizontalAlignment, PropBound, PropPayload, Style, TextModifiers};
+use tuirealm::component::{Component, MockComponent};
+use tuirealm::event::{Event, Key, KeyEvent, NoUserEvent};
+use tuirealm::listener::EventListenerCfg;
+use tuirealm::props::{
+    AttrValue, Attribute, Color, HorizontalAlignment, PropBound, PropPayload, Props, Style,
+    TextModifiers,
+};
+use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::{Constraint, Direction, Layout, Rect};
 use tuirealm::ratatui::widgets::Paragraph;
+use tuirealm::state::State;
 use tuirealm::terminal::{CrosstermTerminalAdapter, TerminalAdapter, TerminalResult};
-use tuirealm::{
-    Application, AttrValue, Attribute, Component, Event, EventListenerCfg, Frame, MockComponent,
-    NoUserEvent, PollStrategy, Props, State,
-};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let event_listener =

--- a/crates/tuirealm/examples/async_ports.rs
+++ b/crates/tuirealm/examples/async_ports.rs
@@ -4,17 +4,20 @@ use std::time::Duration;
 use tempfile::NamedTempFile;
 use tokio::io::AsyncWriteExt as _;
 use tokio::runtime::Handle;
+use tuirealm::application::{Application, PollStrategy};
 use tuirealm::command::{Cmd, CmdResult};
-use tuirealm::event::{Key, KeyEvent};
-use tuirealm::listener::{PollAsync, PortResult};
-use tuirealm::props::{Color, HorizontalAlignment, Style, TextModifiers};
+use tuirealm::component::{Component, MockComponent};
+use tuirealm::event::{Event, Key, KeyEvent};
+use tuirealm::listener::{EventListenerCfg, PollAsync, PortResult};
+use tuirealm::props::{
+    AttrValue, Attribute, Color, HorizontalAlignment, Props, Style, TextModifiers,
+};
+use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::{Constraint, Direction, Layout, Rect};
 use tuirealm::ratatui::widgets::Paragraph;
+use tuirealm::state::State;
+use tuirealm::subscription::{EventClause as SubEventClause, Sub, SubClause};
 use tuirealm::terminal::{CrosstermTerminalAdapter, TerminalAdapter, TerminalResult};
-use tuirealm::{
-    Application, AttrValue, Attribute, Component, Event, EventListenerCfg, Frame, MockComponent,
-    PollStrategy, Props, State, Sub, SubClause, SubEventClause,
-};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/tuirealm/examples/demo/app/model.rs
+++ b/crates/tuirealm/examples/demo/app/model.rs
@@ -5,13 +5,13 @@
 use std::error::Error;
 use std::time::{Duration, SystemTime};
 
+use tuirealm::application::Application;
 use tuirealm::event::NoUserEvent;
-use tuirealm::props::{Color, HorizontalAlignment, TextModifiers};
+use tuirealm::listener::EventListenerCfg;
+use tuirealm::props::{AttrValue, Attribute, Color, HorizontalAlignment, TextModifiers};
 use tuirealm::ratatui::layout::{Constraint, Direction, Layout};
+use tuirealm::subscription::{EventClause as SubEventClause, Sub, SubClause};
 use tuirealm::terminal::{CrosstermTerminalAdapter, TerminalAdapter, TerminalResult};
-use tuirealm::{
-    Application, AttrValue, Attribute, EventListenerCfg, Sub, SubClause, SubEventClause,
-};
 
 use super::components::{Clock, DigitCounter, Label, LetterCounter};
 use super::{Id, Msg};

--- a/crates/tuirealm/examples/demo/components/clock.rs
+++ b/crates/tuirealm/examples/demo/components/clock.rs
@@ -6,11 +6,12 @@ use std::ops::Add;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use tuirealm::command::{Cmd, CmdResult};
-use tuirealm::props::{Color, HorizontalAlignment, TextModifiers};
+use tuirealm::component::{Component, MockComponent};
+use tuirealm::event::{Event, NoUserEvent};
+use tuirealm::props::{AttrValue, Attribute, Color, HorizontalAlignment, TextModifiers};
+use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
-use tuirealm::{
-    AttrValue, Attribute, Component, Event, Frame, MockComponent, NoUserEvent, State, StateValue,
-};
+use tuirealm::state::{State, StateValue};
 
 use super::{Label, Msg};
 

--- a/crates/tuirealm/examples/demo/components/counter.rs
+++ b/crates/tuirealm/examples/demo/components/counter.rs
@@ -2,17 +2,18 @@
 //!
 //! label component
 
+use tuirealm::MockComponent;
 use tuirealm::command::{Cmd, CmdResult};
-use tuirealm::event::{Key, KeyEvent, KeyModifiers};
+use tuirealm::component::{Component, MockComponent};
+use tuirealm::event::{Event, Key, KeyEvent, KeyModifiers, NoUserEvent};
 use tuirealm::props::{
-    Borders, Color, HorizontalAlignment, LineStatic, Style, TextModifiers, Title,
+    AttrValue, Attribute, Borders, Color, HorizontalAlignment, LineStatic, Props, Style,
+    TextModifiers, Title,
 };
+use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
 use tuirealm::ratatui::widgets::{BorderType, Paragraph};
-use tuirealm::{
-    AttrValue, Attribute, Component, Event, Frame, MockComponent, NoUserEvent, Props, State,
-    StateValue,
-};
+use tuirealm::state::{State, StateValue};
 
 use super::{Msg, get_block};
 

--- a/crates/tuirealm/examples/demo/components/label.rs
+++ b/crates/tuirealm/examples/demo/components/label.rs
@@ -3,12 +3,15 @@
 //! label component
 
 use tuirealm::command::{Cmd, CmdResult};
-use tuirealm::props::{Color, HorizontalAlignment, Style, TextModifiers};
+use tuirealm::component::{Component, MockComponent};
+use tuirealm::event::{Event, NoUserEvent};
+use tuirealm::props::{
+    AttrValue, Attribute, Color, HorizontalAlignment, Props, Style, TextModifiers,
+};
+use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
 use tuirealm::ratatui::widgets::Paragraph;
-use tuirealm::{
-    AttrValue, Attribute, Component, Event, Frame, MockComponent, NoUserEvent, Props, State,
-};
+use tuirealm::state::State;
 
 use super::Msg;
 

--- a/crates/tuirealm/examples/demo/demo.rs
+++ b/crates/tuirealm/examples/demo/demo.rs
@@ -7,7 +7,7 @@ extern crate tuirealm;
 use std::time::Duration;
 
 use tuirealm::application::PollStrategy;
-use tuirealm::{AttrValue, Attribute};
+use tuirealm::props::{AttrValue, Attribute};
 // -- internal
 mod app;
 mod components;

--- a/crates/tuirealm/examples/event_display.rs
+++ b/crates/tuirealm/examples/event_display.rs
@@ -1,14 +1,16 @@
 use std::time::Duration;
 
+use tuirealm::application::{Application, PollStrategy};
 use tuirealm::command::{Cmd, CmdResult};
-use tuirealm::event::{Key, KeyEvent};
+use tuirealm::component::{Component, MockComponent};
+use tuirealm::event::{Event, Key, KeyEvent};
+use tuirealm::listener::EventListenerCfg;
+use tuirealm::props::{AttrValue, Attribute};
+use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::{Constraint, Direction, Layout, Rect};
 use tuirealm::ratatui::widgets::Paragraph;
+use tuirealm::state::State;
 use tuirealm::terminal::{CrosstermTerminalAdapter, TerminalAdapter, TerminalResult};
-use tuirealm::{
-    Application, AttrValue, Attribute, Component, Event, EventListenerCfg, Frame, MockComponent,
-    PollStrategy, State,
-};
 
 // /// Enable the crossterm-async event listener.
 // ///

--- a/crates/tuirealm/examples/inline_display.rs
+++ b/crates/tuirealm/examples/inline_display.rs
@@ -1,16 +1,17 @@
 use std::time::Duration;
 
+use tuirealm::application::{Application, PollStrategy};
 use tuirealm::command::{Cmd, CmdResult};
-use tuirealm::event::{Key, KeyEvent};
+use tuirealm::component::{Component, MockComponent};
+use tuirealm::event::{Event, Key, KeyEvent, NoUserEvent};
+use tuirealm::listener::EventListenerCfg;
+use tuirealm::props::{AttrValue, Attribute};
 use tuirealm::ratatui::layout::{Constraint, Direction, Layout, Rect};
 use tuirealm::ratatui::style::{Color, Style};
 use tuirealm::ratatui::widgets::{LineGauge, Paragraph};
-use tuirealm::ratatui::{TerminalOptions, Viewport};
+use tuirealm::ratatui::{Frame, TerminalOptions, Viewport};
+use tuirealm::state::State;
 use tuirealm::terminal::{CrosstermTerminalAdapter, TerminalAdapter};
-use tuirealm::{
-    Application, AttrValue, Attribute, Component, Event, EventListenerCfg, Frame, MockComponent,
-    NoUserEvent, PollStrategy, State,
-};
 
 /// This Example Showcases tui-realm can be used Inline too
 ///

--- a/crates/tuirealm/examples/user_events/components/label.rs
+++ b/crates/tuirealm/examples/user_events/components/label.rs
@@ -5,11 +5,15 @@
 use std::time::UNIX_EPOCH;
 
 use tuirealm::command::{Cmd, CmdResult};
-use tuirealm::event::{Key, KeyEvent};
-use tuirealm::props::{Color, HorizontalAlignment, Style, TextModifiers};
+use tuirealm::component::{Component, MockComponent};
+use tuirealm::event::{Event, Key, KeyEvent};
+use tuirealm::props::{
+    AttrValue, Attribute, Color, HorizontalAlignment, Props, Style, TextModifiers,
+};
+use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
 use tuirealm::ratatui::widgets::Paragraph;
-use tuirealm::{AttrValue, Attribute, Component, Event, Frame, MockComponent, Props, State};
+use tuirealm::state::State;
 
 use super::{Msg, UserEvent};
 

--- a/crates/tuirealm/examples/user_events/model.rs
+++ b/crates/tuirealm/examples/user_events/model.rs
@@ -2,7 +2,7 @@
 //!
 //! app model
 
-use tuirealm::Application;
+use tuirealm::application::Application;
 use tuirealm::ratatui::layout::{Constraint, Direction, Layout};
 use tuirealm::terminal::{CrosstermTerminalAdapter, TerminalAdapter, TerminalResult};
 

--- a/crates/tuirealm/examples/user_events/user_events.rs
+++ b/crates/tuirealm/examples/user_events/user_events.rs
@@ -4,10 +4,10 @@ mod model;
 use std::time::{Duration, SystemTime};
 
 use components::Label;
-use tuirealm::listener::{Poll, PortResult};
-use tuirealm::{
-    Application, Event, EventListenerCfg, PollStrategy, Sub, SubClause, SubEventClause,
-};
+use tuirealm::application::{Application, PollStrategy};
+use tuirealm::event::Event;
+use tuirealm::listener::{EventListenerCfg, Poll, PortResult};
+use tuirealm::subscription::{EventClause as SubEventClause, Sub, SubClause};
 
 use crate::model::Model;
 

--- a/crates/tuirealm/src/core/application.rs
+++ b/crates/tuirealm/src/core/application.rs
@@ -6,12 +6,16 @@ use std::time::{Duration, Instant};
 use ratatui::Frame;
 use thiserror::Error;
 
-use super::{Subscription, View, WrappedComponent};
+use super::component::Component;
+use super::event::Event;
+use super::injector::Injector;
+use super::props::{AttrValue, Attribute};
+use super::state::State;
+use super::subscription::{EventClause, Sub};
+use super::view::{View, ViewError};
+use super::{Subscription, WrappedComponent};
 use crate::listener::{EventListener, EventListenerCfg, ListenerError, PollError};
 use crate::ratatui::layout::Rect;
-use crate::{
-    AttrValue, Attribute, Component, Event, Injector, State, Sub, SubEventClause, ViewError,
-};
 
 /// Result retuned by [`Application`] functions.
 pub type ApplicationResult<T> = Result<T, ApplicationError>;
@@ -262,7 +266,7 @@ where
     pub fn unsubscribe(
         &mut self,
         id: &ComponentId,
-        ev: SubEventClause<UserEvent>,
+        ev: EventClause<UserEvent>,
     ) -> ApplicationResult<()> {
         if !self.view.mounted(id) {
             return Err(ViewError::ComponentNotFound.into());
@@ -293,7 +297,7 @@ where
     }
 
     /// Returns whether component `id` is subscribed to event described by `clause`
-    fn subscribed(&self, id: &ComponentId, clause: &SubEventClause<UserEvent>) -> bool {
+    fn subscribed(&self, id: &ComponentId, clause: &EventClause<UserEvent>) -> bool {
         self.subs
             .iter()
             .any(|s| s.target() == id && s.event() == clause)
@@ -494,7 +498,8 @@ mod test {
     use crate::mock::{
         MockBarInput, MockComponentId, MockEvent, MockFooInput, MockInjector, MockMsg, MockPoll,
     };
-    use crate::{StateValue, SubClause};
+    use crate::state::StateValue;
+    use crate::subscription::SubClause;
 
     /// Create a common Application with Tick that is configured to only happen once (high interval) and have the lister have a test barrier
     fn create_app_tick_once_barrier()
@@ -628,9 +633,9 @@ mod test {
                     MockComponentId::InputFoo,
                     Box::new(MockFooInput::default()),
                     vec![
-                        Sub::new(SubEventClause::Tick, SubClause::Always),
+                        Sub::new(EventClause::Tick, SubClause::Always),
                         Sub::new(
-                            SubEventClause::Tick,
+                            EventClause::Tick,
                             SubClause::HasAttrValue(
                                 MockComponentId::InputFoo,
                                 Attribute::InputLength,
@@ -638,7 +643,7 @@ mod test {
                             )
                         ), // NOTE: This event will be ignored
                         Sub::new(
-                            SubEventClause::User(MockEvent::Bar),
+                            EventClause::User(MockEvent::Bar),
                             SubClause::HasAttrValue(
                                 MockComponentId::InputFoo,
                                 Attribute::Focus,
@@ -656,7 +661,7 @@ mod test {
                 .subscribe(
                     &MockComponentId::InputFoo,
                     Sub::new(
-                        SubEventClause::User(MockEvent::Foo),
+                        EventClause::User(MockEvent::Foo),
                         SubClause::HasAttrValue(
                             MockComponentId::InputFoo,
                             Attribute::Focus,
@@ -673,7 +678,7 @@ mod test {
                 .subscribe(
                     &MockComponentId::InputFoo,
                     Sub::new(
-                        SubEventClause::User(MockEvent::Foo),
+                        EventClause::User(MockEvent::Foo),
                         SubClause::HasAttrValue(
                             MockComponentId::InputFoo,
                             Attribute::Focus,
@@ -689,7 +694,7 @@ mod test {
                 .subscribe(
                     &MockComponentId::InputBar,
                     Sub::new(
-                        SubEventClause::User(MockEvent::Foo),
+                        EventClause::User(MockEvent::Foo),
                         SubClause::HasAttrValue(
                             MockComponentId::InputBar,
                             Attribute::Focus,
@@ -704,7 +709,7 @@ mod test {
             application
                 .unsubscribe(
                     &MockComponentId::InputFoo,
-                    SubEventClause::User(MockEvent::Foo)
+                    EventClause::User(MockEvent::Foo)
                 )
                 .is_ok()
         );
@@ -713,7 +718,7 @@ mod test {
             application
                 .unsubscribe(
                     &MockComponentId::InputFoo,
-                    SubEventClause::User(MockEvent::Foo)
+                    EventClause::User(MockEvent::Foo)
                 )
                 .is_err()
         );
@@ -729,9 +734,9 @@ mod test {
                     MockComponentId::InputFoo,
                     Box::new(MockFooInput::default()),
                     vec![
-                        Sub::new(SubEventClause::Tick, SubClause::Always),
+                        Sub::new(EventClause::Tick, SubClause::Always),
                         Sub::new(
-                            SubEventClause::User(MockEvent::Bar),
+                            EventClause::User(MockEvent::Bar),
                             SubClause::HasAttrValue(
                                 MockComponentId::InputFoo,
                                 Attribute::Focus,
@@ -747,7 +752,7 @@ mod test {
                 .mount(
                     MockComponentId::InputBar,
                     Box::new(MockFooInput::default()),
-                    vec![Sub::new(SubEventClause::Any, SubClause::Always)]
+                    vec![Sub::new(EventClause::Any, SubClause::Always)]
                 )
                 .is_ok()
         );
@@ -779,10 +784,10 @@ mod test {
                     MockComponentId::InputBar,
                     Box::new(MockBarInput::default()),
                     vec![
-                        Sub::new(SubEventClause::Tick, SubClause::Always),
+                        Sub::new(EventClause::Tick, SubClause::Always),
                         Sub::new(
                             // NOTE: won't be thrown, since requires focus
-                            SubEventClause::Keyboard(KeyEvent::from(Key::Enter)),
+                            EventClause::Keyboard(KeyEvent::from(Key::Enter)),
                             SubClause::HasAttrValue(
                                 MockComponentId::InputBar,
                                 Attribute::Focus,
@@ -869,10 +874,10 @@ mod test {
                     MockComponentId::InputBar,
                     Box::new(MockBarInput::default()),
                     vec![
-                        Sub::new(SubEventClause::Tick, SubClause::Always),
+                        Sub::new(EventClause::Tick, SubClause::Always),
                         Sub::new(
                             // NOTE: won't be thrown, since requires focus
-                            SubEventClause::Keyboard(KeyEvent::from(Key::Enter)),
+                            EventClause::Keyboard(KeyEvent::from(Key::Enter)),
                             SubClause::HasAttrValue(
                                 MockComponentId::InputBar,
                                 Attribute::Focus,
@@ -923,10 +928,10 @@ mod test {
                     MockComponentId::InputBar,
                     Box::new(MockBarInput::default()),
                     vec![
-                        Sub::new(SubEventClause::Tick, SubClause::Always),
+                        Sub::new(EventClause::Tick, SubClause::Always),
                         Sub::new(
                             // NOTE: won't be thrown, since requires focus
-                            SubEventClause::Keyboard(KeyEvent::from(Key::Enter)),
+                            EventClause::Keyboard(KeyEvent::from(Key::Enter)),
                             SubClause::HasAttrValue(
                                 MockComponentId::InputBar,
                                 Attribute::Focus,
@@ -977,10 +982,10 @@ mod test {
                     MockComponentId::InputBar,
                     Box::new(MockBarInput::default()),
                     vec![
-                        Sub::new(SubEventClause::Tick, SubClause::Always),
+                        Sub::new(EventClause::Tick, SubClause::Always),
                         Sub::new(
                             // NOTE: won't be thrown, since requires focus
-                            SubEventClause::Keyboard(KeyEvent::from(Key::Enter)),
+                            EventClause::Keyboard(KeyEvent::from(Key::Enter)),
                             SubClause::HasAttrValue(
                                 MockComponentId::InputBar,
                                 Attribute::Focus,
@@ -1033,7 +1038,7 @@ mod test {
                     Box::new(MockBarInput::default()),
                     vec![Sub::new(
                         // NOTE: won't be thrown, since requires focus
-                        SubEventClause::Tick,
+                        EventClause::Tick,
                         SubClause::HasAttrValue(
                             MockComponentId::InputBar,
                             Attribute::Focus,
@@ -1078,7 +1083,7 @@ mod test {
                     MockComponentId::InputBar,
                     Box::new(MockBarInput::default()),
                     vec![Sub::new(
-                        SubEventClause::Tick,
+                        EventClause::Tick,
                         SubClause::HasAttrValue(
                             MockComponentId::InputFoo,
                             Attribute::Focus,
@@ -1123,7 +1128,7 @@ mod test {
                     MockComponentId::InputBar,
                     Box::new(MockBarInput::default()),
                     vec![Sub::new(
-                        SubEventClause::Tick,
+                        EventClause::Tick,
                         SubClause::HasState(MockComponentId::InputFoo, State::None)
                     )]
                 )
@@ -1164,7 +1169,7 @@ mod test {
                     MockComponentId::InputBar,
                     Box::new(MockBarInput::default()),
                     vec![Sub::new(
-                        SubEventClause::Tick,
+                        EventClause::Tick,
                         SubClause::HasState(
                             MockComponentId::InputFoo,
                             State::Single(StateValue::String(String::new()))
@@ -1209,7 +1214,7 @@ mod test {
                     MockComponentId::InputBar,
                     Box::new(MockBarInput::default()),
                     vec![Sub::new(
-                        SubEventClause::Tick,
+                        EventClause::Tick,
                         SubClause::IsMounted(MockComponentId::InputOmar)
                     )]
                 )
@@ -1250,7 +1255,7 @@ mod test {
                     MockComponentId::InputBar,
                     Box::new(MockBarInput::default()),
                     vec![Sub::new(
-                        SubEventClause::Tick,
+                        EventClause::Tick,
                         SubClause::IsMounted(MockComponentId::InputFoo)
                     )]
                 )
@@ -1293,7 +1298,7 @@ mod test {
                     MockComponentId::InputBar,
                     Box::new(MockBarInput::default()),
                     vec![Sub::new(
-                        SubEventClause::Tick,
+                        EventClause::Tick,
                         SubClause::IsMounted(MockComponentId::InputFoo)
                     )]
                 )

--- a/crates/tuirealm/src/core/command.rs
+++ b/crates/tuirealm/src/core/command.rs
@@ -1,7 +1,7 @@
-//! This module exposes the [`Cmd`] type, which must be used when sending commands to the [`MockComponent`](crate::MockComponent) from the
-//! [`Component`](crate::Component) after an `Event`.
+//! This module exposes the [`Cmd`] type, which must be used when sending commands to the [`MockComponent`](crate::component::MockComponent) from the
+//! [`Component`](crate::component::Component) after an `Event`.
 
-use super::State;
+use super::state::State;
 
 // -- Command
 

--- a/crates/tuirealm/src/core/component.rs
+++ b/crates/tuirealm/src/core/component.rs
@@ -4,9 +4,11 @@ use std::any::Any;
 
 use ratatui::Frame;
 
+use super::event::Event;
+use super::props::{AttrValue, Attribute};
+use super::state::State;
 use crate::command::{Cmd, CmdResult};
 use crate::ratatui::layout::Rect;
-use crate::{AttrValue, Attribute, Event, State};
 
 /// A Mock Component represents a component which defines all the properties and states it can handle and represent
 /// and the way it should be rendered. It must also define how to behave in case of a [`Cmd`] (command).

--- a/crates/tuirealm/src/core/mod.rs
+++ b/crates/tuirealm/src/core/mod.rs
@@ -2,18 +2,14 @@
 
 pub mod application;
 pub mod command;
-mod component;
+pub mod component;
 pub mod event;
 pub mod injector;
 pub mod props;
-mod state;
+pub mod state;
 pub mod subscription;
-mod view;
+pub mod view;
 
-// -- export
-pub use component::{Component, MockComponent};
-pub use state::{State, StateValue};
 // -- internal
 pub(crate) use subscription::Subscription;
 pub(crate) use view::WrappedComponent;
-pub use view::{View, ViewError};

--- a/crates/tuirealm/src/core/state.rs
+++ b/crates/tuirealm/src/core/state.rs
@@ -226,8 +226,8 @@ impl StateValue {
 
 #[cfg(test)]
 mod tests {
-    use crate::State;
     use crate::props::PropBound;
+    use crate::state::State;
 
     #[test]
     fn any() {

--- a/crates/tuirealm/src/core/subscription.rs
+++ b/crates/tuirealm/src/core/subscription.rs
@@ -4,8 +4,10 @@ use std::hash::Hash;
 use std::ops::Range;
 use std::sync::Arc;
 
+use super::event::Event;
+use super::props::{AttrValue, Attribute};
+use super::state::State;
 use crate::event::{KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
-use crate::{AttrValue, Attribute, Event, State};
 
 /// Public type to define a subscription.
 pub struct Sub<ComponentId, UserEvent>(EventClause<UserEvent>, Arc<SubClause<ComponentId>>)
@@ -387,9 +389,10 @@ mod test {
 
     use super::*;
     use crate::command::Cmd;
-    use crate::event::{Key, KeyModifiers, MouseEventKind};
+    use crate::component::MockComponent;
+    use crate::event::{Key, KeyModifiers, MouseEventKind, NoUserEvent};
     use crate::mock::{MockComponentId, MockEvent, MockFooInput};
-    use crate::{MockComponent, NoUserEvent, StateValue};
+    use crate::state::StateValue;
 
     #[test]
     fn subscription_should_forward() {

--- a/crates/tuirealm/src/core/view.rs
+++ b/crates/tuirealm/src/core/view.rs
@@ -6,8 +6,12 @@ use std::hash::Hash;
 use ratatui::Frame;
 use thiserror::Error;
 
+use super::component::Component;
+use super::event::Event;
+use super::injector::Injector;
+use super::props::{AttrValue, Attribute};
+use super::state::State;
 use crate::ratatui::layout::Rect;
-use crate::{AttrValue, Attribute, Component, Event, Injector, State};
 
 /// A boxed component. Shorthand for View components map
 pub(crate) type WrappedComponent<Msg, UserEvent> = Box<dyn Component<Msg, UserEvent>>;
@@ -324,11 +328,11 @@ mod test {
     use pretty_assertions::assert_eq;
 
     use super::*;
-    use crate::StateValue;
     use crate::event::{Key, KeyEvent};
     use crate::mock::{
         MockBarInput, MockComponentId, MockEvent, MockFooInput, MockInjector, MockInput, MockMsg,
     };
+    use crate::state::StateValue;
 
     #[test]
     fn default_view_should_be_empty() {

--- a/crates/tuirealm/src/lib.rs
+++ b/crates/tuirealm/src/lib.rs
@@ -69,27 +69,25 @@ extern crate self as tuirealm;
 extern crate tuirealm_derive;
 
 mod core;
-pub mod listener;
 mod macros;
-#[cfg(test)]
-pub mod mock;
+
+pub mod listener;
 pub mod ratatui;
 pub mod terminal;
 pub mod utils;
-// export async trait for async-ports
+
+#[cfg(test)]
+pub mod mock;
+
+// Feature re-exports (must stay at root)
 #[cfg(feature = "async-ports")]
 #[cfg_attr(docsrs, doc(cfg(feature = "async-ports")))]
 pub use async_trait::async_trait;
-pub use listener::{EventListenerCfg, ListenerError};
-// -- derive
 #[cfg(feature = "derive")]
 #[doc(hidden)]
 pub use tuirealm_derive::*;
 
-pub use self::core::application::{self, Application, ApplicationError, PollStrategy};
-pub use self::core::event::{self, Event, NoUserEvent};
-pub use self::core::injector::Injector;
-pub use self::core::props::{self, AttrValue, Attribute, Props};
-pub use self::core::subscription::{EventClause as SubEventClause, Sub, SubClause};
-pub use self::core::{Component, MockComponent, State, StateValue, ViewError, command};
-pub use self::ratatui::Frame;
+// Re-export core submodules as top-level modules
+pub use self::core::{
+    application, command, component, event, injector, props, state, subscription, view,
+};

--- a/crates/tuirealm/src/listener/async_ticker.rs
+++ b/crates/tuirealm/src/listener/async_ticker.rs
@@ -1,5 +1,5 @@
 use super::PollAsync;
-use crate::Event;
+use crate::event::Event;
 use crate::listener::PortResult;
 
 /// [`PollAsync`] implementation to have a Async-Port for emitting [`Event::Tick`].
@@ -27,8 +27,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::AsyncTicker;
+    use crate::event::{Event, NoUserEvent};
     use crate::listener::PollAsync;
-    use crate::{Event, NoUserEvent};
 
     #[tokio::test]
     async fn should_emit_tick_on_every_poll() {

--- a/crates/tuirealm/src/listener/builder.rs
+++ b/crates/tuirealm/src/listener/builder.rs
@@ -332,7 +332,7 @@ where
         self
     }
 
-    /// Change the way [`Event::Tick`](crate::Event::Tick) is emitted from being on a [`SyncPort`] to be a [`AsyncPort`].
+    /// Change the way [`Event::Tick`](crate::event::Event::Tick) is emitted from being on a [`SyncPort`] to be a [`AsyncPort`].
     #[cfg(feature = "async-ports")]
     #[cfg_attr(docsrs, doc(cfg(feature = "async-ports")))]
     pub fn async_tick(mut self, value: bool) -> Self {
@@ -416,7 +416,7 @@ mod test {
     async fn should_spawn_async_ticker() {
         use tokio::time::sleep;
 
-        use crate::Event;
+        use crate::event::Event;
 
         let builder = EventListenerCfg::<MockEvent>::default()
             .with_handle(Handle::current())

--- a/crates/tuirealm/src/listener/mod.rs
+++ b/crates/tuirealm/src/listener/mod.rs
@@ -28,7 +28,7 @@ pub use self::port::SyncPort;
 #[cfg(feature = "async-ports")]
 use self::task_pool::TaskPool;
 use self::worker::EventListenerWorker;
-use super::Event;
+use crate::event::Event;
 
 /// Result returned by `EventListener`. [`Ok`] value depends on the method, while the
 /// Err value is always [`ListenerError`].

--- a/crates/tuirealm/src/listener/port/async_p.rs
+++ b/crates/tuirealm/src/listener/port/async_p.rs
@@ -1,7 +1,7 @@
 use std::ops::Add as _;
 use std::time::{Duration, Instant};
 
-use crate::Event;
+use crate::event::Event;
 use crate::listener::{PollAsync, PortResult};
 
 /// An async port is a wrapper around the [`PollAsync`] trait object, which also defines a interval, which defines

--- a/crates/tuirealm/src/listener/port/sync.rs
+++ b/crates/tuirealm/src/listener/port/sync.rs
@@ -1,7 +1,7 @@
 use std::ops::Add as _;
 use std::time::{Duration, Instant};
 
-use crate::Event;
+use crate::event::Event;
 use crate::listener::{Poll, PortResult};
 
 /// A port is a wrapper around the [`Poll`] trait object, which also defines a interval, which defines

--- a/crates/tuirealm/src/listener/worker.rs
+++ b/crates/tuirealm/src/listener/worker.rs
@@ -33,8 +33,8 @@ where
 {
     /// Create a new Worker.
     ///
-    /// If `tick_interval` is [`None`], no [`Event::Tick`](crate::Event::Tick) will be sent and a fallback interval time will be used.
-    /// If `tick_interval` is [`Some`], [`Event::Tick`](crate::Event::Tick) will be sent and be used as the interval time.
+    /// If `tick_interval` is [`None`], no [`Event::Tick`](crate::event::Event::Tick) will be sent and a fallback interval time will be used.
+    /// If `tick_interval` is [`Some`], [`Event::Tick`](crate::event::Event::Tick) will be sent and be used as the interval time.
     pub(super) fn new(
         ports: Vec<SyncPort<UserEvent>>,
         sender: mpsc::Sender<ListenerMsg<UserEvent>>,
@@ -115,7 +115,8 @@ where
     /// Send tick to listener and calc next tick
     fn send_tick(&mut self) -> Result<(), mpsc::SendError<ListenerMsg<UserEvent>>> {
         // Send tick
-        self.sender.send(ListenerMsg::User(crate::Event::Tick))?;
+        self.sender
+            .send(ListenerMsg::User(crate::event::Event::Tick))?;
         // Calc next tick
         self.calc_next_tick();
         Ok(())
@@ -219,9 +220,9 @@ mod test {
 
     use super::*;
     use crate::core::event::{Key, KeyEvent};
+    use crate::event::{Event, NoUserEvent};
     use crate::listener::{Poll, PollError, PollResult, SyncPort};
     use crate::mock::{MockEvent, MockPoll};
-    use crate::{Event, NoUserEvent};
 
     #[test]
     fn worker_should_poll_multiple_times() {

--- a/crates/tuirealm/src/macros.rs
+++ b/crates/tuirealm/src/macros.rs
@@ -1,10 +1,10 @@
-/// A macro to generate a chain of [`crate::SubClause::AndMany`] from a list of
-/// Ids with the case [`crate::SubClause::IsMounted`] for every id.
+/// A macro to generate a chain of [`crate::subscription::SubClause::AndMany`] from a list of
+/// Ids with the case [`crate::subscription::SubClause::IsMounted`] for every id.
 ///
 /// ### Example
 ///
 /// ```rust
-/// use tuirealm::{SubClause, subclause_and};
+/// use tuirealm::{subscription::SubClause, subclause_and};
 ///
 /// #[derive(Debug, Eq, PartialEq, Clone, Hash)]
 /// pub enum Id {
@@ -40,8 +40,8 @@ macro_rules! subclause_and {
     };
 }
 
-/// A macro to generate a chain of [`crate::SubClause::And`] from a list of
-/// Ids with the case  [`crate::SubClause::Not`] containing [`crate::SubClause::IsMounted`] for every id.
+/// A macro to generate a chain of [`crate::subscription::SubClause::And`] from a list of
+/// Ids with the case  [`crate::subscription::SubClause::Not`] containing [`crate::subscription::SubClause::IsMounted`] for every id.
 ///
 /// Why is this useful?
 /// Well, it happens quite often at least in my application to require a subclause for a "Global Listener" item
@@ -50,7 +50,7 @@ macro_rules! subclause_and {
 /// ### Example
 ///
 /// ```rust
-/// use tuirealm::{SubClause, subclause_and_not};
+/// use tuirealm::{subscription::SubClause, subclause_and_not};
 ///
 /// #[derive(Debug, Eq, PartialEq, Clone, Hash)]
 /// pub enum Id {
@@ -88,13 +88,13 @@ macro_rules! subclause_and_not {
     };
 }
 
-/// A macro to generate a chain of [`crate::SubClause::OrMany`] from a list of
-/// Ids with the case [`crate::SubClause::IsMounted`] for every id.
+/// A macro to generate a chain of [`crate::subscription::SubClause::OrMany`] from a list of
+/// Ids with the case [`crate::subscription::SubClause::IsMounted`] for every id.
 ///
 /// ### Example
 ///
 /// ```rust
-/// use tuirealm::{SubClause, subclause_or};
+/// use tuirealm::{subscription::SubClause, subclause_or};
 ///
 /// #[derive(Debug, Eq, PartialEq, Clone, Hash)]
 /// pub enum Id {
@@ -132,8 +132,8 @@ macro_rules! subclause_or {
 
 #[cfg(test)]
 mod tests {
-    use crate::SubClause;
     use crate::mock::MockComponentId;
+    use crate::subscription::SubClause;
 
     #[test]
     fn subclause_and() {

--- a/crates/tuirealm/src/mock/components.rs
+++ b/crates/tuirealm/src/mock/components.rs
@@ -4,8 +4,10 @@ use ratatui::Frame;
 
 use super::{MockEvent, MockMsg};
 use crate::command::{Cmd, CmdResult, Direction};
+use crate::component::{Component, MockComponent};
 use crate::event::{Event, Key, KeyEvent, KeyModifiers};
-use crate::{AttrValue, Attribute, Component, MockComponent, Props, State, StateValue};
+use crate::props::{AttrValue, Attribute, Props};
+use crate::state::{State, StateValue};
 
 /// Mocked component implementing `MockComponent`
 pub struct MockInput {

--- a/crates/tuirealm/src/mock/mod.rs
+++ b/crates/tuirealm/src/mock/mod.rs
@@ -3,8 +3,9 @@
 use std::marker::PhantomData;
 
 use crate::event::{Event, Key, KeyEvent};
+use crate::injector::Injector;
 use crate::listener::{Poll, PortResult};
-use crate::{AttrValue, Attribute, Injector};
+use crate::props::{AttrValue, Attribute};
 
 // -- modules
 mod components;

--- a/crates/tuirealm/src/terminal/event_listener.rs
+++ b/crates/tuirealm/src/terminal/event_listener.rs
@@ -17,7 +17,7 @@ pub use termion::TermionInputListener;
 pub use termwiz::TermwizInputListener;
 
 #[allow(unused_imports)] // used in the event listeners
-use crate::Event;
+use crate::event::Event;
 use crate::listener::PortError;
 
 /// Convert [`io::Error`](std::io::Error) to a [`PortError`], with correct Intermittent & Permanent Mapping

--- a/crates/tuirealm/src/terminal/event_listener/crossterm.rs
+++ b/crates/tuirealm/src/terminal/event_listener/crossterm.rs
@@ -16,7 +16,7 @@ use crate::terminal::event_listener::io_err_to_port_err;
 
 /// The input listener for crossterm.
 /// If crossterm is enabled, this will already be exported as `InputEventListener` in the `adapter` module
-/// or you can use it directly in the event listener, calling [`EventListenerCfg::crossterm_input_listener()`](crate::EventListenerCfg::crossterm_input_listener)
+/// or you can use it directly in the event listener, calling [`EventListenerCfg::crossterm_input_listener()`](crate::listener::EventListenerCfg::crossterm_input_listener)
 #[doc(alias = "InputEventListener")]
 pub struct CrosstermInputListener {
     interval: Duration,

--- a/crates/tuirealm/src/terminal/event_listener/crossterm_async.rs
+++ b/crates/tuirealm/src/terminal/event_listener/crossterm_async.rs
@@ -1,12 +1,12 @@
 use crossterm::event::EventStream;
 use futures_util::StreamExt;
 
-use crate::Event;
+use crate::event::Event;
 use crate::listener::{PollAsync, PortResult};
 use crate::terminal::event_listener::io_err_to_port_err;
 
 /// The async input listener for crossterm.
-/// This can be manually added as a async port, or directly via [`EventListenerCfg::async_crossterm_input_listener()`](crate::EventListenerCfg::async_crossterm_input_listener)
+/// This can be manually added as a async port, or directly via [`EventListenerCfg::async_crossterm_input_listener()`](crate::listener::EventListenerCfg::async_crossterm_input_listener)
 // NOTE: This relies on [`From`] implementations in [`super::crossterm`].
 #[doc(alias = "InputEventListener")]
 #[derive(Debug)]

--- a/crates/tuirealm/src/terminal/event_listener/termwiz.rs
+++ b/crates/tuirealm/src/terminal/event_listener/termwiz.rs
@@ -17,7 +17,7 @@ use crate::listener::{Poll, PortError, PortResult};
 
 /// The input listener for [`termwiz`].
 /// If [`termwiz`] is enabled, this will already be exported as `InputEventListener` in the `adapter` module
-/// or you can use it directly in the event listener, calling [`EventListenerCfg::termwiz_input_listener()`](crate::EventListenerCfg::termwiz_input_listener)
+/// or you can use it directly in the event listener, calling [`EventListenerCfg::termwiz_input_listener()`](crate::listener::EventListenerCfg::termwiz_input_listener)
 #[doc(alias = "InputEventListener")]
 pub struct TermwizInputListener {
     terminal: BufferedTerminal<SystemTerminal>,

--- a/crates/tuirealm_derive/src/lib.rs
+++ b/crates/tuirealm_derive/src/lib.rs
@@ -153,8 +153,10 @@ pub fn mock_component(input: TokenStream) -> TokenStream {
         let output = quote! {
             const _: () = {
                 use ::tuirealm::command::{Cmd, CmdResult};
-                use ::tuirealm::ratatui::layout::Rect;
-                use ::tuirealm::{Attribute, AttrValue, Frame, MockComponent, State};
+                use ::tuirealm::component::MockComponent;
+                use ::tuirealm::props::{AttrValue, Attribute};
+                use ::tuirealm::ratatui::{layout::Rect, Frame};
+                use ::tuirealm::state::State;
                 impl #generics MockComponent for #ident #generics {
                     fn view(&mut self, frame: &mut Frame, area: Rect) {
                         self.#component_name.view(frame, area);

--- a/docs/en/migrating-4.0.md
+++ b/docs/en/migrating-4.0.md
@@ -109,3 +109,34 @@ This makes it consistent with other functions like `view` which did not have a t
 This allows for customization of how the `update` function is called, for example if you dont ever returns a message for recursive processing, it can now be omitted.
 
 Migration is as simple as changing `impl Update for Model` to `impl Model` and potentially changing the visibility to `pub fn`.
+
+### Cleanup of module exports
+
+Root-level re-exports have been removed from all crates. All types must now be imported from their defining module rather than from the crate root. This makes the public API surface explicit and consistent across the workspace.
+
+In addition:
+
+- The `SubEventClause` type alias has been removed. Use `EventClause` from the `subscription` module instead.
+- `Frame` is no longer re-exported at the crate root. Use `tuirealm::ratatui::Frame`.
+
+The following table summarises the key import path changes:
+
+| Old import | New import |
+|---|---|
+| `tuirealm::Application` | `tuirealm::application::Application` |
+| `tuirealm::Event` | `tuirealm::event::Event` |
+| `tuirealm::NoUserEvent` | `tuirealm::event::NoUserEvent` |
+| `tuirealm::{AttrValue, Attribute, Props}` | `tuirealm::props::{AttrValue, Attribute, Props}` |
+| `tuirealm::{Component, MockComponent}` | `tuirealm::component::{Component, MockComponent}` |
+| `tuirealm::{State, StateValue}` | `tuirealm::state::{State, StateValue}` |
+| `tuirealm::{Sub, SubClause, SubEventClause}` | `tuirealm::subscription::{Sub, SubClause, EventClause}` |
+| `tuirealm::Frame` | `tuirealm::ratatui::Frame` |
+| `tuirealm::EventListenerCfg` | `tuirealm::listener::EventListenerCfg` |
+| `tuirealm::PollStrategy` | `tuirealm::application::PollStrategy` |
+| `tuirealm::ViewError` | `tuirealm::view::ViewError` |
+| `tuirealm::Injector` | `tuirealm::injector::Injector` |
+| `tui_realm_stdlib::Input` (etc.) | `tui_realm_stdlib::components::Input` |
+| `tui_realm_treeview::TreeState` | `tui_realm_treeview::tree_state::TreeState` |
+| `tui_realm_treeview::TreeWidget` | `tui_realm_treeview::widget::TreeWidget` |
+
+> **Note:** The `#[derive(MockComponent)]` proc macro and `async_trait` remain exported at the crate root level, as they need to be in scope for derive and trait usage.


### PR DESCRIPTION
## Summary

- Removed all root-level type re-exports from `tuirealm` lib.rs — types are now accessible only through their defining module (e.g., `tuirealm::application::Application`, `tuirealm::component::MockComponent`)
- Made previously private core submodules (`component`, `state`, `view`) public
- Made `tui-realm-stdlib`'s `components` module public and removed `pub use components::{props, *}` wildcard re-export
- Made `tui-realm-treeview`'s `tree_state` and `widget` modules public and removed root re-exports
- Updated all imports across the workspace: source, examples, doc tests, and derive macro codegen
- Removed the `SubEventClause` alias — use `EventClause` from `tuirealm::subscription` directly
- Added "Cleanup of module exports" section to the 4.0 migration guide with full old→new import table

Closes #168

## Test plan

- [x] `cargo build --workspace --all-features` passes
- [x] `cargo test --workspace --all-features` passes (257 tests)
- [x] `cargo clippy --workspace --all-targets --all-features -- -Dwarnings` clean
- [x] `cargo +nightly fmt --all -- --check` clean
- [x] All examples compile (`--examples` flag on each crate)
- [x] All doc tests pass