### PR TITLE
feat: add TestTerminalAdapter for ratatui TestBackend

### DIFF
--- a/crates/tuirealm-stdlib/examples/bar_chart.rs
+++ b/crates/tuirealm-stdlib/examples/bar_chart.rs
@@ -8,6 +8,7 @@ use tuirealm::component::{AppComponent, Component};
 use tuirealm::event::{Event, Key, KeyEvent, NoUserEvent};
 use tuirealm::props::{BorderType, Borders, Color, HorizontalAlignment, Style, Title};
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
+use tuirealm::terminal::TerminalAdapter;
 
 mod utils;
 use utils::Model;
@@ -31,7 +32,6 @@ impl Model<Id, Msg> {
     /// Draw all components.
     fn view(&mut self) {
         self.terminal
-            .raw_mut()
             .draw(|f| {
                 // Prepare chunks
                 let chunks = Layout::default()

--- a/crates/tuirealm-stdlib/examples/canvas.rs
+++ b/crates/tuirealm-stdlib/examples/canvas.rs
@@ -11,6 +11,7 @@ use tuirealm::props::{Borders, Color, HorizontalAlignment, Shape, Title};
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
 use tuirealm::ratatui::symbols::Marker;
 use tuirealm::ratatui::widgets::canvas::{Line, Map, MapResolution, Rectangle};
+use tuirealm::terminal::TerminalAdapter;
 
 mod utils;
 use utils::Model;
@@ -31,7 +32,6 @@ impl Model<Id, Msg> {
     /// Draw all components.
     fn view(&mut self) {
         self.terminal
-            .raw_mut()
             .draw(|f| {
                 // Prepare chunks
                 let chunks = Layout::default()

--- a/crates/tuirealm-stdlib/examples/chart.rs
+++ b/crates/tuirealm-stdlib/examples/chart.rs
@@ -16,6 +16,7 @@ use tuirealm::props::{
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
 use tuirealm::ratatui::symbols::Marker;
 use tuirealm::ratatui::widgets::GraphType;
+use tuirealm::terminal::TerminalAdapter;
 
 mod utils;
 use utils::{DataGen, Model};
@@ -43,7 +44,6 @@ impl Model<Id, Msg, UserEvent> {
     /// Draw all components.
     fn view(&mut self) {
         self.terminal
-            .raw_mut()
             .draw(|f| {
                 // Prepare chunks
                 let chunks = Layout::default()

--- a/crates/tuirealm-stdlib/examples/checkbox.rs
+++ b/crates/tuirealm-stdlib/examples/checkbox.rs
@@ -10,6 +10,7 @@ use tuirealm::component::{AppComponent, Component};
 use tuirealm::event::{Event, Key, KeyEvent, NoUserEvent};
 use tuirealm::props::{BorderType, Borders, Color, HorizontalAlignment, Title};
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
+use tuirealm::terminal::TerminalAdapter;
 
 mod utils;
 use utils::Model;
@@ -33,7 +34,6 @@ impl Model<Id, Msg> {
     /// Draw all components.
     fn view(&mut self) {
         self.terminal
-            .raw_mut()
             .draw(|f| {
                 // Prepare chunks
                 let chunks = Layout::default()

--- a/crates/tuirealm-stdlib/examples/container.rs
+++ b/crates/tuirealm-stdlib/examples/container.rs
@@ -13,6 +13,7 @@ use tuirealm::props::{
 };
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout as TuiLayout};
 use tuirealm::ratatui::text::Line;
+use tuirealm::terminal::TerminalAdapter;
 
 mod utils;
 use utils::Model;
@@ -33,7 +34,6 @@ impl Model<Id, Msg> {
     /// Draw all components.
     fn view(&mut self) {
         self.terminal
-            .raw_mut()
             .draw(|f| {
                 // Prepare chunks
                 let chunks = TuiLayout::default()

--- a/crates/tuirealm-stdlib/examples/gauge.rs
+++ b/crates/tuirealm-stdlib/examples/gauge.rs
@@ -14,6 +14,7 @@ use tuirealm::props::{
     Title,
 };
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
+use tuirealm::terminal::TerminalAdapter;
 
 mod utils;
 use utils::{Loader, Model};
@@ -45,7 +46,6 @@ impl Model<Id, Msg, UserEvent> {
     /// Draw all components.
     fn view(&mut self) {
         self.terminal
-            .raw_mut()
             .draw(|f| {
                 // Prepare chunks
                 let chunks = Layout::default()

--- a/crates/tuirealm-stdlib/examples/input.rs
+++ b/crates/tuirealm-stdlib/examples/input.rs
@@ -13,6 +13,7 @@ use tuirealm::props::{
 };
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
 use tuirealm::state::{State, StateValue};
+use tuirealm::terminal::TerminalAdapter;
 
 mod utils;
 use utils::Model;
@@ -44,7 +45,6 @@ impl Model<Id, Msg> {
     /// Draw all components.
     fn view(&mut self) {
         self.terminal
-            .raw_mut()
             .draw(|f| {
                 // Prepare chunks
                 let chunks = Layout::default()

--- a/crates/tuirealm-stdlib/examples/label.rs
+++ b/crates/tuirealm-stdlib/examples/label.rs
@@ -10,6 +10,7 @@ use tuirealm::component::{AppComponent, Component};
 use tuirealm::event::{Event, Key, KeyEvent, NoUserEvent};
 use tuirealm::props::{Color, HorizontalAlignment, TextModifiers};
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
+use tuirealm::terminal::TerminalAdapter;
 
 mod utils;
 use utils::Model;
@@ -31,7 +32,6 @@ impl Model<Id, Msg> {
     /// Draw all components.
     fn view(&mut self) {
         self.terminal
-            .raw_mut()
             .draw(|f| {
                 // Prepare chunks
                 let chunks = Layout::default()

--- a/crates/tuirealm-stdlib/examples/line_gauge.rs
+++ b/crates/tuirealm-stdlib/examples/line_gauge.rs
@@ -16,6 +16,7 @@ use tuirealm::props::{
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
 use tuirealm::ratatui::symbols::line::{HORIZONTAL, THICK_HORIZONTAL};
 use tuirealm::ratatui::text::Span;
+use tuirealm::terminal::TerminalAdapter;
 
 mod utils;
 use utils::{Loader, Model};
@@ -46,7 +47,6 @@ impl Model<Id, Msg, UserEvent> {
     /// Draw all components.
     fn view(&mut self) {
         self.terminal
-            .raw_mut()
             .draw(|f| {
                 // Prepare chunks
                 let chunks = Layout::default()

--- a/crates/tuirealm-stdlib/examples/list.rs
+++ b/crates/tuirealm-stdlib/examples/list.rs
@@ -12,6 +12,7 @@ use tuirealm::props::{BorderType, Borders, Color, HorizontalAlignment, Title};
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
 use tuirealm::ratatui::style::Stylize;
 use tuirealm::ratatui::text::Span;
+use tuirealm::terminal::TerminalAdapter;
 
 mod utils;
 use utils::Model;
@@ -35,7 +36,6 @@ impl Model<Id, Msg> {
     /// Draw all components.
     fn view(&mut self) {
         self.terminal
-            .raw_mut()
             .draw(|f| {
                 // Prepare chunks
                 let chunks = Layout::default()

--- a/crates/tuirealm-stdlib/examples/paragraph.rs
+++ b/crates/tuirealm-stdlib/examples/paragraph.rs
@@ -12,6 +12,7 @@ use tuirealm::props::{BorderType, Borders, Color, HorizontalAlignment, Title};
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
 use tuirealm::ratatui::style::Stylize;
 use tuirealm::ratatui::text::Line;
+use tuirealm::terminal::TerminalAdapter;
 
 mod utils;
 use utils::Model;
@@ -33,7 +34,6 @@ impl Model<Id, Msg> {
     /// Draw all components.
     fn view(&mut self) {
         self.terminal
-            .raw_mut()
             .draw(|f| {
                 // Prepare chunks
                 let chunks = Layout::default()

--- a/crates/tuirealm-stdlib/examples/radio.rs
+++ b/crates/tuirealm-stdlib/examples/radio.rs
@@ -10,6 +10,7 @@ use tuirealm::component::{AppComponent, Component};
 use tuirealm::event::{Event, Key, KeyEvent, NoUserEvent};
 use tuirealm::props::{BorderType, Borders, Color, HorizontalAlignment, Title};
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
+use tuirealm::terminal::TerminalAdapter;
 
 mod utils;
 use utils::Model;
@@ -33,7 +34,6 @@ impl Model<Id, Msg> {
     /// Draw all components.
     fn view(&mut self) {
         self.terminal
-            .raw_mut()
             .draw(|f| {
                 // Prepare chunks
                 let chunks = Layout::default()

--- a/crates/tuirealm-stdlib/examples/select.rs
+++ b/crates/tuirealm-stdlib/examples/select.rs
@@ -11,6 +11,7 @@ use tuirealm::event::{Event, Key, KeyEvent, NoUserEvent};
 use tuirealm::props::{BorderType, Borders, Color, HorizontalAlignment, Title};
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
 use tuirealm::state::State;
+use tuirealm::terminal::TerminalAdapter;
 
 mod utils;
 use utils::Model;
@@ -43,7 +44,6 @@ impl Model<Id, Msg> {
             _ => 8,
         };
         self.terminal
-            .raw_mut()
             .draw(|f| {
                 // Prepare chunks
                 let chunks = Layout::default()

--- a/crates/tuirealm-stdlib/examples/span.rs
+++ b/crates/tuirealm-stdlib/examples/span.rs
@@ -12,6 +12,7 @@ use tuirealm::props::{Color, HorizontalAlignment, TextModifiers};
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
 use tuirealm::ratatui::style::Stylize;
 use tuirealm::ratatui::text::Span as RSpan;
+use tuirealm::terminal::TerminalAdapter;
 
 mod utils;
 use utils::Model;
@@ -33,7 +34,6 @@ impl Model<Id, Msg> {
     /// Draw all components.
     fn view(&mut self) {
         self.terminal
-            .raw_mut()
             .draw(|f| {
                 // Prepare chunks
                 let chunks = Layout::default()

--- a/crates/tuirealm-stdlib/examples/sparkline.rs
+++ b/crates/tuirealm-stdlib/examples/sparkline.rs
@@ -14,6 +14,7 @@ use tuirealm::props::{
     Title,
 };
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
+use tuirealm::terminal::TerminalAdapter;
 
 mod utils;
 use utils::{DataGen, Model};
@@ -41,7 +42,6 @@ impl Model<Id, Msg, UserEvent> {
     /// Draw all components.
     fn view(&mut self) {
         self.terminal
-            .raw_mut()
             .draw(|f| {
                 // Prepare chunks
                 let chunks = Layout::default()

--- a/crates/tuirealm-stdlib/examples/spinner.rs
+++ b/crates/tuirealm-stdlib/examples/spinner.rs
@@ -13,6 +13,7 @@ use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout
 use tuirealm::ratatui::style::Stylize;
 use tuirealm::ratatui::text::Span as RSpan;
 use tuirealm::subscription::{EventClause, Sub, SubClause};
+use tuirealm::terminal::TerminalAdapter;
 
 mod utils;
 use utils::Model;
@@ -36,7 +37,6 @@ impl Model<Id, Msg> {
     /// Draw all components.
     fn view(&mut self) {
         self.terminal
-            .raw_mut()
             .draw(|f| {
                 // Prepare chunks
                 let chunks = Layout::default()

--- a/crates/tuirealm-stdlib/examples/table.rs
+++ b/crates/tuirealm-stdlib/examples/table.rs
@@ -11,6 +11,7 @@ use tuirealm::event::{Event, Key, KeyEvent, NoUserEvent};
 use tuirealm::props::{BorderType, Borders, Color, HorizontalAlignment, TableBuilder, Title};
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
 use tuirealm::ratatui::text::Line;
+use tuirealm::terminal::TerminalAdapter;
 
 mod utils;
 use utils::Model;
@@ -34,7 +35,6 @@ impl Model<Id, Msg> {
     /// Draw all components.
     fn view(&mut self) {
         self.terminal
-            .raw_mut()
             .draw(|f| {
                 // Prepare chunks
                 let chunks = Layout::default()

--- a/crates/tuirealm-stdlib/examples/textarea.rs
+++ b/crates/tuirealm-stdlib/examples/textarea.rs
@@ -12,6 +12,7 @@ use tuirealm::props::{BorderType, Borders, Color, HorizontalAlignment, Title};
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
 use tuirealm::ratatui::style::Stylize;
 use tuirealm::ratatui::text::Span;
+use tuirealm::terminal::TerminalAdapter;
 
 mod utils;
 use utils::Model;
@@ -35,7 +36,6 @@ impl Model<Id, Msg> {
     /// Draw all components.
     fn view(&mut self) {
         self.terminal
-            .raw_mut()
             .draw(|f| {
                 // Prepare chunks
                 let chunks = Layout::default()

--- a/crates/tuirealm/src/terminal.rs
+++ b/crates/tuirealm/src/terminal.rs
@@ -8,13 +8,13 @@ use thiserror::Error;
 #[cfg(feature = "crossterm")]
 #[cfg_attr(docsrs, doc(cfg(feature = "crossterm")))]
 pub use self::adapter::CrosstermTerminalAdapter;
-pub use self::adapter::TerminalAdapter;
 #[cfg(feature = "termion")]
 #[cfg_attr(docsrs, doc(cfg(feature = "termion")))]
 pub use self::adapter::TermionTerminalAdapter;
 #[cfg(feature = "termwiz")]
 #[cfg_attr(docsrs, doc(cfg(feature = "termwiz")))]
 pub use self::adapter::TermwizTerminalAdapter;
+pub use self::adapter::{TerminalAdapter, TestTerminalAdapter};
 #[cfg(all(feature = "crossterm", feature = "async-ports"))]
 #[cfg_attr(docsrs, doc(cfg(all(feature = "crossterm", feature = "async-ports"))))]
 pub use self::event_listener::CrosstermAsyncStream;

--- a/crates/tuirealm/src/terminal/adapter.rs
+++ b/crates/tuirealm/src/terminal/adapter.rs
@@ -4,16 +4,18 @@ mod crossterm;
 mod termion;
 #[cfg(feature = "termwiz")]
 mod termwiz;
+mod test;
 
 #[cfg(feature = "crossterm")]
 pub use crossterm::CrosstermTerminalAdapter;
-use ratatui::{CompletedFrame, Frame};
+use ratatui::{CompletedFrame, Frame, Terminal};
 #[cfg(feature = "termion")]
 pub use termion::TermionTerminalAdapter;
 #[cfg(feature = "termwiz")]
 pub use termwiz::TermwizTerminalAdapter;
+pub use test::TestTerminalAdapter;
 
-use super::TerminalResult;
+use super::{TerminalError, TerminalResult};
 
 /// [`TerminalAdapter`] is a trait that defines the methods that a terminal adapter should implement.
 ///
@@ -27,6 +29,9 @@ use super::TerminalResult;
 ///
 /// It is also expected of all backends to automatically restore modes on [`Drop`].
 pub trait TerminalAdapter {
+    /// The ratatui backend type used by this adapter.
+    type Backend: ratatui::backend::Backend + 'static;
+
     /// Draws a single frame to the terminal.
     ///
     /// Returns a [`CompletedFrame`] if successful, otherwise a [`TerminalError`](super::TerminalError).
@@ -40,7 +45,7 @@ pub trait TerminalAdapter {
     /// - return a [`CompletedFrame`] with the current buffer and the area of the terminal
     ///
     /// The [`CompletedFrame`] returned by this method can be useful for debugging or testing
-    /// purposes, but it is often not used in regular applicationss.
+    /// purposes, but it is often not used in regular applications.
     ///
     /// The render callback should fully render the entire frame when called, including areas that
     /// are unchanged from the previous frame. This is because each frame is compared to the
@@ -51,10 +56,19 @@ pub trait TerminalAdapter {
     /// This function will call [`ratatui::Terminal::draw`].
     fn draw<F>(&mut self, render_callback: F) -> TerminalResult<CompletedFrame<'_>>
     where
-        F: FnOnce(&mut Frame<'_>);
+        F: FnOnce(&mut Frame<'_>),
+    {
+        self.raw_mut()
+            .draw(render_callback)
+            .map_err(|_| TerminalError::CannotDrawFrame)
+    }
 
     /// Clear the screen
-    fn clear_screen(&mut self) -> TerminalResult<()>;
+    fn clear_screen(&mut self) -> TerminalResult<()> {
+        self.raw_mut()
+            .clear()
+            .map_err(|_| TerminalError::CannotClear)
+    }
 
     /// Enable terminal raw mode
     fn enable_raw_mode(&mut self) -> TerminalResult<()>;
@@ -73,4 +87,10 @@ pub trait TerminalAdapter {
 
     /// Disable mouse capture using the terminal adapter
     fn disable_mouse_capture(&mut self) -> TerminalResult<()>;
+
+    /// Returns a mutable reference to a [`Terminal`] wrapping a [`ratatui::backend::Backend`].
+    fn raw_mut(&mut self) -> &mut Terminal<Self::Backend>;
+
+    /// Returns a reference to a [`Terminal`] wrapping a [`ratatui::backend::Backend`].
+    fn raw(&self) -> &Terminal<Self::Backend>;
 }

--- a/crates/tuirealm/src/terminal/adapter/crossterm.rs
+++ b/crates/tuirealm/src/terminal/adapter/crossterm.rs
@@ -62,16 +62,6 @@ impl CrosstermTerminalAdapter {
         Ok(Self { terminal, modes })
     }
 
-    /// Access the underlying [`ratatui::backend::CrosstermBackend`] immutably.
-    pub fn raw(&self) -> &Terminal<CrosstermBackend<std::io::Stdout>> {
-        &self.terminal
-    }
-
-    /// Access the underlying [`ratatui::backend::CrosstermBackend`] mutably.
-    pub fn raw_mut(&mut self) -> &mut Terminal<CrosstermBackend<std::io::Stdout>> {
-        &mut self.terminal
-    }
-
     /// Restore the terminal state to pre [`TerminalAdapter`] state.
     ///
     /// This is automatically called on `Drop`.
@@ -144,14 +134,7 @@ impl CrosstermTerminalAdapter {
 }
 
 impl TerminalAdapter for CrosstermTerminalAdapter {
-    fn draw<F>(&mut self, render_callback: F) -> TerminalResult<ratatui::CompletedFrame<'_>>
-    where
-        F: FnOnce(&mut ratatui::Frame<'_>),
-    {
-        self.raw_mut()
-            .draw(render_callback)
-            .map_err(|_| TerminalError::CannotDrawFrame)
-    }
+    type Backend = CrosstermBackend<std::io::Stdout>;
 
     fn clear_screen(&mut self) -> TerminalResult<()> {
         self.terminal
@@ -209,6 +192,14 @@ impl TerminalAdapter for CrosstermTerminalAdapter {
             .inspect(|_| {
                 self.unset_mode(Modes::MOUSE);
             })
+    }
+
+    fn raw_mut(&mut self) -> &mut Terminal<CrosstermBackend<std::io::Stdout>> {
+        &mut self.terminal
+    }
+
+    fn raw(&self) -> &Terminal<CrosstermBackend<std::io::Stdout>> {
+        &self.terminal
     }
 }
 

--- a/crates/tuirealm/src/terminal/adapter/termion.rs
+++ b/crates/tuirealm/src/terminal/adapter/termion.rs
@@ -161,33 +161,10 @@ impl TermionTerminalAdapter {
 
         Ok(Self { terminal })
     }
-
-    /// Access the underlying [`ratatui::backend::TermionBackend`] immutably.
-    pub fn raw(&self) -> &TermionBackend {
-        &self.terminal
-    }
-
-    /// Access the underlying [`ratatui::backend::TermionBackend`] mutably.
-    pub fn raw_mut(&mut self) -> &mut TermionBackend {
-        &mut self.terminal
-    }
 }
 
 impl TerminalAdapter for TermionTerminalAdapter {
-    fn draw<F>(&mut self, render_callback: F) -> TerminalResult<ratatui::CompletedFrame<'_>>
-    where
-        F: FnOnce(&mut ratatui::Frame<'_>),
-    {
-        self.raw_mut()
-            .draw(render_callback)
-            .map_err(|_| TerminalError::CannotDrawFrame)
-    }
-
-    fn clear_screen(&mut self) -> TerminalResult<()> {
-        self.terminal
-            .clear()
-            .map_err(|_| TerminalError::CannotClear)
-    }
+    type Backend = backend::TermionBackend<TermionWrapper>;
 
     /// UNSUPPORTED in termion
     ///
@@ -223,5 +200,13 @@ impl TerminalAdapter for TermionTerminalAdapter {
     /// UNSUPPORTED in termion
     fn disable_mouse_capture(&mut self) -> TerminalResult<()> {
         Err(TerminalError::Unsupported)
+    }
+
+    fn raw(&self) -> &TermionBackend {
+        &self.terminal
+    }
+
+    fn raw_mut(&mut self) -> &mut TermionBackend {
+        &mut self.terminal
     }
 }

--- a/crates/tuirealm/src/terminal/adapter/termwiz.rs
+++ b/crates/tuirealm/src/terminal/adapter/termwiz.rs
@@ -36,33 +36,10 @@ impl TermwizTerminalAdapter {
 
         Ok(Self { terminal })
     }
-
-    /// Access the underlying [`ratatui::backend::TermwizBackend`] immutably.
-    pub fn raw(&self) -> &Terminal<TermwizBackend> {
-        &self.terminal
-    }
-
-    /// Access the underlying [`ratatui::backend::TermwizBackend`] mutably.
-    pub fn raw_mut(&mut self) -> &mut Terminal<TermwizBackend> {
-        &mut self.terminal
-    }
 }
 
 impl TerminalAdapter for TermwizTerminalAdapter {
-    fn draw<F>(&mut self, render_callback: F) -> TerminalResult<ratatui::CompletedFrame<'_>>
-    where
-        F: FnOnce(&mut ratatui::Frame<'_>),
-    {
-        self.raw_mut()
-            .draw(render_callback)
-            .map_err(|_| TerminalError::CannotDrawFrame)
-    }
-
-    fn clear_screen(&mut self) -> TerminalResult<()> {
-        self.terminal
-            .clear()
-            .map_err(|_| TerminalError::CannotClear)
-    }
+    type Backend = TermwizBackend;
 
     fn enable_raw_mode(&mut self) -> TerminalResult<()> {
         self.terminal
@@ -84,7 +61,7 @@ impl TerminalAdapter for TermwizTerminalAdapter {
             .buffered_terminal_mut()
             .terminal()
             .enter_alternate_screen()
-            .map_err(|_| TerminalError::CannotLeaveAlternateMode)
+            .map_err(|_| TerminalError::CannotEnterAlternateMode)
     }
 
     fn leave_alternate_screen(&mut self) -> TerminalResult<()> {
@@ -104,5 +81,13 @@ impl TerminalAdapter for TermwizTerminalAdapter {
     /// UNSUPPORTED in termwiz
     fn disable_mouse_capture(&mut self) -> TerminalResult<()> {
         Err(TerminalError::Unsupported)
+    }
+
+    fn raw_mut(&mut self) -> &mut Terminal<TermwizBackend> {
+        &mut self.terminal
+    }
+
+    fn raw(&self) -> &Terminal<TermwizBackend> {
+        &self.terminal
     }
 }

--- a/crates/tuirealm/src/terminal/adapter/test.rs
+++ b/crates/tuirealm/src/terminal/adapter/test.rs
@@ -1,0 +1,79 @@
+//! Test backend provides the [`TestBackend`](ratatui::backend::TestBackend) which can be used for
+//! integration tests: [`TestBackend`].
+
+use ratatui::Terminal;
+use ratatui::backend::TestBackend;
+
+use crate::ratatui::TerminalOptions;
+use crate::terminal::{TerminalAdapter, TerminalError, TerminalResult};
+
+/// A [`TerminalAdapter`] implementing the ratatui [`TestBackend`].
+///
+/// This backend is useful for doing integration tests.
+pub struct TestTerminalAdapter {
+    terminal: Terminal<TestBackend>,
+}
+
+impl TestTerminalAdapter {
+    /// Create a new [`TestTerminalAdapter`] instance with default ratatui Terminal options and the provided
+    /// height and width.
+    pub fn new(width: u16, height: u16) -> TerminalResult<Self> {
+        Self::new_with_options(width, height, TerminalOptions::default())
+    }
+
+    /// Create a new [`TestTerminalAdapter`] instance with custom ratatui Terminal options, and the provided
+    /// sizes.
+    pub fn new_with_options(
+        width: u16,
+        height: u16,
+        options: TerminalOptions,
+    ) -> TerminalResult<Self> {
+        let backend = TestBackend::new(width, height);
+        let terminal = Terminal::with_options(backend, options)
+            .map_err(|_| TerminalError::Other("Failed creating terminal"))?;
+
+        Ok(Self { terminal })
+    }
+}
+
+impl TerminalAdapter for TestTerminalAdapter {
+    type Backend = TestBackend;
+
+    /// UNSUPPORTED in test backend
+    fn enable_raw_mode(&mut self) -> TerminalResult<()> {
+        Err(TerminalError::Unsupported)
+    }
+
+    /// UNSUPPORTED in test backend
+    fn disable_raw_mode(&mut self) -> TerminalResult<()> {
+        Err(TerminalError::Unsupported)
+    }
+
+    /// UNSUPPORTED in test backend
+    fn enter_alternate_screen(&mut self) -> TerminalResult<()> {
+        Err(TerminalError::Unsupported)
+    }
+
+    /// UNSUPPORTED in test backend
+    fn leave_alternate_screen(&mut self) -> TerminalResult<()> {
+        Err(TerminalError::Unsupported)
+    }
+
+    /// UNSUPPORTED in test backend
+    fn enable_mouse_capture(&mut self) -> TerminalResult<()> {
+        Err(TerminalError::Unsupported)
+    }
+
+    /// UNSUPPORTED in test backend
+    fn disable_mouse_capture(&mut self) -> TerminalResult<()> {
+        Err(TerminalError::Unsupported)
+    }
+
+    fn raw_mut(&mut self) -> &mut Terminal<ratatui::backend::TestBackend> {
+        &mut self.terminal
+    }
+
+    fn raw(&self) -> &Terminal<ratatui::backend::TestBackend> {
+        &self.terminal
+    }
+}


### PR DESCRIPTION
## Summary

- Replace monolithic `TerminalBridge` with a `TerminalAdapter<B>` trait and per-backend adapter structs (`CrosstermTerminalAdapter`, `TermionTerminalAdapter`, `TermwizTerminalAdapter`, `TestTerminalAdapter`)
- Add `TestTerminalAdapter` wrapping ratatui's `TestBackend` for integration testing without a real terminal
- Fix `enter_alternate_screen` error mapping in termwiz adapter (`CannotLeaveAlternateMode` → `CannotEnterAlternateMode`)
- Update all examples to use the trait's `draw()` method directly instead of `.raw_mut().draw()`

Closes #145

## Test plan

- [x] `cargo build --workspace --all-features` passes
- [x] `cargo clippy --workspace --all-targets --all-features -- -Dwarnings` passes
- [x] Verify examples run correctly with crossterm backend
- [x] Verify `TestTerminalAdapter` works in integration tests