### PR TITLE
fix: Textarea::perform returns CmdResult::Changed on state change

### DIFF
--- a/crates/tuirealm-stdlib/src/components/textarea.rs
+++ b/crates/tuirealm-stdlib/src/components/textarea.rs
@@ -9,7 +9,7 @@ use tuirealm::ratatui::{
     layout::Rect,
     widgets::{List, ListItem, ListState},
 };
-use tuirealm::state::State;
+use tuirealm::state::{State, StateValue};
 
 use crate::prop_ext::CommonProps;
 use crate::utils::borrow_clone_line;
@@ -240,10 +240,11 @@ impl Component for Textarea {
     }
 
     fn state(&self) -> State {
-        State::None
+        State::Single(StateValue::Usize(self.states.list_index))
     }
 
     fn perform(&mut self, cmd: Cmd) -> CmdResult {
+        let prev = self.states.list_index;
         match cmd {
             Cmd::Move(Direction::Down) => {
                 self.states.incr_list_index();
@@ -275,7 +276,11 @@ impl Component for Textarea {
             }
             _ => {}
         }
-        CmdResult::None
+        if prev != self.states.list_index {
+            CmdResult::Changed(self.state())
+        } else {
+            CmdResult::None
+        }
     }
 }
 
@@ -287,6 +292,7 @@ mod tests {
     use pretty_assertions::assert_eq;
     use tuirealm::props::HorizontalAlignment;
     use tuirealm::ratatui::text::Span;
+    use tuirealm::state::StateValue;
 
     #[test]
     fn test_components_textarea() {
@@ -316,43 +322,54 @@ mod tests {
         assert_eq!(component.states.list_index, 1); // Kept
         assert_eq!(component.states.list_len, 3);
         // get value
-        assert_eq!(component.state(), State::None);
+        assert_eq!(component.state(), State::Single(StateValue::Usize(1)));
         // Render
         assert_eq!(component.states.list_index, 1);
         // Handle inputs
         assert_eq!(
             component.perform(Cmd::Move(Direction::Down)),
-            CmdResult::None
+            CmdResult::Changed(State::Single(StateValue::Usize(2)))
         );
         // Index should be incremented
         assert_eq!(component.states.list_index, 2);
         // Index should be decremented
-        assert_eq!(component.perform(Cmd::Move(Direction::Up)), CmdResult::None);
-        // Index should be incremented
+        assert_eq!(
+            component.perform(Cmd::Move(Direction::Up)),
+            CmdResult::Changed(State::Single(StateValue::Usize(1)))
+        );
+        // Index should be decremented
         assert_eq!(component.states.list_index, 1);
         // Index should be 2
         assert_eq!(
             component.perform(Cmd::Scroll(Direction::Down)),
-            CmdResult::None
+            CmdResult::Changed(State::Single(StateValue::Usize(2)))
         );
         // Index should be incremented
         assert_eq!(component.states.list_index, 2);
         // Index should be 0
         assert_eq!(
             component.perform(Cmd::Scroll(Direction::Up)),
-            CmdResult::None
+            CmdResult::Changed(State::Single(StateValue::Usize(0)))
         );
+        assert_eq!(component.states.list_index, 0);
         // End
-        assert_eq!(component.perform(Cmd::GoTo(Position::End)), CmdResult::None);
+        assert_eq!(
+            component.perform(Cmd::GoTo(Position::End)),
+            CmdResult::Changed(State::Single(StateValue::Usize(2)))
+        );
         assert_eq!(component.states.list_index, 2);
         // Home
         assert_eq!(
             component.perform(Cmd::GoTo(Position::Begin)),
+            CmdResult::Changed(State::Single(StateValue::Usize(0)))
+        );
+        assert_eq!(component.states.list_index, 0);
+        // No-op when already at beginning
+        assert_eq!(
+            component.perform(Cmd::GoTo(Position::Begin)),
             CmdResult::None
         );
-        // Index should be incremented
-        assert_eq!(component.states.list_index, 0);
-        // On key
+        // Unhandled command
         assert_eq!(component.perform(Cmd::Delete), CmdResult::None);
     }
 

--- a/crates/tuirealm-textarea/src/lib.rs
+++ b/crates/tuirealm-textarea/src/lib.rs
@@ -566,109 +566,87 @@ impl Component for TextArea<'_> {
     }
 
     fn perform(&mut self, cmd: Cmd) -> CmdResult {
+        let prev_lines: Vec<String> = self.widget.lines().iter().map(|l| l.to_string()).collect();
         match cmd {
             Cmd::Cancel => {
                 self.widget.delete_next_char();
-                CmdResult::None
             }
             Cmd::Custom(TEXTAREA_CMD_DEL_LINE_BY_END) => {
                 self.widget.delete_line_by_end();
-                CmdResult::None
             }
             Cmd::Custom(TEXTAREA_CMD_DEL_LINE_BY_HEAD) => {
                 self.widget.delete_line_by_head();
-                CmdResult::None
             }
             Cmd::Custom(TEXTAREA_CMD_DEL_NEXT_WORD) => {
                 self.widget.delete_next_word();
-                CmdResult::None
             }
             Cmd::Custom(TEXTAREA_CMD_DEL_WORD) => {
                 self.widget.delete_word();
-                CmdResult::None
             }
             Cmd::Custom(TEXTAREA_CMD_MOVE_PARAGRAPH_BACK) => {
                 self.widget.move_cursor(CursorMove::ParagraphBack);
-                CmdResult::None
             }
             Cmd::Custom(TEXTAREA_CMD_MOVE_PARAGRAPH_FORWARD) => {
                 self.widget.move_cursor(CursorMove::ParagraphForward);
-                CmdResult::None
             }
             Cmd::Custom(TEXTAREA_CMD_MOVE_WORD_BACK) => {
                 self.widget.move_cursor(CursorMove::WordBack);
-                CmdResult::None
             }
             Cmd::Custom(TEXTAREA_CMD_MOVE_WORD_FORWARD) => {
                 self.widget.move_cursor(CursorMove::WordForward);
-                CmdResult::None
             }
             Cmd::Custom(TEXTAREA_CMD_MOVE_BOTTOM) => {
                 if !self.single_line {
                     self.widget.move_cursor(CursorMove::Bottom);
                 }
-                CmdResult::None
             }
             Cmd::Custom(TEXTAREA_CMD_MOVE_TOP) => {
                 if !self.single_line {
                     self.widget.move_cursor(CursorMove::Top);
                 }
-                CmdResult::None
             }
             #[cfg(feature = "clipboard")]
             Cmd::Custom(TEXTAREA_CMD_PASTE) => {
                 self.paste();
-                CmdResult::None
             }
             Cmd::Custom(TEXTAREA_CMD_REDO) => {
                 self.widget.redo();
-                CmdResult::None
             }
             #[cfg(feature = "search")]
             Cmd::Custom(TEXTAREA_CMD_SEARCH_BACK) => {
                 self.widget.search_back(true);
-                CmdResult::None
             }
             #[cfg(feature = "search")]
             Cmd::Custom(TEXTAREA_CMD_SEARCH_FORWARD) => {
                 self.widget.search_forward(true);
-                CmdResult::None
             }
             Cmd::Custom(TEXTAREA_CMD_UNDO) => {
                 self.widget.undo();
-                CmdResult::None
             }
             Cmd::Delete => {
                 self.widget.delete_char();
-                CmdResult::None
             }
             Cmd::GoTo(Position::Begin) => {
                 self.widget.move_cursor(CursorMove::Head);
-                CmdResult::None
             }
             Cmd::GoTo(Position::End) => {
                 self.widget.move_cursor(CursorMove::End);
-                CmdResult::None
             }
             Cmd::Move(Direction::Down) => {
                 if !self.single_line {
                     self.widget.move_cursor(CursorMove::Down);
                 }
-                CmdResult::None
             }
             Cmd::Move(Direction::Left) => {
                 self.widget.move_cursor(CursorMove::Back);
-                CmdResult::None
             }
             Cmd::Move(Direction::Right) => {
                 self.widget.move_cursor(CursorMove::Forward);
-                CmdResult::None
             }
             Cmd::Move(Direction::Up) => {
                 if !self.single_line {
                     self.widget.move_cursor(CursorMove::Up);
                 }
-                CmdResult::None
             }
             Cmd::Scroll(Direction::Down) => {
                 if !self.single_line {
@@ -678,7 +656,6 @@ impl Component for TextArea<'_> {
                         .unwrap_length();
                     (0..step).for_each(|_| self.widget.move_cursor(CursorMove::Down));
                 }
-                CmdResult::None
             }
             Cmd::Scroll(Direction::Up) => {
                 if !self.single_line {
@@ -688,24 +665,27 @@ impl Component for TextArea<'_> {
                         .unwrap_length();
                     (0..step).for_each(|_| self.widget.move_cursor(CursorMove::Up));
                 }
-                CmdResult::None
             }
             Cmd::Type('\t') => {
                 self.widget.insert_tab();
-                CmdResult::None
             }
             Cmd::Type('\n') | Cmd::Custom(TEXTAREA_CMD_NEWLINE) => {
                 if !self.single_line {
                     self.widget.insert_newline();
                 }
-                CmdResult::None
             }
             Cmd::Type(ch) => {
                 self.widget.insert_char(ch);
-                CmdResult::None
             }
-            Cmd::Submit => CmdResult::Submit(self.state()),
-            _ => CmdResult::None,
+            Cmd::Submit => return CmdResult::Submit(self.state()),
+            _ => return CmdResult::None,
+        }
+        let current_lines: Vec<String> =
+            self.widget.lines().iter().map(|l| l.to_string()).collect();
+        if prev_lines != current_lines {
+            CmdResult::Changed(self.state())
+        } else {
+            CmdResult::None
         }
     }
 }

--- a/crates/tuirealm-textarea/src/lib.rs
+++ b/crates/tuirealm-textarea/src/lib.rs
@@ -566,7 +566,7 @@ impl Component for TextArea<'_> {
     }
 
     fn perform(&mut self, cmd: Cmd) -> CmdResult {
-        let prev_lines: Vec<String> = self.widget.lines().iter().map(|l| l.to_string()).collect();
+        let prev_lines = self.widget.lines().to_vec();
         match cmd {
             Cmd::Cancel => {
                 self.widget.delete_next_char();
@@ -680,12 +680,138 @@ impl Component for TextArea<'_> {
             Cmd::Submit => return CmdResult::Submit(self.state()),
             _ => return CmdResult::None,
         }
-        let current_lines: Vec<String> =
-            self.widget.lines().iter().map(|l| l.to_string()).collect();
-        if prev_lines != current_lines {
+        if prev_lines != self.widget.lines() {
             CmdResult::Changed(self.state())
         } else {
             CmdResult::None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tuirealm::command::{Cmd, CmdResult, Direction, Position};
+
+    use super::*;
+
+    /// Creates a default empty textarea for testing.
+    fn make_textarea() -> TextArea<'static> {
+        TextArea::default()
+    }
+
+    #[test]
+    fn perform_type_char_returns_changed() {
+        let mut textarea = make_textarea();
+        let result = textarea.perform(Cmd::Type('a'));
+        assert!(
+            matches!(result, CmdResult::Changed(_)),
+            "typing a character into an empty textarea should return Changed"
+        );
+    }
+
+    #[test]
+    fn perform_type_multiple_chars_returns_changed() {
+        let mut textarea = make_textarea();
+        textarea.perform(Cmd::Type('h'));
+        let result = textarea.perform(Cmd::Type('i'));
+        assert!(
+            matches!(result, CmdResult::Changed(_)),
+            "typing a second character should return Changed"
+        );
+    }
+
+    #[test]
+    fn perform_delete_on_empty_returns_none() {
+        let mut textarea = make_textarea();
+        let result = textarea.perform(Cmd::Delete);
+        assert!(
+            matches!(result, CmdResult::None),
+            "deleting from an empty textarea should return None"
+        );
+    }
+
+    #[test]
+    fn perform_delete_char_returns_changed() {
+        let mut textarea = make_textarea();
+        textarea.perform(Cmd::Type('x'));
+        let result = textarea.perform(Cmd::Delete);
+        assert!(
+            matches!(result, CmdResult::Changed(_)),
+            "deleting an existing character should return Changed"
+        );
+    }
+
+    #[test]
+    fn perform_cancel_on_empty_returns_none() {
+        let mut textarea = make_textarea();
+        let result = textarea.perform(Cmd::Cancel);
+        assert!(
+            matches!(result, CmdResult::None),
+            "cancel (delete-next) on empty textarea should return None"
+        );
+    }
+
+    #[test]
+    fn perform_submit_returns_submit() {
+        let mut textarea = make_textarea();
+        textarea.perform(Cmd::Type('a'));
+        let result = textarea.perform(Cmd::Submit);
+        assert!(
+            matches!(result, CmdResult::Submit(_)),
+            "submit should return Submit with current state"
+        );
+    }
+
+    #[test]
+    fn perform_move_returns_none() {
+        let mut textarea = make_textarea();
+        textarea.perform(Cmd::Type('a'));
+        let result = textarea.perform(Cmd::Move(Direction::Left));
+        assert!(
+            matches!(result, CmdResult::None),
+            "cursor movement should return None (no content change)"
+        );
+    }
+
+    #[test]
+    fn perform_goto_returns_none() {
+        let mut textarea = make_textarea();
+        textarea.perform(Cmd::Type('a'));
+        textarea.perform(Cmd::Type('b'));
+        let result = textarea.perform(Cmd::GoTo(Position::Begin));
+        assert!(
+            matches!(result, CmdResult::None),
+            "goto should return None (no content change)"
+        );
+    }
+
+    #[test]
+    fn perform_newline_returns_changed() {
+        let mut textarea = make_textarea();
+        let result = textarea.perform(Cmd::Type('\n'));
+        assert!(
+            matches!(result, CmdResult::Changed(_)),
+            "inserting a newline should return Changed"
+        );
+    }
+
+    #[test]
+    fn perform_tab_returns_changed() {
+        let mut textarea = make_textarea();
+        let result = textarea.perform(Cmd::Type('\t'));
+        assert!(
+            matches!(result, CmdResult::Changed(_)),
+            "inserting a tab should return Changed"
+        );
+    }
+
+    #[test]
+    fn perform_unknown_cmd_returns_none() {
+        let mut textarea = make_textarea();
+        let result = textarea.perform(Cmd::Toggle);
+        assert!(
+            matches!(result, CmdResult::None),
+            "unhandled command should return None"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **stdlib Textarea** (read-only): `state()` now returns `State::Single(StateValue::Usize(list_index))` instead of `State::None`; `perform()` returns `CmdResult::Changed` when the scroll index moves
- **editable TextArea**: `perform()` returns `CmdResult::Changed` when text content is modified (typing, deleting, undo/redo, paste, etc.)
- Both components still return `CmdResult::None` when an operation has no effect (e.g., scrolling at boundary)

## Test plan

- [x] stdlib textarea unit tests updated and passing
- [x] editable textarea tests passing
- [x] clippy clean

Closes #179