### PR TITLE
feat(tuirealm): add TestEventListener for integration testing

### DIFF
--- a/crates/tuirealm/src/terminal.rs
+++ b/crates/tuirealm/src/terminal.rs
@@ -15,6 +15,9 @@ pub use self::adapter::TermionTerminalAdapter;
 #[cfg_attr(docsrs, doc(cfg(feature = "termwiz")))]
 pub use self::adapter::TermwizTerminalAdapter;
 pub use self::adapter::{TerminalAdapter, TestTerminalAdapter};
+#[cfg(feature = "async-ports")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async-ports")))]
+pub use self::event_listener::AsyncTestEventListener;
 #[cfg(all(feature = "crossterm", feature = "async-ports"))]
 #[cfg_attr(docsrs, doc(cfg(all(feature = "crossterm", feature = "async-ports"))))]
 pub use self::event_listener::CrosstermAsyncStream;
@@ -27,6 +30,7 @@ pub use self::event_listener::TermionInputListener;
 #[cfg(feature = "termwiz")]
 #[cfg_attr(docsrs, doc(cfg(feature = "termwiz")))]
 pub use self::event_listener::TermwizInputListener;
+pub use self::event_listener::TestEventListener;
 
 /// TerminalResult is a type alias for a Result that uses [`TerminalError`] as the error type.
 pub type TerminalResult<T> = Result<T, TerminalError>;

--- a/crates/tuirealm/src/terminal/event_listener.rs
+++ b/crates/tuirealm/src/terminal/event_listener.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "async-ports")]
+mod async_test;
 #[cfg(feature = "crossterm")]
 mod crossterm;
 #[cfg(all(feature = "crossterm", feature = "async-ports"))]
@@ -6,7 +8,10 @@ mod crossterm_async;
 mod termion;
 #[cfg(feature = "termwiz")]
 mod termwiz;
+mod test;
 
+#[cfg(feature = "async-ports")]
+pub use async_test::AsyncTestEventListener;
 #[cfg(feature = "crossterm")]
 pub use crossterm::CrosstermInputListener;
 #[cfg(all(feature = "crossterm", feature = "async-ports"))]
@@ -15,6 +20,7 @@ pub use crossterm_async::CrosstermAsyncStream;
 pub use termion::TermionInputListener;
 #[cfg(feature = "termwiz")]
 pub use termwiz::TermwizInputListener;
+pub use test::TestEventListener;
 
 #[allow(unused_imports)] // used in the event listeners
 use crate::event::Event;

--- a/crates/tuirealm/src/terminal/event_listener/async_test.rs
+++ b/crates/tuirealm/src/terminal/event_listener/async_test.rs
@@ -1,0 +1,104 @@
+//! An async test event listener useful for integration tests. Can be paired with any adapter, but it's generally preferred
+//! to work with [`crate::terminal::TestTerminalAdapter`].
+
+use tokio::sync::mpsc::Receiver;
+use tokio::sync::mpsc::error::TryRecvError;
+use tuirealm::listener::PortError;
+
+use super::Event;
+use crate::listener::{PollAsync, PortResult};
+
+/// An async test [`Poll`] implementation that can be used for integration tests.
+///
+/// It has a [`Receiver`] which can be used to enqueue events to raise to the application.
+pub struct AsyncTestEventListener<UserEvent>
+where
+    UserEvent: Eq + PartialEq + Clone,
+{
+    receiver: Receiver<Event<UserEvent>>,
+}
+
+impl<UserEvent> AsyncTestEventListener<UserEvent>
+where
+    UserEvent: Eq + PartialEq + Clone,
+{
+    /// Creates a new [`crate::terminal::AsyncTestEventListener`] with the provided [`Receiver`].
+    ///
+    /// The receiver will be checked for pending events each time [`Poll::poll`] is called.
+    pub fn new(receiver: Receiver<Event<UserEvent>>) -> Self {
+        Self { receiver }
+    }
+}
+
+impl<UserEvent> From<Receiver<Event<UserEvent>>> for AsyncTestEventListener<UserEvent>
+where
+    UserEvent: Eq + PartialEq + Clone,
+{
+    fn from(receiver: Receiver<Event<UserEvent>>) -> Self {
+        Self::new(receiver)
+    }
+}
+
+#[async_trait::async_trait]
+impl<UserEvent> PollAsync<UserEvent> for AsyncTestEventListener<UserEvent>
+where
+    UserEvent: Eq + PartialEq + Clone + Send + 'static,
+{
+    async fn poll(&mut self) -> PortResult<Option<Event<UserEvent>>> {
+        match self.receiver.try_recv() {
+            Ok(msg) => Ok(Some(msg)),
+            Err(TryRecvError::Empty) => Ok(None),
+            Err(TryRecvError::Disconnected) => Err(PortError::PermanentError(
+                "Receiver disconnected".to_string(),
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event::{Key, KeyEvent, KeyModifiers, NoUserEvent};
+
+    #[tokio::test]
+    async fn test_should_poll_from_test_event_listener() {
+        let (tx, rx) = tokio::sync::mpsc::channel(512);
+        let mut listener = AsyncTestEventListener::<NoUserEvent>::new(rx);
+
+        // poll
+        assert_eq!(listener.poll().await, Ok(None));
+
+        // enqueue event
+        tx.send(Event::Keyboard(KeyEvent::new(
+            Key::Backspace,
+            KeyModifiers::NONE,
+        )))
+        .await
+        .expect("send keyboard event");
+
+        assert_eq!(
+            listener.poll().await,
+            Ok(Some(Event::Keyboard(KeyEvent::new(
+                Key::Backspace,
+                KeyModifiers::NONE,
+            ))))
+        );
+
+        // poll empty again
+        assert_eq!(listener.poll().await, Ok(None));
+    }
+
+    #[tokio::test]
+    async fn test_should_create_test_event_listener_from() {
+        let (_tx, rx) = tokio::sync::mpsc::channel(512);
+        let _listener = AsyncTestEventListener::<NoUserEvent>::from(rx);
+    }
+
+    #[tokio::test]
+    async fn test_should_return_error_on_disconnected_tx() {
+        let (tx, rx) = tokio::sync::mpsc::channel(512);
+        let mut listener = AsyncTestEventListener::<NoUserEvent>::new(rx);
+        drop(tx);
+        assert!(listener.poll().await.is_err());
+    }
+}

--- a/crates/tuirealm/src/terminal/event_listener/test.rs
+++ b/crates/tuirealm/src/terminal/event_listener/test.rs
@@ -1,0 +1,102 @@
+//! A test event listener useful for integration tests. Can be paired with any adapter, but it's generally preferred
+//! to work with [`crate::terminal::TestTerminalAdapter`].
+
+use std::sync::mpsc::{Receiver, TryRecvError};
+
+use tuirealm::listener::PortError;
+
+use super::Event;
+use crate::listener::{Poll, PortResult};
+
+/// A test [`Poll`] implementation that can be used for integration tests.
+///
+/// It has a [`Receiver`] which can be used to enqueue events to raise to the application.
+pub struct TestEventListener<UserEvent>
+where
+    UserEvent: Eq + PartialEq + Clone,
+{
+    receiver: Receiver<Event<UserEvent>>,
+}
+
+impl<UserEvent> TestEventListener<UserEvent>
+where
+    UserEvent: Eq + PartialEq + Clone,
+{
+    /// Creates a new [`TestEventListener`] with the provided [`Receiver`].
+    ///
+    /// The receiver will be checked for pending events each time [`Poll::poll`] is called.
+    pub fn new(receiver: Receiver<Event<UserEvent>>) -> Self {
+        Self { receiver }
+    }
+}
+
+impl<UserEvent> From<Receiver<Event<UserEvent>>> for TestEventListener<UserEvent>
+where
+    UserEvent: Eq + PartialEq + Clone,
+{
+    fn from(receiver: Receiver<Event<UserEvent>>) -> Self {
+        Self::new(receiver)
+    }
+}
+
+impl<UserEvent> Poll<UserEvent> for TestEventListener<UserEvent>
+where
+    UserEvent: Eq + PartialEq + Clone + Send + 'static,
+{
+    fn poll(&mut self) -> PortResult<Option<Event<UserEvent>>> {
+        match self.receiver.try_recv() {
+            Ok(msg) => Ok(Some(msg)),
+            Err(TryRecvError::Empty) => Ok(None),
+            Err(TryRecvError::Disconnected) => Err(PortError::PermanentError(
+                "Receiver disconnected".to_string(),
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event::{Key, KeyEvent, KeyModifiers, NoUserEvent};
+
+    #[test]
+    fn test_should_poll_from_test_event_listener() {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let mut listener = TestEventListener::<NoUserEvent>::new(rx);
+
+        // poll
+        assert_eq!(listener.poll(), Ok(None));
+
+        // enqueue event
+        tx.send(Event::Keyboard(KeyEvent::new(
+            Key::Backspace,
+            KeyModifiers::NONE,
+        )))
+        .expect("send keyboard event");
+
+        assert_eq!(
+            listener.poll(),
+            Ok(Some(Event::Keyboard(KeyEvent::new(
+                Key::Backspace,
+                KeyModifiers::NONE,
+            ))))
+        );
+
+        // poll empty again
+        assert_eq!(listener.poll(), Ok(None));
+    }
+
+    #[test]
+    fn test_should_create_test_event_listener_from() {
+        let (_tx, rx) = std::sync::mpsc::channel();
+        let _listener = TestEventListener::<NoUserEvent>::from(rx);
+    }
+
+    #[test]
+    fn test_should_return_error_on_disconnected_tx() {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let mut listener = TestEventListener::<NoUserEvent>::new(rx);
+        drop(tx);
+        assert!(listener.poll().is_err());
+    }
+}


### PR DESCRIPTION
Closes #190

## Summary

- Add `TestEventListener` (sync) and `AsyncTestEventListener` (async, requires `async-ports` feature) for programmatic event injection in integration tests without requiring a real terminal
