### PR TITLE
Change `Component::query` to be able to return reference data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,6 +368,12 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -580,6 +598,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "insta"
+version = "1.46.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e82db8c87c7f1ccecb34ce0c24399b8a73081427f3c7c50a5d597925356115e4"
+dependencies = [
+ "console",
+ "once_cell",
+ "similar",
+ "tempfile",
 ]
 
 [[package]]
@@ -1359,6 +1389,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1690,6 +1726,7 @@ checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
 name = "tui-realm-stdlib"
 version = "4.0.0"
 dependencies = [
+ "insta",
  "pretty_assertions",
  "rand 0.10.0",
  "textwrap",
@@ -1702,6 +1739,7 @@ name = "tui-realm-textarea"
 version = "2.1.0"
 dependencies = [
  "crossterm 0.28.1",
+ "insta",
  "lazy-regex",
  "pretty_assertions",
  "tui-realm-stdlib",
@@ -1714,6 +1752,7 @@ name = "tui-realm-treeview"
 version = "3.0.0"
 dependencies = [
  "crossterm 0.29.0",
+ "insta",
  "orange-trees",
  "pretty_assertions",
  "tui-realm-stdlib",
@@ -1745,6 +1784,7 @@ dependencies = [
  "crossterm 0.29.0",
  "dyn-clone",
  "futures-util",
+ "insta",
  "lazy-regex",
  "pretty_assertions",
  "ratatui",

--- a/crates/tuirealm-derive/README.md
+++ b/crates/tuirealm-derive/README.md
@@ -117,7 +117,7 @@ impl Component for IpAddressInput {
         self.component.view(frame, area);
     }
 
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
         self.component.query(attr)
     }
 

--- a/crates/tuirealm-derive/src/lib.rs
+++ b/crates/tuirealm-derive/src/lib.rs
@@ -49,7 +49,7 @@
 //!         self.component.view(frame, area);
 //!     }
 //!
-//!     fn query(&self, attr: Attribute) -> Option<AttrValue> {
+//!     fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
 //!         self.component.query(attr)
 //!     }
 //!
@@ -318,7 +318,7 @@ pub fn mock_component(input: TokenStream) -> TokenStream {
             const _: () = {
                 use ::tuirealm::command::{Cmd, CmdResult};
                 use ::tuirealm::ratatui::layout::Rect;
-                use ::tuirealm::props::{AttrValue, Attribute};
+                use ::tuirealm::props::{AttrValue, Attribute, QueryResult};
                 use ::tuirealm::component::Component;
                 use ::tuirealm::ratatui::Frame;
                 use ::tuirealm::state::State;
@@ -328,7 +328,7 @@ pub fn mock_component(input: TokenStream) -> TokenStream {
                         self.#component_field.view(frame, area);
                     }
 
-                    fn query(&self, attr: Attribute) -> Option<AttrValue> {
+                    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
                         self.#component_field.query(attr)
                     }
 

--- a/crates/tuirealm-stdlib/examples/gauge.rs
+++ b/crates/tuirealm-stdlib/examples/gauge.rs
@@ -10,8 +10,8 @@ use tuirealm::component::{AppComponent, Component};
 use tuirealm::event::{Event, Key, KeyEvent};
 use tuirealm::listener::{Poll, PortResult, SyncPort};
 use tuirealm::props::{
-    AttrValue, Attribute, BorderType, Borders, Color, HorizontalAlignment, PropPayload, PropValue,
-    Title,
+    AttrValue, AttrValueRef, Attribute, BorderType, Borders, Color, HorizontalAlignment,
+    PropPayload, PropPayloadRef, PropValue, PropValueRef, QueryResult, Title,
 };
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
 use tuirealm::terminal::TerminalAdapter;
@@ -235,9 +235,10 @@ impl AppComponent<Msg, UserEvent> for GaugeBeta {
                 let mut prog = self
                     .query(Attribute::Value)
                     .as_ref()
-                    .and_then(AttrValue::as_payload)
-                    .and_then(PropPayload::as_single)
-                    .and_then(PropValue::as_f64)
+                    .map(QueryResult::as_ref)
+                    .and_then(AttrValueRef::as_payload)
+                    .and_then(PropPayloadRef::as_single)
+                    .and_then(PropValueRef::as_f64)
                     .unwrap_or_default();
                 prog += 0.001f64;
 

--- a/crates/tuirealm-stdlib/src/components/bar_chart.rs
+++ b/crates/tuirealm-stdlib/src/components/bar_chart.rs
@@ -5,8 +5,8 @@ use std::collections::LinkedList;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::component::Component;
 use tuirealm::props::{
-    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style, TextModifiers,
-    Title,
+    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, QueryResult, Style,
+    TextModifiers, Title,
 };
 use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
@@ -305,12 +305,12 @@ impl Component for BarChart {
         render.render_widget(widget, area);
     }
 
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
-        if let Some(value) = self.common.get(attr) {
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+        if let Some(value) = self.common.get_for_query(attr) {
             return Some(value);
         }
 
-        self.props.get(attr).cloned()
+        self.props.get_for_query(attr)
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {

--- a/crates/tuirealm-stdlib/src/components/canvas.rs
+++ b/crates/tuirealm-stdlib/src/components/canvas.rs
@@ -3,7 +3,7 @@
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::component::Component;
 use tuirealm::props::{
-    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Shape, Style,
+    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, QueryResult, Shape, Style,
     TextModifiers, Title,
 };
 use tuirealm::ratatui::Frame;
@@ -232,12 +232,12 @@ impl Component for Canvas {
         render.render_widget(widget, area);
     }
 
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
-        if let Some(value) = self.common.get(attr) {
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+        if let Some(value) = self.common.get_for_query(attr) {
             return Some(value);
         }
 
-        self.props.get(attr).cloned()
+        self.props.get_for_query(attr)
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {

--- a/crates/tuirealm-stdlib/src/components/chart/chart.rs
+++ b/crates/tuirealm-stdlib/src/components/chart/chart.rs
@@ -5,8 +5,8 @@ use std::any::Any;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::component::Component;
 use tuirealm::props::{
-    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style, TextModifiers,
-    Title,
+    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, QueryResult, Style,
+    TextModifiers, Title,
 };
 use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
@@ -368,16 +368,16 @@ impl Component for Chart {
         render.render_widget(widget, area);
     }
 
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
-        if let Some(value) = self.common.get(attr) {
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+        if let Some(value) = self.common.get_for_query(attr) {
             return Some(value);
         }
 
         if attr == Attribute::Dataset {
-            return Some(self.data_to_attr());
+            return Some(self.data_to_attr().into());
         }
 
-        self.props.get(attr).cloned()
+        self.props.get_for_query(attr)
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {

--- a/crates/tuirealm-stdlib/src/components/checkbox.rs
+++ b/crates/tuirealm-stdlib/src/components/checkbox.rs
@@ -26,8 +26,8 @@
 use tuirealm::command::{Cmd, CmdResult, Direction};
 use tuirealm::component::Component;
 use tuirealm::props::{
-    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style, TextModifiers,
-    Title,
+    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, QueryResult, Style,
+    TextModifiers, Title,
 };
 use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
@@ -244,12 +244,12 @@ impl Component for Checkbox {
         render.render_widget(widget, area);
     }
 
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
-        if let Some(value) = self.common.get(attr) {
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+        if let Some(value) = self.common.get_for_query(attr) {
             return Some(value);
         }
 
-        self.props.get(attr).cloned()
+        self.props.get_for_query(attr)
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {

--- a/crates/tuirealm-stdlib/src/components/container.rs
+++ b/crates/tuirealm-stdlib/src/components/container.rs
@@ -3,7 +3,7 @@
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::component::Component;
 use tuirealm::props::{
-    AttrValue, Attribute, Borders, Color, Layout, Props, Style, TextModifiers, Title,
+    AttrValue, Attribute, Borders, Color, Layout, Props, QueryResult, Style, TextModifiers, Title,
 };
 use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
@@ -130,12 +130,12 @@ impl Component for Container {
         }
     }
 
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
-        if let Some(value) = self.common.get(attr) {
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+        if let Some(value) = self.common.get_for_query(attr) {
             return Some(value);
         }
 
-        self.props.get(attr).cloned()
+        self.props.get_for_query(attr)
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {

--- a/crates/tuirealm-stdlib/src/components/gauge.rs
+++ b/crates/tuirealm-stdlib/src/components/gauge.rs
@@ -3,8 +3,8 @@
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::component::Component;
 use tuirealm::props::{
-    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style, TextModifiers,
-    Title,
+    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, QueryResult, Style,
+    TextModifiers, Title,
 };
 use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
@@ -134,12 +134,12 @@ impl Component for Gauge {
         render.render_widget(widget, area);
     }
 
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
-        if let Some(value) = self.common.get(attr) {
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+        if let Some(value) = self.common.get_for_query(attr) {
             return Some(value);
         }
 
-        self.props.get(attr).cloned()
+        self.props.get_for_query(attr)
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {

--- a/crates/tuirealm-stdlib/src/components/input.rs
+++ b/crates/tuirealm-stdlib/src/components/input.rs
@@ -4,7 +4,8 @@
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::component::Component;
 use tuirealm::props::{
-    AttrValue, Attribute, Borders, Color, InputType, Props, Style, TextModifiers, Title,
+    AttrValue, Attribute, Borders, Color, InputType, Props, QueryResult, Style, TextModifiers,
+    Title,
 };
 use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
@@ -390,12 +391,12 @@ impl Component for Input {
         }
     }
 
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
-        if let Some(value) = self.common.get(attr) {
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+        if let Some(value) = self.common.get_for_query(attr) {
             return Some(value);
         }
 
-        self.props.get(attr).cloned()
+        self.props.get_for_query(attr)
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {

--- a/crates/tuirealm-stdlib/src/components/label.rs
+++ b/crates/tuirealm-stdlib/src/components/label.rs
@@ -1,7 +1,7 @@
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::component::Component;
 use tuirealm::props::{
-    AttrValue, Attribute, Color, HorizontalAlignment, Props, Style, TextModifiers,
+    AttrValue, Attribute, Color, HorizontalAlignment, Props, QueryResult, Style, TextModifiers,
 };
 use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
@@ -89,12 +89,12 @@ impl Component for Label {
         );
     }
 
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
-        if let Some(value) = self.common.get(attr) {
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+        if let Some(value) = self.common.get_for_query(attr) {
             return Some(value);
         }
 
-        self.props.get(attr).cloned()
+        self.props.get_for_query(attr)
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {

--- a/crates/tuirealm-stdlib/src/components/line_gauge.rs
+++ b/crates/tuirealm-stdlib/src/components/line_gauge.rs
@@ -1,8 +1,8 @@
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::component::Component;
 use tuirealm::props::{
-    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, SpanStatic, Style,
-    TextModifiers, Title,
+    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, QueryResult, SpanStatic,
+    Style, TextModifiers, Title,
 };
 use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
@@ -168,12 +168,12 @@ impl Component for LineGauge {
         render.render_widget(widget, area);
     }
 
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
-        if let Some(value) = self.common.get(attr) {
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+        if let Some(value) = self.common.get_for_query(attr) {
             return Some(value);
         }
 
-        self.props.get(attr).cloned()
+        self.props.get_for_query(attr)
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {

--- a/crates/tuirealm-stdlib/src/components/list.rs
+++ b/crates/tuirealm-stdlib/src/components/list.rs
@@ -3,8 +3,8 @@
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::component::Component;
 use tuirealm::props::{
-    AttrValue, Attribute, Borders, Color, LineStatic, PropPayload, PropValue, Props, Style,
-    TextModifiers, Title,
+    AttrValue, Attribute, Borders, Color, LineStatic, PropPayload, PropValue, Props, QueryResult,
+    Style, TextModifiers, Title,
 };
 use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
@@ -283,12 +283,12 @@ impl Component for List {
         }
     }
 
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
-        if let Some(value) = self.common.get(attr) {
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+        if let Some(value) = self.common.get_for_query(attr) {
             return Some(value);
         }
 
-        self.props.get(attr).cloned()
+        self.props.get_for_query(attr)
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {

--- a/crates/tuirealm-stdlib/src/components/paragraph.rs
+++ b/crates/tuirealm-stdlib/src/components/paragraph.rs
@@ -1,8 +1,8 @@
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::component::Component;
 use tuirealm::props::{
-    AttrValue, Attribute, Borders, Color, HorizontalAlignment, Props, Style, TextModifiers,
-    TextStatic, Title,
+    AttrValue, Attribute, Borders, Color, HorizontalAlignment, Props, QueryResult, Style,
+    TextModifiers, TextStatic, Title,
 };
 use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
@@ -130,12 +130,12 @@ impl Component for Paragraph {
         render.render_widget(paragraph, area);
     }
 
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
-        if let Some(value) = self.common.get(attr) {
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+        if let Some(value) = self.common.get_for_query(attr) {
             return Some(value);
         }
 
-        self.props.get(attr).cloned()
+        self.props.get_for_query(attr)
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {

--- a/crates/tuirealm-stdlib/src/components/phantom.rs
+++ b/crates/tuirealm-stdlib/src/components/phantom.rs
@@ -1,6 +1,6 @@
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::component::Component;
-use tuirealm::props::{AttrValue, Attribute, Props};
+use tuirealm::props::{AttrValue, Attribute, Props, QueryResult};
 use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
 use tuirealm::state::State;
@@ -18,8 +18,8 @@ pub struct Phantom {
 impl Component for Phantom {
     fn view(&mut self, _render: &mut Frame, _area: Rect) {}
 
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
-        self.props.get(attr).cloned()
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+        self.props.get_for_query(attr)
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {

--- a/crates/tuirealm-stdlib/src/components/radio.rs
+++ b/crates/tuirealm-stdlib/src/components/radio.rs
@@ -26,8 +26,8 @@
 use tuirealm::command::{Cmd, CmdResult, Direction};
 use tuirealm::component::Component;
 use tuirealm::props::{
-    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style, TextModifiers,
-    Title,
+    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, QueryResult, Style,
+    TextModifiers, Title,
 };
 use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
@@ -216,12 +216,12 @@ impl Component for Radio {
         render.render_widget(widget, area);
     }
 
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
-        if let Some(value) = self.common.get(attr) {
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+        if let Some(value) = self.common.get_for_query(attr) {
             return Some(value);
         }
 
-        self.props.get(attr).cloned()
+        self.props.get_for_query(attr)
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {

--- a/crates/tuirealm-stdlib/src/components/select.rs
+++ b/crates/tuirealm-stdlib/src/components/select.rs
@@ -4,8 +4,8 @@
 use tuirealm::command::{Cmd, CmdResult, Direction};
 use tuirealm::component::Component;
 use tuirealm::props::{
-    AttrValue, Attribute, Borders, Color, LineStatic, PropPayload, PropValue, Props, Style,
-    TextModifiers, Title,
+    AttrValue, Attribute, Borders, Color, LineStatic, PropPayload, PropValue, Props, QueryResult,
+    Style, TextModifiers, Title,
 };
 use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout, Rect};
@@ -304,12 +304,12 @@ impl Component for Select {
         }
     }
 
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
-        if let Some(value) = self.common.get(attr) {
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+        if let Some(value) = self.common.get_for_query(attr) {
             return Some(value);
         }
 
-        self.props.get(attr).cloned()
+        self.props.get_for_query(attr)
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {

--- a/crates/tuirealm-stdlib/src/components/span.rs
+++ b/crates/tuirealm-stdlib/src/components/span.rs
@@ -1,8 +1,8 @@
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::component::Component;
 use tuirealm::props::{
-    AttrValue, Attribute, Color, HorizontalAlignment, PropPayload, PropValue, Props, SpanStatic,
-    Style, TextModifiers,
+    AttrValue, Attribute, Color, HorizontalAlignment, PropPayload, PropValue, Props, QueryResult,
+    SpanStatic, Style, TextModifiers,
 };
 use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
@@ -113,12 +113,12 @@ impl Component for Span {
         );
     }
 
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
-        if let Some(value) = self.common.get(attr) {
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+        if let Some(value) = self.common.get_for_query(attr) {
             return Some(value);
         }
 
-        self.props.get(attr).cloned()
+        self.props.get_for_query(attr)
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {

--- a/crates/tuirealm-stdlib/src/components/sparkline.rs
+++ b/crates/tuirealm-stdlib/src/components/sparkline.rs
@@ -3,7 +3,7 @@
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::component::Component;
 use tuirealm::props::{
-    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style, Title,
+    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, QueryResult, Style, Title,
 };
 use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
@@ -138,12 +138,12 @@ impl Component for Sparkline {
         render.render_widget(widget, area);
     }
 
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
-        if let Some(value) = self.common.get(attr) {
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+        if let Some(value) = self.common.get_for_query(attr) {
             return Some(value);
         }
 
-        self.props.get(attr).cloned()
+        self.props.get_for_query(attr)
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {

--- a/crates/tuirealm-stdlib/src/components/spinner.rs
+++ b/crates/tuirealm-stdlib/src/components/spinner.rs
@@ -2,7 +2,9 @@
 
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::component::Component;
-use tuirealm::props::{AttrValue, Attribute, Color, HorizontalAlignment, Props, Style};
+use tuirealm::props::{
+    AttrValue, Attribute, Color, HorizontalAlignment, Props, QueryResult, Style,
+};
 use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
 use tuirealm::ratatui::widgets::Paragraph;
@@ -125,12 +127,12 @@ impl Component for Spinner {
         );
     }
 
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
-        if let Some(value) = self.common.get(attr) {
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+        if let Some(value) = self.common.get_for_query(attr) {
             return Some(value);
         }
 
-        self.props.get(attr).cloned()
+        self.props.get_for_query(attr)
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {

--- a/crates/tuirealm-stdlib/src/components/table.rs
+++ b/crates/tuirealm-stdlib/src/components/table.rs
@@ -5,8 +5,8 @@ use std::cmp::max;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::component::Component;
 use tuirealm::props::{
-    AttrValue, Attribute, Borders, Color, LineStatic, PropPayload, PropValue, Props, Style,
-    Table as PropTable, TextModifiers, Title,
+    AttrValue, Attribute, Borders, Color, LineStatic, PropPayload, PropValue, Props, QueryResult,
+    Style, Table as PropTable, TextModifiers, Title,
 };
 use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::{Constraint, Rect};
@@ -402,12 +402,12 @@ impl Component for Table {
         }
     }
 
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
-        if let Some(value) = self.common.get(attr) {
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+        if let Some(value) = self.common.get_for_query(attr) {
             return Some(value);
         }
 
-        self.props.get(attr).cloned()
+        self.props.get_for_query(attr)
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {

--- a/crates/tuirealm-stdlib/src/components/textarea.rs
+++ b/crates/tuirealm-stdlib/src/components/textarea.rs
@@ -1,8 +1,8 @@
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::component::Component;
 use tuirealm::props::{
-    AttrValue, Attribute, Borders, Color, LineStatic, PropPayload, PropValue, Props, SpanStatic,
-    Style, TextModifiers, Title,
+    AttrValue, Attribute, Borders, Color, LineStatic, PropPayload, PropValue, Props, QueryResult,
+    SpanStatic, Style, TextModifiers, Title,
 };
 use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
@@ -216,12 +216,12 @@ impl Component for Textarea {
         render.render_stateful_widget(list, area, &mut state);
     }
 
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
-        if let Some(value) = self.common.get(attr) {
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+        if let Some(value) = self.common.get_for_query(attr) {
             return Some(value);
         }
 
-        self.props.get(attr).cloned()
+        self.props.get_for_query(attr)
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {

--- a/crates/tuirealm-stdlib/src/prop_ext.rs
+++ b/crates/tuirealm-stdlib/src/prop_ext.rs
@@ -1,6 +1,6 @@
 //! Extra extensions to handle Properties.
 
-use tuirealm::props::{AttrValue, Attribute, Borders, Style, Title};
+use tuirealm::props::{AttrValue, AttrValueRef, Attribute, Borders, QueryResult, Style, Title};
 use tuirealm::ratatui::widgets::Block;
 
 /// Prop Store for very common props.
@@ -91,6 +91,30 @@ impl CommonProps {
             // other
             _ => None,
         }
+    }
+
+    /// Try to get a given [`Attribute`] as a type compatible with [`Component::query`](tuirealm::component::Component::query).
+    pub fn get_for_query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+        match attr {
+            // handle style attributes
+            Attribute::Style => Some(AttrValueRef::Style(self.style)),
+            Attribute::Foreground => self.style.fg.map(AttrValueRef::Color),
+            Attribute::Background => self.style.bg.map(AttrValueRef::Color),
+            Attribute::FocusStyle => Some(AttrValueRef::Style(self.border_unfocused_style)),
+            Attribute::TextProps => Some(AttrValueRef::TextModifiers(self.style.add_modifier)),
+
+            // handle flags
+            Attribute::Display => Some(AttrValueRef::Flag(self.display)),
+            Attribute::Focus => Some(AttrValueRef::Flag(self.focused)),
+
+            // handle borders & titles
+            Attribute::Borders => self.border.map(AttrValueRef::Borders),
+            Attribute::Title => self.title.as_ref().map(AttrValueRef::Title),
+
+            // other
+            _ => None,
+        }
+        .map(QueryResult::Borrowed)
     }
 
     /// Get a [`Block`] with the configuration from the common props, if `borders` are defined.

--- a/crates/tuirealm-stdlib/src/utils.rs
+++ b/crates/tuirealm-stdlib/src/utils.rs
@@ -100,8 +100,8 @@ pub fn calc_utf8_cursor_position(chars: &[char]) -> u16 {
 /// Note that a normal [`Span::clone`] (and by extension `Cow::clone`) will preserve the `Cow` Variant.
 pub fn borrow_clone_span<'a, 'b: 'a>(span: &'b Span<'a>) -> Span<'a> {
     Span {
-        style: span.style,
         content: Cow::Borrowed(&*span.content),
+        ..*span
     }
 }
 

--- a/crates/tuirealm-textarea/examples/editor.rs
+++ b/crates/tuirealm-textarea/examples/editor.rs
@@ -20,8 +20,8 @@ use tuirealm::component::{AppComponent, Component};
 use tuirealm::event::{Event, Key, KeyEvent, KeyModifiers, NoUserEvent};
 use tuirealm::listener::EventListenerCfg;
 use tuirealm::props::{
-    AttrValue, Attribute, BorderType, Borders, Color, HorizontalAlignment, Style, TextModifiers,
-    Title,
+    AttrValue, Attribute, BorderType, Borders, Color, HorizontalAlignment, QueryResult, Style,
+    TextModifiers, Title,
 };
 // tui
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
@@ -202,7 +202,7 @@ impl Component for Editor {
         self.component.view(frame, area);
     }
 
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
         self.component.query(attr)
     }
 

--- a/crates/tuirealm-textarea/examples/single_line.rs
+++ b/crates/tuirealm-textarea/examples/single_line.rs
@@ -10,8 +10,8 @@ use tuirealm::component::{AppComponent, Component};
 use tuirealm::event::{Event, Key, KeyEvent, KeyModifiers, NoUserEvent};
 use tuirealm::listener::EventListenerCfg;
 use tuirealm::props::{
-    AttrValue, Attribute, BorderType, Borders, Color, HorizontalAlignment, Style, TextModifiers,
-    Title,
+    AttrValue, Attribute, BorderType, Borders, Color, HorizontalAlignment, QueryResult, Style,
+    TextModifiers, Title,
 };
 // tui
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
@@ -142,7 +142,7 @@ impl Component for Input {
         self.component.view(frame, area);
     }
 
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
         self.component.query(attr)
     }
 

--- a/crates/tuirealm-textarea/src/lib.rs
+++ b/crates/tuirealm-textarea/src/lib.rs
@@ -131,6 +131,8 @@
 
 // -- internal
 mod fmt;
+use std::borrow::Cow;
+
 use fmt::LineFmt;
 
 // deps
@@ -142,10 +144,12 @@ use tui_textarea::{CursorMove, TextArea as TextAreaWidget};
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::component::Component;
 use tuirealm::props::{
-    AttrValue, Attribute, Borders, PropPayload, PropValue, Props, Style, TextModifiers, Title,
+    AttrValue, AttrValueRef, Attribute, Borders, PropPayload, PropValue, Props, QueryResult, Style,
+    TextModifiers, Title,
 };
 use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout, Rect};
+use tuirealm::ratatui::text::{Line, Span};
 use tuirealm::ratatui::widgets::{Block, Paragraph};
 use tuirealm::state::{State, StateValue};
 
@@ -367,16 +371,26 @@ impl<'a> TextArea<'a> {
     }
 
     // -- private
-    fn get_block(&self) -> Option<Block<'a>> {
+    fn get_block(&self) -> Option<Block<'static>> {
         let mut block = Block::default();
-        if let Some(AttrValue::Title(title)) = self.query(Attribute::Title) {
-            block = block.title(title.content).title_position(title.position);
+        if let Some(QueryResult::Borrowed(AttrValueRef::Title(title))) =
+            self.query(Attribute::Title)
+        {
+            block = block
+                .title(title.content.clone())
+                .title_position(title.position);
         }
-        if let Some(AttrValue::Borders(borders)) = self.query(Attribute::Borders) {
+        if let Some(
+            QueryResult::Borrowed(AttrValueRef::Borders(borders))
+            | QueryResult::Owned(AttrValue::Borders(borders)),
+        ) = self.query(Attribute::Borders)
+        {
             let inactive_style = self
                 .query(Attribute::FocusStyle)
-                .unwrap_or_else(|| AttrValue::Style(Style::default()))
-                .unwrap_style();
+                .as_ref()
+                .map(QueryResult::as_ref)
+                .and_then(AttrValueRef::as_style)
+                .unwrap_or_default();
             let focus = self
                 .props
                 .get(Attribute::Focus)
@@ -466,8 +480,8 @@ impl Component for TextArea<'_> {
         }
     }
 
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
-        self.props.get(attr).cloned()
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+        self.props.get_for_query(attr)
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {
@@ -662,6 +676,24 @@ impl Component for TextArea<'_> {
         } else {
             CmdResult::None
         }
+    }
+}
+
+/// Convert a `&Span` to a `Span` by using [`Cow::Borrowed`].
+///
+/// Note that a normal [`Span::clone`] (and by extension `Cow::clone`) will preserve the `Cow` Variant.
+pub fn borrow_clone_span<'a, 'b: 'a>(span: &'b Span<'a>) -> Span<'a> {
+    Span {
+        style: span.style,
+        content: Cow::Borrowed(&*span.content),
+    }
+}
+
+/// Convert a `&Line` to a `Line` by using [`Cow::Borrowed`].
+pub fn borrow_clone_line<'a, 'b: 'a>(line: &'b Line<'a>) -> Line<'a> {
+    Line {
+        spans: line.spans.iter().map(borrow_clone_span).collect(),
+        ..*line
     }
 }
 

--- a/crates/tuirealm-treeview/src/lib.rs
+++ b/crates/tuirealm-treeview/src/lib.rs
@@ -210,7 +210,8 @@ use tui_realm_stdlib::utils::get_block;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::component::Component;
 use tuirealm::props::{
-    AttrValue, Attribute, Borders, Color, Props, SpanStatic, Style, TextModifiers, Title,
+    AttrValue, Attribute, Borders, Color, Props, QueryResult, SpanStatic, Style, TextModifiers,
+    Title,
 };
 use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
@@ -478,8 +479,8 @@ impl<V: NodeValue> Component for TreeView<V> {
         frame.render_stateful_widget(tree, area, &mut state);
     }
 
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
-        self.props.get(attr).cloned()
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+        self.props.get_for_query(attr)
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {

--- a/crates/tuirealm/Cargo.toml
+++ b/crates/tuirealm/Cargo.toml
@@ -48,6 +48,7 @@ pretty_assertions = "^1"
 tempfile = "^3"
 tokio = { version = "1", features = ["full"] }
 toml = "^0.9"
+insta = "1"
 
 [features]
 default = ["derive", "crossterm"]

--- a/crates/tuirealm/docs/en/advanced.md
+++ b/crates/tuirealm/docs/en/advanced.md
@@ -296,8 +296,8 @@ impl Radio {
 impl Component for Radio {
     // ...
 
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
-        self.props.get(attr).cloned()
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+        self.props.get_as_ref(attr)
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {

--- a/crates/tuirealm/docs/en/get-started.md
+++ b/crates/tuirealm/docs/en/get-started.md
@@ -649,8 +649,8 @@ impl Component for Counter {
         );
     }
 
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
-        self.props.get(attr).cloned()
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+        self.props.get_as_ref(attr)
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {

--- a/crates/tuirealm/docs/en/migrating-4.0.md
+++ b/crates/tuirealm/docs/en/migrating-4.0.md
@@ -174,3 +174,8 @@ impl AppComponent<Msg, UserEvent> for MyWidget {
     fn on(&mut self, ev: &Event<UserEvent>) -> Option<Msg> { ... }
 }
 ```
+
+### Change `Component::query` to return Borrowed content
+
+`Component::query` has been changed to allow for and prefer borrowed content, but still allow owned content to be returned.
+This allowed the consumer to decide when a clone is actually necessary, for practically anything other than `PropPayload::Any`.

--- a/crates/tuirealm/docs/zh-cn/advanced.md
+++ b/crates/tuirealm/docs/zh-cn/advanced.md
@@ -303,8 +303,8 @@ impl Component for Radio {
 
     // ...
 
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
-        self.props.get(attr).cloned()
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+        self.props.get_as_ref(attr)
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {

--- a/crates/tuirealm/docs/zh-cn/get-started.md
+++ b/crates/tuirealm/docs/zh-cn/get-started.md
@@ -441,7 +441,7 @@ impl Component for Counter {
         self.component.view(frame, area);
     }
     
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
         self.component.query(attr)
     }
     

--- a/crates/tuirealm/examples/arbitrary_data.rs
+++ b/crates/tuirealm/examples/arbitrary_data.rs
@@ -13,7 +13,8 @@ use tuirealm::component::{AppComponent, Component};
 use tuirealm::event::{Event, Key, KeyEvent, NoUserEvent};
 use tuirealm::listener::EventListenerCfg;
 use tuirealm::props::{
-    AttrValue, Attribute, Color, HorizontalAlignment, PropBound, PropPayload, Props, Style,
+    AttrValue, Attribute, Color, HorizontalAlignment, PropBound, PropPayload, Props, QueryResult,
+    Style,
 };
 use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::{Constraint, Direction, Layout, Rect};
@@ -248,8 +249,8 @@ impl Component for StdLabel {
         );
     }
 
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
-        self.props.get(attr).cloned()
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+        self.props.get_for_query(attr)
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {
@@ -276,9 +277,10 @@ impl AppComponent<Msg, NoUserEvent> for OurLabel {
         match ev {
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => Some(Msg::AppClose),
             Event::Keyboard(KeyEvent { code: Key::Tab, .. }) => {
-                let mut existing_attr = self.query(Attribute::Value).unwrap_or_else(|| {
-                    AttrValue::Payload(PropPayload::Any(CustomState::default().to_any_prop()))
-                });
+                let mut existing_attr = self.query(Attribute::Value).map_or_else(
+                    || AttrValue::Payload(PropPayload::Any(CustomState::default().to_any_prop())),
+                    QueryResult::into_attr,
+                );
                 let tmp = existing_attr
                     .as_payload_mut()
                     .and_then(|v| v.as_any_mut())

--- a/crates/tuirealm/examples/async_ports.rs
+++ b/crates/tuirealm/examples/async_ports.rs
@@ -9,7 +9,9 @@ use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::component::{AppComponent, Component};
 use tuirealm::event::{Event, Key, KeyEvent};
 use tuirealm::listener::{EventListenerCfg, PollAsync, PortResult};
-use tuirealm::props::{AttrValue, Attribute, Color, HorizontalAlignment, Props, Style};
+use tuirealm::props::{
+    AttrValue, Attribute, Color, HorizontalAlignment, Props, QueryResult, Style,
+};
 use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::{Constraint, Direction, Layout, Rect};
 use tuirealm::ratatui::widgets::Paragraph;
@@ -258,8 +260,8 @@ impl Component for Label {
         );
     }
 
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
-        self.props.get(attr).cloned()
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+        self.props.get_for_query(attr)
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {

--- a/crates/tuirealm/examples/demo/components/clock.rs
+++ b/crates/tuirealm/examples/demo/components/clock.rs
@@ -8,7 +8,9 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::component::{AppComponent, Component};
 use tuirealm::event::{Event, NoUserEvent};
-use tuirealm::props::{AttrValue, Attribute, Color, HorizontalAlignment, TextModifiers};
+use tuirealm::props::{
+    AttrValue, Attribute, Color, HorizontalAlignment, QueryResult, TextModifiers,
+};
 use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
 use tuirealm::state::{State, StateValue};
@@ -75,7 +77,7 @@ impl Component for Clock {
         self.component.view(frame, area);
     }
 
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
         self.component.query(attr)
     }
 

--- a/crates/tuirealm/examples/demo/components/counter.rs
+++ b/crates/tuirealm/examples/demo/components/counter.rs
@@ -6,8 +6,8 @@ use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::component::{AppComponent, Component};
 use tuirealm::event::{Event, Key, KeyEvent, KeyModifiers, NoUserEvent};
 use tuirealm::props::{
-    AttrValue, Attribute, Borders, Color, HorizontalAlignment, LineStatic, Props, Style,
-    TextModifiers, Title,
+    AttrValue, AttrValueRef, Attribute, Borders, Color, HorizontalAlignment, LineStatic, Props,
+    QueryResult, Style, TextModifiers, Title,
 };
 use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
@@ -128,12 +128,12 @@ impl Component for Counter {
         );
     }
 
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
         if attr == Attribute::Value {
-            return Some(AttrValue::Number(self.states.counter));
+            return Some(AttrValueRef::Number(self.states.counter).into());
         }
 
-        self.props.get(attr).cloned()
+        self.props.get_for_query(attr)
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {

--- a/crates/tuirealm/examples/demo/components/label.rs
+++ b/crates/tuirealm/examples/demo/components/label.rs
@@ -6,7 +6,7 @@ use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::component::{AppComponent, Component};
 use tuirealm::event::{Event, NoUserEvent};
 use tuirealm::props::{
-    AttrValue, Attribute, Color, HorizontalAlignment, Props, Style, TextModifiers,
+    AttrValue, Attribute, Color, HorizontalAlignment, Props, QueryResult, Style, TextModifiers,
 };
 use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
@@ -103,8 +103,8 @@ impl Component for Label {
         );
     }
 
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
-        self.props.get(attr).cloned()
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+        self.props.get_for_query(attr)
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {

--- a/crates/tuirealm/examples/event_display.rs
+++ b/crates/tuirealm/examples/event_display.rs
@@ -5,7 +5,7 @@ use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::component::{AppComponent, Component};
 use tuirealm::event::{Event, Key, KeyEvent};
 use tuirealm::listener::EventListenerCfg;
-use tuirealm::props::{AttrValue, Attribute};
+use tuirealm::props::{AttrValue, Attribute, QueryResult};
 use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::{Constraint, Direction, Layout, Rect};
 use tuirealm::ratatui::widgets::Paragraph;
@@ -202,7 +202,7 @@ impl Component for Label {
         frame.render_widget(Paragraph::new(text), area);
     }
 
-    fn query(&self, _attr: Attribute) -> Option<AttrValue> {
+    fn query<'a>(&'a self, _attr: Attribute) -> Option<QueryResult<'a>> {
         None
     }
 
@@ -240,7 +240,7 @@ impl Component for EventDisplay {
         frame.render_widget(Paragraph::new(text), area);
     }
 
-    fn query(&self, _attr: Attribute) -> Option<AttrValue> {
+    fn query<'a>(&'a self, _attr: Attribute) -> Option<QueryResult<'a>> {
         None
     }
 

--- a/crates/tuirealm/examples/inline_display.rs
+++ b/crates/tuirealm/examples/inline_display.rs
@@ -5,7 +5,7 @@ use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::component::{AppComponent, Component};
 use tuirealm::event::{Event, Key, KeyEvent, NoUserEvent};
 use tuirealm::listener::EventListenerCfg;
-use tuirealm::props::{AttrValue, Attribute};
+use tuirealm::props::{AttrValue, Attribute, QueryResult};
 use tuirealm::ratatui::layout::{Constraint, Direction, Layout, Rect};
 use tuirealm::ratatui::style::{Color, Style};
 use tuirealm::ratatui::widgets::{LineGauge, Paragraph};
@@ -179,7 +179,7 @@ impl Component for Label {
         frame.render_widget(Paragraph::new(text), area);
     }
 
-    fn query(&self, _attr: Attribute) -> Option<AttrValue> {
+    fn query<'a>(&'a self, _attr: Attribute) -> Option<QueryResult<'a>> {
         None
     }
 
@@ -214,7 +214,7 @@ impl Component for ProgressBar {
         frame.render_widget(progressbar, area);
     }
 
-    fn query(&self, _attr: Attribute) -> Option<AttrValue> {
+    fn query<'a>(&'a self, _attr: Attribute) -> Option<QueryResult<'a>> {
         None
     }
 

--- a/crates/tuirealm/examples/user_events/components/label.rs
+++ b/crates/tuirealm/examples/user_events/components/label.rs
@@ -7,7 +7,9 @@ use std::time::UNIX_EPOCH;
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::component::{AppComponent, Component};
 use tuirealm::event::{Event, Key, KeyEvent};
-use tuirealm::props::{AttrValue, Attribute, Color, HorizontalAlignment, Props, Style};
+use tuirealm::props::{
+    AttrValue, Attribute, Color, HorizontalAlignment, Props, QueryResult, Style,
+};
 use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
 use tuirealm::ratatui::widgets::Paragraph;
@@ -73,8 +75,8 @@ impl Component for Label {
         );
     }
 
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
-        self.props.get(attr).cloned()
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+        self.props.get_for_query(attr)
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {

--- a/crates/tuirealm/src/core/application.rs
+++ b/crates/tuirealm/src/core/application.rs
@@ -11,7 +11,7 @@ use crate::component::AppComponent;
 use crate::event::Event;
 use crate::injector::Injector;
 use crate::listener::{EventListener, EventListenerCfg, ListenerError, PollError};
-use crate::props::{AttrValue, Attribute};
+use crate::props::{AttrValue, Attribute, QueryResult};
 use crate::ratatui::layout::Rect;
 use crate::state::State;
 use crate::subscription::{EventClause, Sub};
@@ -176,11 +176,11 @@ where
     /// Query view component for a certain `AttrValue`
     /// Returns error if the component doesn't exist
     /// Returns None if the attribute doesn't exist.
-    pub fn query(
-        &self,
+    pub fn query<'a>(
+        &'a self,
         id: &ComponentId,
         query: Attribute,
-    ) -> ApplicationResult<Option<AttrValue>> {
+    ) -> ApplicationResult<Option<QueryResult<'a>>> {
         self.view.query(id, query).map_err(ApplicationError::from)
     }
 

--- a/crates/tuirealm/src/core/component.rs
+++ b/crates/tuirealm/src/core/component.rs
@@ -9,7 +9,7 @@ pub use tuirealm_derive::Component;
 
 use crate::command::{Cmd, CmdResult};
 use crate::event::Event;
-use crate::props::{AttrValue, Attribute};
+use crate::props::{AttrValue, Attribute, QueryResult};
 use crate::ratatui::layout::Rect;
 use crate::state::State;
 
@@ -33,7 +33,13 @@ pub trait Component {
     fn view(&mut self, frame: &mut Frame, area: Rect);
 
     /// Query attribute of component properties.
-    fn query(&self, attr: Attribute) -> Option<AttrValue>;
+    ///
+    /// The result should always be [`QueryResult::Borrowed`] unless absolutely necessary.
+    /// In practice, [`QueryResult::Owned`] should only be used for when [`PropPayload::Any`](crate::props::PropPayload::Any) is required to be send.
+    ///
+    /// For handling both [`QueryResult`] cases *readonly*, [`as_ref`](QueryResult::as_ref) can be used.
+    /// For handling both [`QueryResult`] cases *mutably*, [`into_attr`](QueryResult::into_attr) can be used.
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>>;
 
     /// Set attribute to properties.
     /// `query` describes the name, while `attr` the value it'll take

--- a/crates/tuirealm/src/core/props/attr_value.rs
+++ b/crates/tuirealm/src/core/props/attr_value.rs
@@ -2,8 +2,8 @@ use ratatui::layout::{HorizontalAlignment, VerticalAlignment};
 use ratatui::style::{Color, Modifier as TextModifiers, Style};
 
 use crate::props::{
-    Borders, Direction, InputType, Layout, LineStatic, PropPayload, Shape, SpanStatic, Table,
-    TextStatic, Title,
+    AttrValueRef, Borders, Direction, InputType, Layout, LineStatic, PropPayload, Shape,
+    SpanStatic, Table, TextStatic, Title,
 };
 
 /// Describes a single attribute in the component properties.
@@ -35,6 +35,12 @@ pub enum AttrValue {
 }
 
 impl AttrValue {
+    /// Create a [`AttrValueRef`] from the current value.
+    #[inline]
+    pub fn as_attr_ref<'a>(&'a self) -> AttrValueRef<'a> {
+        self.into()
+    }
+
     // -- unwrappers
 
     /// Get the inner Horizontal Alignment value from AttrValue, or panic.

--- a/crates/tuirealm/src/core/props/attr_value_ref.rs
+++ b/crates/tuirealm/src/core/props/attr_value_ref.rs
@@ -479,6 +479,38 @@ impl<'a> PartialEq<AttrValueRef<'a>> for AttrValue {
     }
 }
 
+impl<'a> From<&'a AttrValue> for AttrValueRef<'a> {
+    fn from(value: &'a AttrValue) -> Self {
+        match value {
+            AttrValue::AlignmentHorizontal(horizontal_alignment) => {
+                Self::AlignmentHorizontal(*horizontal_alignment)
+            }
+            AttrValue::AlignmentVertical(vertical_alignment) => {
+                Self::AlignmentVertical(*vertical_alignment)
+            }
+            AttrValue::Borders(borders) => Self::Borders(*borders),
+            AttrValue::Color(color) => Self::Color(*color),
+            AttrValue::Direction(direction) => Self::Direction(*direction),
+            AttrValue::Flag(flag) => Self::Flag(*flag),
+            AttrValue::InputType(input_type) => Self::InputType(input_type),
+            AttrValue::Layout(layout) => Self::Layout(layout),
+            AttrValue::Length(length) => Self::Length(*length),
+            AttrValue::Number(number) => Self::Number(*number),
+            AttrValue::Shape(shape) => Self::Shape(shape),
+            AttrValue::Size(size) => Self::Size(*size),
+            AttrValue::String(string) => Self::String(string),
+            AttrValue::Style(style) => Self::Style(*style),
+            AttrValue::Table(items) => Self::Table(items),
+            AttrValue::TextSpan(span) => Self::TextSpan(span),
+            AttrValue::TextLine(line) => Self::TextLine(line),
+            AttrValue::Text(text) => Self::Text(text),
+            AttrValue::TextModifiers(modifier) => Self::TextModifiers(*modifier),
+            AttrValue::Title(title) => Self::Title(title),
+            AttrValue::Payload(prop_payload) => Self::Payload(prop_payload.into()),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use pretty_assertions::assert_eq;
@@ -824,6 +856,94 @@ mod tests {
             AttrValueRef::Payload(PropPayloadRef::None) == AttrValue::Payload(PropPayload::None)
         );
         assert!(!(AttrValueRef::Payload(PropPayloadRef::None) == AttrValue::Flag(false)));
+    }
+
+    #[test]
+    fn from_nonref_attrvalue() {
+        assert_eq!(
+            AttrValueRef::from(&AttrValue::Flag(true)),
+            AttrValueRef::Flag(true)
+        );
+        assert_eq!(
+            AttrValueRef::from(&AttrValue::Size(1)),
+            AttrValueRef::Size(1)
+        );
+        assert_eq!(
+            AttrValueRef::from(&AttrValue::AlignmentHorizontal(HorizontalAlignment::Center)),
+            AttrValueRef::AlignmentHorizontal(HorizontalAlignment::Center)
+        );
+        assert_eq!(
+            AttrValueRef::from(&AttrValue::AlignmentVertical(VerticalAlignment::Bottom)),
+            AttrValueRef::AlignmentVertical(VerticalAlignment::Bottom)
+        );
+        assert_eq!(
+            AttrValueRef::from(&AttrValue::Borders(Borders::default())),
+            AttrValueRef::Borders(Borders::default())
+        );
+        assert_eq!(
+            AttrValueRef::from(&AttrValue::Color(Color::Black)),
+            AttrValueRef::Color(Color::Black)
+        );
+        assert_eq!(
+            AttrValueRef::from(&AttrValue::Direction(Direction::Down)),
+            AttrValueRef::Direction(Direction::Down)
+        );
+        assert_eq!(
+            AttrValueRef::from(&AttrValue::InputType(InputType::Color)),
+            AttrValueRef::InputType(&InputType::Color)
+        );
+        assert_eq!(
+            AttrValueRef::from(&AttrValue::Layout(Layout::default())),
+            AttrValueRef::Layout(&Layout::default())
+        );
+        assert_eq!(
+            AttrValueRef::from(&AttrValue::Length(1)),
+            AttrValueRef::Length(1)
+        );
+        assert_eq!(
+            AttrValueRef::from(&AttrValue::Number(1)),
+            AttrValueRef::Number(1)
+        );
+        assert_eq!(
+            AttrValueRef::from(&AttrValue::Shape(Shape::Layer)),
+            AttrValueRef::Shape(&Shape::Layer)
+        );
+        assert_eq!(
+            AttrValueRef::from(&AttrValue::String("hello".to_string())),
+            AttrValueRef::String("hello")
+        );
+        assert_eq!(
+            AttrValueRef::from(&AttrValue::Style(Style::default())),
+            AttrValueRef::Style(Style::default())
+        );
+        assert_eq!(
+            AttrValueRef::from(&AttrValue::Table(Table::new())),
+            AttrValueRef::Table(&Table::new())
+        );
+        assert_eq!(
+            AttrValueRef::from(&AttrValue::TextSpan(SpanStatic::from("hello"))),
+            AttrValueRef::TextSpan(&SpanStatic::from("hello"))
+        );
+        assert_eq!(
+            AttrValueRef::from(&AttrValue::TextLine(LineStatic::from("hello"))),
+            AttrValueRef::TextLine(&LineStatic::from("hello"))
+        );
+        assert_eq!(
+            AttrValueRef::from(&AttrValue::Text(TextStatic::from("hello"))),
+            AttrValueRef::Text(&TextStatic::from("hello"))
+        );
+        assert_eq!(
+            AttrValueRef::from(&AttrValue::TextModifiers(TextModifiers::default())),
+            AttrValueRef::TextModifiers(TextModifiers::default())
+        );
+        assert_eq!(
+            AttrValueRef::from(&AttrValue::Title(Title::default())),
+            AttrValueRef::Title(&Title::default())
+        );
+        assert_eq!(
+            AttrValueRef::from(&AttrValue::Payload(PropPayload::None)),
+            AttrValueRef::Payload(PropPayloadRef::None)
+        );
     }
 
     #[test]

--- a/crates/tuirealm/src/core/props/attr_value_ref.rs
+++ b/crates/tuirealm/src/core/props/attr_value_ref.rs
@@ -1,0 +1,804 @@
+use ratatui::layout::{HorizontalAlignment, VerticalAlignment};
+use ratatui::style::{Color, Modifier as TextModifiers, Style};
+use ratatui::text::{Line, Span, Text};
+
+use crate::props::prop_value_ref::PropPayloadRef;
+use crate::props::{Borders, Direction, InputType, Layout, Shape, Table, Title};
+
+/// Describes a single attribute in the component properties as a reference.
+#[derive(Debug, PartialEq, Clone)]
+#[allow(clippy::large_enum_variant)]
+pub enum AttrValueRef<'a> {
+    AlignmentHorizontal(HorizontalAlignment),
+    AlignmentVertical(VerticalAlignment),
+    Borders(Borders),
+    Color(Color),
+    Direction(Direction),
+    Flag(bool),
+    InputType(&'a InputType),
+    Layout(&'a Layout),
+    Length(usize),
+    Number(isize),
+    Shape(&'a Shape),
+    Size(u16),
+    String(&'a str),
+    Style(Style),
+    Table(&'a Table),
+    TextSpan(&'a Span<'a>),
+    TextLine(&'a Line<'a>),
+    Text(&'a Text<'a>),
+    TextModifiers(TextModifiers),
+    Title(&'a Title),
+    /// User defined complex attribute value
+    Payload(PropPayloadRef<'a>),
+}
+
+impl<'a> AttrValueRef<'a> {
+    // -- unwrappers
+
+    /// Get the inner Horizontal Alignment value from AttrValue, or panic.
+    pub fn unwrap_alignment_horizontal(self) -> HorizontalAlignment {
+        match self {
+            AttrValueRef::AlignmentHorizontal(v) => v,
+            _ => panic!("AttrValue is not AlignmentHorizontal"),
+        }
+    }
+
+    /// Get the inner Vertical Alignment value from AttrValue, or panic.
+    pub fn unwrap_alignment_vertical(self) -> VerticalAlignment {
+        match self {
+            AttrValueRef::AlignmentVertical(v) => v,
+            _ => panic!("AttrValue is not AlignmentVertical"),
+        }
+    }
+
+    /// Get the inner Borders value from AttrValue, or panic.
+    pub fn unwrap_borders(self) -> Borders {
+        match self {
+            AttrValueRef::Borders(b) => b,
+            _ => panic!("AttrValue is not Borders"),
+        }
+    }
+
+    /// Get the inner Color value from AttrValue, or panic.
+    pub fn unwrap_color(self) -> Color {
+        match self {
+            AttrValueRef::Color(x) => x,
+            _ => panic!("AttrValue is not Color"),
+        }
+    }
+
+    /// Get the inner Direction value from AttrValue, or panic.
+    pub fn unwrap_direction(self) -> Direction {
+        match self {
+            AttrValueRef::Direction(x) => x,
+            _ => panic!("AttrValue is not Direction"),
+        }
+    }
+
+    /// Get the inner Flag value from AttrValue, or panic.
+    pub fn unwrap_flag(self) -> bool {
+        match self {
+            AttrValueRef::Flag(x) => x,
+            _ => panic!("AttrValue is not Flag"),
+        }
+    }
+
+    /// Get the inner InputType value from AttrValue, or panic.
+    pub fn unwrap_input_type(self) -> &'a InputType {
+        match self {
+            AttrValueRef::InputType(x) => x,
+            _ => panic!("AttrValue is not InputType"),
+        }
+    }
+
+    /// Get the inner Layout value from AttrValue, or panic.
+    pub fn unwrap_layout(self) -> &'a Layout {
+        match self {
+            AttrValueRef::Layout(l) => l,
+            _ => panic!("AttrValue is not a Layout"),
+        }
+    }
+
+    /// Get the inner Length value from AttrValue, or panic.
+    pub fn unwrap_length(self) -> usize {
+        match self {
+            AttrValueRef::Length(x) => x,
+            _ => panic!("AttrValue is not Length"),
+        }
+    }
+
+    /// Get the inner Number value from AttrValue, or panic.
+    pub fn unwrap_number(self) -> isize {
+        match self {
+            AttrValueRef::Number(x) => x,
+            _ => panic!("AttrValue is not Number"),
+        }
+    }
+
+    /// Get the inner Shape value from AttrValue, or panic.
+    pub fn unwrap_shape(self) -> &'a Shape {
+        match self {
+            AttrValueRef::Shape(x) => x,
+            _ => panic!("AttrValue is not Shape"),
+        }
+    }
+
+    /// Get the inner Size value from AttrValue, or panic.
+    pub fn unwrap_size(self) -> u16 {
+        match self {
+            AttrValueRef::Size(x) => x,
+            _ => panic!("AttrValue is not Size"),
+        }
+    }
+
+    /// Get the inner String value from AttrValue, or panic.
+    pub fn unwrap_string(self) -> &'a str {
+        match self {
+            AttrValueRef::String(x) => x,
+            _ => panic!("AttrValue is not String"),
+        }
+    }
+
+    /// Get the inner Style value from AttrValue, or panic.
+    pub fn unwrap_style(self) -> Style {
+        match self {
+            AttrValueRef::Style(x) => x,
+            _ => panic!("AttrValue is not Style"),
+        }
+    }
+
+    /// Get the inner Table value from AttrValue, or panic.
+    pub fn unwrap_table(self) -> &'a Table {
+        match self {
+            AttrValueRef::Table(x) => x,
+            _ => panic!("AttrValue is not Table"),
+        }
+    }
+
+    /// Get the inner [`SpanStatic`] value from AttrValue, or panic.
+    pub fn unwrap_textspan(self) -> &'a Span<'a> {
+        match self {
+            AttrValueRef::TextSpan(x) => x,
+            _ => panic!("AttrValue is not TextSpan"),
+        }
+    }
+
+    /// Get the inner [`LineStatic`] value from AttrValue, or panic.
+    pub fn unwrap_textline(self) -> &'a Line<'a> {
+        match self {
+            AttrValueRef::TextLine(x) => x,
+            _ => panic!("AttrValue is not TextLine"),
+        }
+    }
+
+    /// Get the inner [`TextStatic`] value from AttrValue, or panic.
+    pub fn unwrap_text(self) -> &'a Text<'a> {
+        match self {
+            AttrValueRef::Text(x) => x,
+            _ => panic!("AttrValue is not Text"),
+        }
+    }
+
+    /// Get the inner TextModifiers value from AttrValue, or panic.
+    pub fn unwrap_text_modifiers(self) -> TextModifiers {
+        match self {
+            AttrValueRef::TextModifiers(x) => x,
+            _ => panic!("AttrValue is not TextModifiers"),
+        }
+    }
+
+    /// Get the inner [`Title`] value from AttrValue, or panic.
+    pub fn unwrap_title(self) -> &'a Title {
+        match self {
+            AttrValueRef::Title(x) => x,
+            _ => panic!("AttrValue is not Title"),
+        }
+    }
+
+    /// Get the inner Payload value from AttrValue, or panic.
+    pub fn unwrap_payload(self) -> PropPayloadRef<'a> {
+        match self {
+            AttrValueRef::Payload(x) => x,
+            _ => panic!("AttrValue is not Payload"),
+        }
+    }
+
+    // -- as reference
+
+    /// Get a Horizontal Alignment value from AttrValue, or None
+    pub fn as_alignment_horizontal(&self) -> Option<HorizontalAlignment> {
+        match self {
+            // cheap copy, so no reference
+            AttrValueRef::AlignmentHorizontal(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Get a Vertical Alignment value from AttrValue, or None
+    pub fn as_alignment_vertical(&self) -> Option<VerticalAlignment> {
+        match self {
+            // cheap copy, so no reference
+            AttrValueRef::AlignmentVertical(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Get a Borders value from AttrValue, or None
+    pub fn as_borders(&self) -> Option<Borders> {
+        match self {
+            // cheap copy, so no reference
+            AttrValueRef::Borders(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Get a Color value from AttrValue, or None
+    pub fn as_color(&self) -> Option<Color> {
+        match self {
+            // cheap copy, so no reference
+            AttrValueRef::Color(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Get a Direction value from AttrValue, or None
+    pub fn as_direction(&self) -> Option<Direction> {
+        match self {
+            // cheap copy, so no reference
+            AttrValueRef::Direction(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Get a Flag value from AttrValue, or None
+    pub fn as_flag(&self) -> Option<bool> {
+        match self {
+            // cheap copy, so no reference
+            AttrValueRef::Flag(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Get a InputType value from AttrValue, or None
+    pub fn as_input_type(&self) -> Option<&'a InputType> {
+        match self {
+            AttrValueRef::InputType(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Get a Layout value from AttrValue, or None
+    pub fn as_layout(&self) -> Option<&'a Layout> {
+        match self {
+            AttrValueRef::Layout(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Get a Length value from AttrValue, or None
+    pub fn as_length(&self) -> Option<usize> {
+        match self {
+            // cheap copy, so no reference
+            AttrValueRef::Length(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Get a Number value from AttrValue, or None
+    pub fn as_number(&self) -> Option<isize> {
+        match self {
+            // cheap copy, so no reference
+            AttrValueRef::Number(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Get a Shape value from AttrValue, or None
+    pub fn as_shape(&self) -> Option<&'a Shape> {
+        match self {
+            AttrValueRef::Shape(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Get a Size value from AttrValue, or None
+    pub fn as_size(&self) -> Option<u16> {
+        match self {
+            // cheap copy, so no reference
+            AttrValueRef::Size(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Get a String value from AttrValue, or None
+    pub fn as_string(&self) -> Option<&'a str> {
+        match self {
+            AttrValueRef::String(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Get a Style value from AttrValue, or None
+    pub fn as_style(&self) -> Option<Style> {
+        match self {
+            // cheap copy, so no reference
+            AttrValueRef::Style(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Get a Table value from AttrValue, or None
+    pub fn as_table(&self) -> Option<&'a Table> {
+        match self {
+            AttrValueRef::Table(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Get a [`SpanStatic`] value from AttrValue, or None
+    pub fn as_textspan(&self) -> Option<&'a Span<'a>> {
+        match self {
+            AttrValueRef::TextSpan(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Get a [`LineStatic`] value from AttrValue, or None
+    pub fn as_textline(&self) -> Option<&'a Line<'a>> {
+        match self {
+            AttrValueRef::TextLine(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Get a [`TextStatic`] value from AttrValue, or None
+    pub fn as_text(&self) -> Option<&'a Text<'a>> {
+        match self {
+            AttrValueRef::Text(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Get a TextModifiers value from AttrValue, or None
+    pub fn as_text_modifiers(&self) -> Option<TextModifiers> {
+        match self {
+            // cheap copy, so no reference
+            AttrValueRef::TextModifiers(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Get a [`Title`] value from AttrValue, or None
+    pub fn as_title(&self) -> Option<&Title> {
+        match self {
+            AttrValueRef::Title(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Get a Payload value from AttrValue, or None
+    pub fn as_payload(&self) -> Option<PropPayloadRef<'a>> {
+        match self {
+            AttrValueRef::Payload(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    // -- as mutable references
+
+    /// Get a Horizontal Alignment value from AttrValue, or None
+    pub fn as_alignment_horizontal_mut(&mut self) -> Option<&mut HorizontalAlignment> {
+        match self {
+            AttrValueRef::AlignmentHorizontal(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Get a Vertical Alignment value from AttrValue, or None
+    pub fn as_alignment_vertical_mut(&mut self) -> Option<&mut VerticalAlignment> {
+        match self {
+            AttrValueRef::AlignmentVertical(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Get a Borders value from AttrValue, or None
+    pub fn as_borders_mut(&mut self) -> Option<&mut Borders> {
+        match self {
+            AttrValueRef::Borders(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Get a Color value from AttrValue, or None
+    pub fn as_color_mut(&mut self) -> Option<&mut Color> {
+        match self {
+            AttrValueRef::Color(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Get a Direction value from AttrValue, or None
+    pub fn as_direction_mut(&mut self) -> Option<&mut Direction> {
+        match self {
+            AttrValueRef::Direction(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Get a Flag value from AttrValue, or None
+    pub fn as_flag_mut(&mut self) -> Option<&mut bool> {
+        match self {
+            AttrValueRef::Flag(v) => Some(v),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+    use crate::props::{LineStatic, SpanStatic, TextStatic};
+
+    #[test]
+    fn unwrapping_should_unwrap() {
+        assert_eq!(
+            AttrValueRef::AlignmentHorizontal(HorizontalAlignment::Center)
+                .unwrap_alignment_horizontal(),
+            HorizontalAlignment::Center
+        );
+        assert_eq!(
+            AttrValueRef::AlignmentVertical(VerticalAlignment::Top).unwrap_alignment_vertical(),
+            VerticalAlignment::Top
+        );
+        assert_eq!(
+            AttrValueRef::Borders(Borders::default()).unwrap_borders(),
+            Borders::default()
+        );
+        assert_eq!(AttrValueRef::Color(Color::Red).unwrap_color(), Color::Red);
+        assert_eq!(
+            AttrValueRef::Direction(Direction::Left).unwrap_direction(),
+            Direction::Left
+        );
+        assert_eq!(AttrValueRef::Flag(true).unwrap_flag(), true);
+        assert_eq!(
+            AttrValueRef::InputType(&InputType::Number).unwrap_input_type(),
+            &InputType::Number
+        );
+        assert_eq!(
+            AttrValueRef::Layout(&Layout::default()).unwrap_layout(),
+            &Layout::default()
+        );
+        assert_eq!(AttrValueRef::Length(12).unwrap_length(), 12);
+        assert_eq!(AttrValueRef::Number(-24).unwrap_number(), -24);
+        assert_eq!(
+            AttrValueRef::Shape(&Shape::Layer).unwrap_shape(),
+            &Shape::Layer
+        );
+        assert_eq!(AttrValueRef::Size(12).unwrap_size(), 12);
+        assert_eq!(
+            AttrValueRef::String(&String::from("pippo")).unwrap_string(),
+            String::from("pippo")
+        );
+        assert_eq!(
+            AttrValueRef::Style(Style::default()).unwrap_style(),
+            Style::default()
+        );
+        assert_eq!(
+            AttrValueRef::Table(&Table::default()).unwrap_table(),
+            &Table::default()
+        );
+        assert_eq!(
+            AttrValueRef::TextSpan(&SpanStatic::default()).unwrap_textspan(),
+            &SpanStatic::default()
+        );
+        assert_eq!(
+            AttrValueRef::TextLine(&LineStatic::default()).unwrap_textline(),
+            &LineStatic::default()
+        );
+        assert_eq!(
+            AttrValueRef::Text(&TextStatic::default()).unwrap_text(),
+            &TextStatic::default()
+        );
+        assert_eq!(
+            AttrValueRef::TextModifiers(TextModifiers::BOLD).unwrap_text_modifiers(),
+            TextModifiers::BOLD
+        );
+        assert_eq!(
+            AttrValueRef::Title(
+                &Title::from(String::from("pippo")).alignment(HorizontalAlignment::Left)
+            )
+            .unwrap_title(),
+            (&Title::from(String::from("pippo")).alignment(HorizontalAlignment::Left))
+        );
+        assert_eq!(
+            AttrValueRef::Payload(PropPayloadRef::None).unwrap_payload(),
+            PropPayloadRef::None
+        );
+    }
+
+    #[test]
+    fn as_attrvalue() {
+        assert_eq!(
+            AttrValueRef::AlignmentHorizontal(HorizontalAlignment::Center)
+                .as_alignment_horizontal(),
+            Some(HorizontalAlignment::Center)
+        );
+        assert_eq!(
+            AttrValueRef::Color(Color::Black).as_alignment_horizontal(),
+            None
+        );
+        assert_eq!(
+            AttrValueRef::AlignmentVertical(VerticalAlignment::Top).as_alignment_vertical(),
+            Some(VerticalAlignment::Top)
+        );
+        assert_eq!(
+            AttrValueRef::Color(Color::Black).as_alignment_vertical(),
+            None
+        );
+
+        assert_eq!(
+            AttrValueRef::Borders(Borders::default()).as_borders(),
+            Some(Borders::default())
+        );
+        assert_eq!(
+            AttrValueRef::AlignmentHorizontal(HorizontalAlignment::Center).as_borders(),
+            None
+        );
+
+        assert_eq!(
+            AttrValueRef::Color(Color::Black).as_color(),
+            Some(Color::Black)
+        );
+        assert_eq!(
+            AttrValueRef::AlignmentHorizontal(HorizontalAlignment::Center).as_color(),
+            None
+        );
+
+        assert_eq!(
+            AttrValueRef::Direction(Direction::Down).as_direction(),
+            Some(Direction::Down)
+        );
+        assert_eq!(
+            AttrValueRef::AlignmentHorizontal(HorizontalAlignment::Center).as_direction(),
+            None
+        );
+
+        assert_eq!(AttrValueRef::Flag(true).as_flag(), Some(true));
+        assert_eq!(
+            AttrValueRef::AlignmentHorizontal(HorizontalAlignment::Center).as_flag(),
+            None
+        );
+
+        assert_eq!(
+            AttrValueRef::InputType(&InputType::Color).as_input_type(),
+            Some(&InputType::Color)
+        );
+        assert_eq!(
+            AttrValueRef::AlignmentHorizontal(HorizontalAlignment::Center).as_input_type(),
+            None
+        );
+
+        assert_eq!(
+            AttrValueRef::Layout(&Layout::default()).as_layout(),
+            Some(&Layout::default())
+        );
+        assert_eq!(
+            AttrValueRef::AlignmentHorizontal(HorizontalAlignment::Center).as_layout(),
+            None
+        );
+
+        assert_eq!(AttrValueRef::Length(1).as_length(), Some(1));
+        assert_eq!(
+            AttrValueRef::AlignmentHorizontal(HorizontalAlignment::Center).as_length(),
+            None
+        );
+
+        assert_eq!(AttrValueRef::Number(-1).as_number(), Some(-1));
+        assert_eq!(
+            AttrValueRef::AlignmentHorizontal(HorizontalAlignment::Center).as_number(),
+            None
+        );
+
+        assert_eq!(
+            AttrValueRef::Shape(&Shape::Layer).as_shape(),
+            Some(&Shape::Layer)
+        );
+        assert_eq!(
+            AttrValueRef::AlignmentHorizontal(HorizontalAlignment::Center).as_shape(),
+            None
+        );
+
+        assert_eq!(AttrValueRef::Size(1).as_size(), Some(1));
+        assert_eq!(
+            AttrValueRef::AlignmentHorizontal(HorizontalAlignment::Center).as_size(),
+            None
+        );
+
+        assert_eq!(AttrValueRef::String("hello").as_string(), Some("hello"));
+        assert_eq!(
+            AttrValueRef::AlignmentHorizontal(HorizontalAlignment::Center).as_string(),
+            None
+        );
+
+        assert_eq!(
+            AttrValueRef::Style(Style::default()).as_style(),
+            Some(Style::default())
+        );
+        assert_eq!(
+            AttrValueRef::AlignmentHorizontal(HorizontalAlignment::Center).as_style(),
+            None
+        );
+
+        assert_eq!(
+            AttrValueRef::Table(&Vec::new()).as_table(),
+            Some(&Vec::new())
+        );
+        assert_eq!(
+            AttrValueRef::AlignmentHorizontal(HorizontalAlignment::Center).as_table(),
+            None
+        );
+
+        assert_eq!(
+            AttrValueRef::TextSpan(&SpanStatic::default()).as_textspan(),
+            Some(&SpanStatic::default())
+        );
+        assert_eq!(
+            AttrValueRef::TextLine(&LineStatic::default()).as_textline(),
+            Some(&LineStatic::default())
+        );
+        assert_eq!(
+            AttrValueRef::Text(&TextStatic::default()).as_text(),
+            Some(&TextStatic::default())
+        );
+        assert_eq!(
+            AttrValueRef::AlignmentHorizontal(HorizontalAlignment::Center).as_text(),
+            None
+        );
+
+        assert_eq!(
+            AttrValueRef::TextModifiers(TextModifiers::all()).as_text_modifiers(),
+            Some(TextModifiers::all())
+        );
+        assert_eq!(
+            AttrValueRef::AlignmentHorizontal(HorizontalAlignment::Center).as_text_modifiers(),
+            None
+        );
+
+        assert_eq!(
+            AttrValueRef::Title(&Title::from("hello").alignment(HorizontalAlignment::Center))
+                .as_title(),
+            Some(&Title::from("hello").alignment(HorizontalAlignment::Center))
+        );
+        assert_eq!(
+            AttrValueRef::AlignmentHorizontal(HorizontalAlignment::Center).as_title(),
+            None
+        );
+
+        assert_eq!(
+            AttrValueRef::Payload(PropPayloadRef::None).as_payload(),
+            Some(PropPayloadRef::None)
+        );
+        assert_eq!(
+            AttrValueRef::AlignmentHorizontal(HorizontalAlignment::Center).as_payload(),
+            None
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn unwrapping_alignment_horizontal_should_panic_if_not_identity() {
+        AttrValueRef::Flag(true).unwrap_alignment_horizontal();
+    }
+
+    #[test]
+    #[should_panic]
+    fn unwrapping_alignment_vertical_should_panic_if_not_identity() {
+        AttrValueRef::Flag(true).unwrap_alignment_vertical();
+    }
+
+    #[test]
+    #[should_panic]
+    fn unwrapping_borders_should_panic_if_not_identity() {
+        AttrValueRef::Flag(true).unwrap_borders();
+    }
+
+    #[test]
+    #[should_panic]
+    fn unwrapping_color_should_panic_if_not_identity() {
+        AttrValueRef::Flag(true).unwrap_color();
+    }
+
+    #[test]
+    #[should_panic]
+    fn unwrapping_direction_should_panic_if_not_identity() {
+        AttrValueRef::Flag(true).unwrap_direction();
+    }
+
+    #[test]
+    #[should_panic]
+    fn unwrapping_flag_should_panic_if_not_identity() {
+        AttrValueRef::Borders(Borders::default()).unwrap_flag();
+    }
+
+    #[test]
+    #[should_panic]
+    fn unwrapping_inputtype_should_panic_if_not_identity() {
+        AttrValueRef::Flag(true).unwrap_input_type();
+    }
+
+    #[test]
+    #[should_panic]
+    fn unwrapping_layout_should_panic_if_not_identity() {
+        AttrValueRef::Flag(true).unwrap_layout();
+    }
+
+    #[test]
+    #[should_panic]
+    fn unwrapping_length_should_panic_if_not_identity() {
+        AttrValueRef::Flag(true).unwrap_length();
+    }
+
+    #[test]
+    #[should_panic]
+    fn unwrapping_number_should_panic_if_not_identity() {
+        AttrValueRef::Flag(true).unwrap_number();
+    }
+
+    #[test]
+    #[should_panic]
+    fn unwrapping_shape_should_panic_if_not_identity() {
+        AttrValueRef::Flag(true).unwrap_shape();
+    }
+
+    #[test]
+    #[should_panic]
+    fn unwrapping_size_should_panic_if_not_identity() {
+        AttrValueRef::Flag(true).unwrap_size();
+    }
+
+    #[test]
+    #[should_panic]
+    fn unwrapping_string_should_panic_if_not_identity() {
+        AttrValueRef::Flag(true).unwrap_string();
+    }
+
+    #[test]
+    #[should_panic]
+    fn unwrapping_style_should_panic_if_not_identity() {
+        AttrValueRef::Flag(true).unwrap_style();
+    }
+
+    #[test]
+    #[should_panic]
+    fn unwrapping_table_should_panic_if_not_identity() {
+        AttrValueRef::Flag(true).unwrap_table();
+    }
+
+    #[test]
+    #[should_panic]
+    fn unwrapping_text_should_panic_if_not_identity() {
+        AttrValueRef::Flag(true).unwrap_text();
+    }
+
+    #[test]
+    #[should_panic]
+    fn unwrapping_textmodifiers_should_panic_if_not_identity() {
+        AttrValueRef::Flag(true).unwrap_text_modifiers();
+    }
+
+    #[test]
+    #[should_panic]
+    fn unwrapping_title_should_panic_if_not_identity() {
+        AttrValueRef::Flag(true).unwrap_title();
+    }
+
+    #[test]
+    #[should_panic]
+    fn unwrapping_payload_should_panic_if_not_identity() {
+        AttrValueRef::Flag(true).unwrap_payload();
+    }
+}

--- a/crates/tuirealm/src/core/props/attr_value_ref.rs
+++ b/crates/tuirealm/src/core/props/attr_value_ref.rs
@@ -7,7 +7,7 @@ use crate::props::{AttrValue, Borders, Direction, InputType, Layout, Shape, Tabl
 use crate::utils::{clone_line, clone_span, clone_text};
 
 /// Describes a single attribute in the component properties as a reference.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 #[allow(clippy::large_enum_variant)]
 pub enum AttrValueRef<'a> {
     AlignmentHorizontal(HorizontalAlignment),
@@ -208,61 +208,55 @@ impl<'a> AttrValueRef<'a> {
     // -- as reference
 
     /// Get a Horizontal Alignment value from AttrValue, or None
-    pub fn as_alignment_horizontal(&self) -> Option<HorizontalAlignment> {
+    pub fn as_alignment_horizontal(self) -> Option<HorizontalAlignment> {
         match self {
-            // cheap copy, so no reference
-            AttrValueRef::AlignmentHorizontal(v) => Some(*v),
+            AttrValueRef::AlignmentHorizontal(v) => Some(v),
             _ => None,
         }
     }
 
     /// Get a Vertical Alignment value from AttrValue, or None
-    pub fn as_alignment_vertical(&self) -> Option<VerticalAlignment> {
+    pub fn as_alignment_vertical(self) -> Option<VerticalAlignment> {
         match self {
-            // cheap copy, so no reference
-            AttrValueRef::AlignmentVertical(v) => Some(*v),
+            AttrValueRef::AlignmentVertical(v) => Some(v),
             _ => None,
         }
     }
 
     /// Get a Borders value from AttrValue, or None
-    pub fn as_borders(&self) -> Option<Borders> {
+    pub fn as_borders(self) -> Option<Borders> {
         match self {
-            // cheap copy, so no reference
-            AttrValueRef::Borders(v) => Some(*v),
+            AttrValueRef::Borders(v) => Some(v),
             _ => None,
         }
     }
 
     /// Get a Color value from AttrValue, or None
-    pub fn as_color(&self) -> Option<Color> {
+    pub fn as_color(self) -> Option<Color> {
         match self {
-            // cheap copy, so no reference
-            AttrValueRef::Color(v) => Some(*v),
+            AttrValueRef::Color(v) => Some(v),
             _ => None,
         }
     }
 
     /// Get a Direction value from AttrValue, or None
-    pub fn as_direction(&self) -> Option<Direction> {
+    pub fn as_direction(self) -> Option<Direction> {
         match self {
-            // cheap copy, so no reference
-            AttrValueRef::Direction(v) => Some(*v),
+            AttrValueRef::Direction(v) => Some(v),
             _ => None,
         }
     }
 
     /// Get a Flag value from AttrValue, or None
-    pub fn as_flag(&self) -> Option<bool> {
+    pub fn as_flag(self) -> Option<bool> {
         match self {
-            // cheap copy, so no reference
-            AttrValueRef::Flag(v) => Some(*v),
+            AttrValueRef::Flag(v) => Some(v),
             _ => None,
         }
     }
 
     /// Get a InputType value from AttrValue, or None
-    pub fn as_input_type(&self) -> Option<&'a InputType> {
+    pub fn as_input_type(self) -> Option<&'a InputType> {
         match self {
             AttrValueRef::InputType(v) => Some(v),
             _ => None,
@@ -270,7 +264,7 @@ impl<'a> AttrValueRef<'a> {
     }
 
     /// Get a Layout value from AttrValue, or None
-    pub fn as_layout(&self) -> Option<&'a Layout> {
+    pub fn as_layout(self) -> Option<&'a Layout> {
         match self {
             AttrValueRef::Layout(v) => Some(v),
             _ => None,
@@ -278,25 +272,23 @@ impl<'a> AttrValueRef<'a> {
     }
 
     /// Get a Length value from AttrValue, or None
-    pub fn as_length(&self) -> Option<usize> {
+    pub fn as_length(self) -> Option<usize> {
         match self {
-            // cheap copy, so no reference
-            AttrValueRef::Length(v) => Some(*v),
+            AttrValueRef::Length(v) => Some(v),
             _ => None,
         }
     }
 
     /// Get a Number value from AttrValue, or None
-    pub fn as_number(&self) -> Option<isize> {
+    pub fn as_number(self) -> Option<isize> {
         match self {
-            // cheap copy, so no reference
-            AttrValueRef::Number(v) => Some(*v),
+            AttrValueRef::Number(v) => Some(v),
             _ => None,
         }
     }
 
     /// Get a Shape value from AttrValue, or None
-    pub fn as_shape(&self) -> Option<&'a Shape> {
+    pub fn as_shape(self) -> Option<&'a Shape> {
         match self {
             AttrValueRef::Shape(v) => Some(v),
             _ => None,
@@ -304,16 +296,15 @@ impl<'a> AttrValueRef<'a> {
     }
 
     /// Get a Size value from AttrValue, or None
-    pub fn as_size(&self) -> Option<u16> {
+    pub fn as_size(self) -> Option<u16> {
         match self {
-            // cheap copy, so no reference
-            AttrValueRef::Size(v) => Some(*v),
+            AttrValueRef::Size(v) => Some(v),
             _ => None,
         }
     }
 
     /// Get a String value from AttrValue, or None
-    pub fn as_string(&self) -> Option<&'a str> {
+    pub fn as_string(self) -> Option<&'a str> {
         match self {
             AttrValueRef::String(v) => Some(v),
             _ => None,
@@ -321,16 +312,15 @@ impl<'a> AttrValueRef<'a> {
     }
 
     /// Get a Style value from AttrValue, or None
-    pub fn as_style(&self) -> Option<Style> {
+    pub fn as_style(self) -> Option<Style> {
         match self {
-            // cheap copy, so no reference
-            AttrValueRef::Style(v) => Some(*v),
+            AttrValueRef::Style(v) => Some(v),
             _ => None,
         }
     }
 
     /// Get a Table value from AttrValue, or None
-    pub fn as_table(&self) -> Option<&'a Table> {
+    pub fn as_table(self) -> Option<&'a Table> {
         match self {
             AttrValueRef::Table(v) => Some(v),
             _ => None,
@@ -338,7 +328,7 @@ impl<'a> AttrValueRef<'a> {
     }
 
     /// Get a [`SpanStatic`] value from AttrValue, or None
-    pub fn as_textspan(&self) -> Option<&'a Span<'a>> {
+    pub fn as_textspan(self) -> Option<&'a Span<'a>> {
         match self {
             AttrValueRef::TextSpan(v) => Some(v),
             _ => None,
@@ -346,7 +336,7 @@ impl<'a> AttrValueRef<'a> {
     }
 
     /// Get a [`LineStatic`] value from AttrValue, or None
-    pub fn as_textline(&self) -> Option<&'a Line<'a>> {
+    pub fn as_textline(self) -> Option<&'a Line<'a>> {
         match self {
             AttrValueRef::TextLine(v) => Some(v),
             _ => None,
@@ -354,7 +344,7 @@ impl<'a> AttrValueRef<'a> {
     }
 
     /// Get a [`TextStatic`] value from AttrValue, or None
-    pub fn as_text(&self) -> Option<&'a Text<'a>> {
+    pub fn as_text(self) -> Option<&'a Text<'a>> {
         match self {
             AttrValueRef::Text(v) => Some(v),
             _ => None,
@@ -362,16 +352,15 @@ impl<'a> AttrValueRef<'a> {
     }
 
     /// Get a TextModifiers value from AttrValue, or None
-    pub fn as_text_modifiers(&self) -> Option<TextModifiers> {
+    pub fn as_text_modifiers(self) -> Option<TextModifiers> {
         match self {
-            // cheap copy, so no reference
-            AttrValueRef::TextModifiers(v) => Some(*v),
+            AttrValueRef::TextModifiers(v) => Some(v),
             _ => None,
         }
     }
 
     /// Get a [`Title`] value from AttrValue, or None
-    pub fn as_title(&self) -> Option<&Title> {
+    pub fn as_title(self) -> Option<&'a Title> {
         match self {
             AttrValueRef::Title(v) => Some(v),
             _ => None,
@@ -379,9 +368,9 @@ impl<'a> AttrValueRef<'a> {
     }
 
     /// Get a Payload value from AttrValue, or None
-    pub fn as_payload(&self) -> Option<PropPayloadRef<'a>> {
+    pub fn as_payload(self) -> Option<PropPayloadRef<'a>> {
         match self {
-            AttrValueRef::Payload(v) => Some(*v),
+            AttrValueRef::Payload(v) => Some(v),
             _ => None,
         }
     }

--- a/crates/tuirealm/src/core/props/attr_value_ref.rs
+++ b/crates/tuirealm/src/core/props/attr_value_ref.rs
@@ -3,7 +3,7 @@ use ratatui::style::{Color, Modifier as TextModifiers, Style};
 use ratatui::text::{Line, Span, Text};
 
 use crate::props::prop_value_ref::PropPayloadRef;
-use crate::props::{Borders, Direction, InputType, Layout, Shape, Table, Title};
+use crate::props::{AttrValue, Borders, Direction, InputType, Layout, Shape, Table, Title};
 
 /// Describes a single attribute in the component properties as a reference.
 #[derive(Debug, PartialEq, Clone)]
@@ -436,12 +436,55 @@ impl<'a> AttrValueRef<'a> {
     }
 }
 
+impl<'a> PartialEq<AttrValue> for AttrValueRef<'a> {
+    fn eq(&self, other: &AttrValue) -> bool {
+        match other {
+            AttrValue::AlignmentHorizontal(horizontal_alignment) => {
+                Some(*horizontal_alignment) == self.as_alignment_horizontal()
+            }
+            AttrValue::AlignmentVertical(vertical_alignment) => {
+                Some(*vertical_alignment) == self.as_alignment_vertical()
+            }
+            AttrValue::Borders(borders) => Some(*borders) == self.as_borders(),
+            AttrValue::Color(color) => Some(*color) == self.as_color(),
+            AttrValue::Direction(direction) => Some(*direction) == self.as_direction(),
+            AttrValue::Flag(flag) => Some(*flag) == self.as_flag(),
+            AttrValue::InputType(input_type) => Some(input_type) == self.as_input_type(),
+            AttrValue::Layout(layout) => Some(layout) == self.as_layout(),
+            AttrValue::Length(length) => Some(*length) == self.as_length(),
+            AttrValue::Number(number) => Some(*number) == self.as_number(),
+            AttrValue::Shape(shape) => Some(shape) == self.as_shape(),
+            AttrValue::Size(size) => Some(*size) == self.as_size(),
+            AttrValue::String(string) => Some(string.as_str()) == self.as_string(),
+            AttrValue::Style(style) => Some(*style) == self.as_style(),
+            AttrValue::Table(items) => Some(items) == self.as_table(),
+            AttrValue::TextSpan(span) => Some(span) == self.as_textspan(),
+            AttrValue::TextLine(line) => Some(line) == self.as_textline(),
+            AttrValue::Text(text) => Some(text) == self.as_text(),
+            AttrValue::TextModifiers(modifier) => Some(*modifier) == self.as_text_modifiers(),
+            AttrValue::Title(title) => Some(title) == self.as_title(),
+            AttrValue::Payload(prop_payload) => self
+                .as_payload()
+                .map(|p| p == *prop_payload)
+                .unwrap_or_default(),
+        }
+    }
+}
+
+// reverse impl to not have position-dependent implementations
+// ex. allow `AttrValue == AttrValueRef` AND `AttrValueRef == AttrValue`, without this, it would only allow one of them
+impl<'a> PartialEq<AttrValueRef<'a>> for AttrValue {
+    fn eq(&self, other: &AttrValueRef<'a>) -> bool {
+        *other == *self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use pretty_assertions::assert_eq;
 
     use super::*;
-    use crate::props::{LineStatic, SpanStatic, TextStatic};
+    use crate::props::{LineStatic, PropPayload, SpanStatic, TextStatic};
 
     #[test]
     fn unwrapping_should_unwrap() {
@@ -686,6 +729,101 @@ mod tests {
             AttrValueRef::AlignmentHorizontal(HorizontalAlignment::Center).as_payload(),
             None
         );
+    }
+
+    #[test]
+    fn eq_nonref_attrvalue() {
+        assert!(AttrValueRef::Flag(true) == AttrValue::Flag(true));
+        assert!(!(AttrValueRef::Flag(true) == AttrValue::Size(1)));
+
+        assert!(AttrValueRef::Size(1) == AttrValue::Size(1));
+        assert!(!(AttrValueRef::Size(1) == AttrValue::Flag(false)));
+
+        assert!(
+            AttrValueRef::AlignmentHorizontal(HorizontalAlignment::Center)
+                == AttrValue::AlignmentHorizontal(HorizontalAlignment::Center)
+        );
+        assert!(
+            !(AttrValueRef::AlignmentHorizontal(HorizontalAlignment::Center)
+                == AttrValue::Flag(false))
+        );
+
+        assert!(
+            AttrValueRef::AlignmentVertical(VerticalAlignment::Bottom)
+                == AttrValue::AlignmentVertical(VerticalAlignment::Bottom)
+        );
+        assert!(
+            !(AttrValueRef::AlignmentVertical(VerticalAlignment::Bottom) == AttrValue::Flag(false))
+        );
+
+        assert!(
+            AttrValueRef::Borders(Borders::default()) == AttrValue::Borders(Borders::default())
+        );
+        assert!(!(AttrValueRef::Borders(Borders::default()) == AttrValue::Flag(false)));
+
+        assert!(AttrValueRef::Color(Color::Black) == AttrValue::Color(Color::Black));
+        assert!(!(AttrValueRef::Color(Color::Black) == AttrValue::Flag(false)));
+
+        assert!(AttrValueRef::Direction(Direction::Down) == AttrValue::Direction(Direction::Down));
+        assert!(!(AttrValueRef::Direction(Direction::Down) == AttrValue::Flag(false)));
+
+        assert!(
+            AttrValueRef::InputType(&InputType::Color) == AttrValue::InputType(InputType::Color)
+        );
+        assert!(!(AttrValueRef::InputType(&InputType::Color) == AttrValue::Flag(false)));
+
+        assert!(AttrValueRef::Layout(&Layout::default()) == AttrValue::Layout(Layout::default()));
+        assert!(!(AttrValueRef::Layout(&Layout::default()) == AttrValue::Flag(false)));
+
+        assert!(AttrValueRef::Length(1) == AttrValue::Length(1));
+        assert!(!(AttrValueRef::Length(1) == AttrValue::Flag(false)));
+
+        assert!(AttrValueRef::Number(1) == AttrValue::Number(1));
+        assert!(!(AttrValueRef::Number(1) == AttrValue::Flag(false)));
+
+        assert!(AttrValueRef::Shape(&Shape::Layer) == AttrValue::Shape(Shape::Layer));
+        assert!(!(AttrValueRef::Shape(&Shape::Layer) == AttrValue::Flag(false)));
+
+        assert!(AttrValueRef::String("hello") == AttrValue::String("hello".to_string()));
+        assert!(!(AttrValueRef::String("hello") == AttrValue::Flag(false)));
+
+        assert!(AttrValueRef::Style(Style::default()) == AttrValue::Style(Style::default()));
+        assert!(!(AttrValueRef::Style(Style::default()) == AttrValue::Flag(false)));
+
+        assert!(AttrValueRef::Table(&Table::new()) == AttrValue::Table(Table::new()));
+        assert!(!(AttrValueRef::Table(&Table::new()) == AttrValue::Flag(false)));
+
+        assert!(
+            AttrValueRef::TextSpan(&SpanStatic::from("hello"))
+                == AttrValue::TextSpan(SpanStatic::from("hello"))
+        );
+        assert!(!(AttrValueRef::TextSpan(&SpanStatic::from("hello")) == AttrValue::Flag(false)));
+
+        assert!(
+            AttrValueRef::TextLine(&LineStatic::from("hello"))
+                == AttrValue::TextLine(LineStatic::from("hello"))
+        );
+        assert!(!(AttrValueRef::TextLine(&LineStatic::from("hello")) == AttrValue::Flag(false)));
+
+        assert!(
+            AttrValueRef::Text(&TextStatic::from("hello"))
+                == AttrValue::Text(TextStatic::from("hello"))
+        );
+        assert!(!(AttrValueRef::Text(&TextStatic::from("hello")) == AttrValue::Flag(false)));
+
+        assert!(
+            AttrValueRef::TextModifiers(TextModifiers::default())
+                == AttrValue::TextModifiers(TextModifiers::default())
+        );
+        assert!(!(AttrValueRef::TextModifiers(TextModifiers::default()) == AttrValue::Flag(false)));
+
+        assert!(AttrValueRef::Title(&Title::default()) == AttrValue::Title(Title::default()));
+        assert!(!(AttrValueRef::Title(&Title::default()) == AttrValue::Flag(false)));
+
+        assert!(
+            AttrValueRef::Payload(PropPayloadRef::None) == AttrValue::Payload(PropPayload::None)
+        );
+        assert!(!(AttrValueRef::Payload(PropPayloadRef::None) == AttrValue::Flag(false)));
     }
 
     #[test]

--- a/crates/tuirealm/src/core/props/attr_value_ref.rs
+++ b/crates/tuirealm/src/core/props/attr_value_ref.rs
@@ -4,6 +4,7 @@ use ratatui::text::{Line, Span, Text};
 
 use crate::props::prop_value_ref::PropPayloadRef;
 use crate::props::{AttrValue, Borders, Direction, InputType, Layout, Shape, Table, Title};
+use crate::utils::{clone_line, clone_span, clone_text};
 
 /// Describes a single attribute in the component properties as a reference.
 #[derive(Debug, PartialEq, Clone)]
@@ -511,6 +512,38 @@ impl<'a> From<&'a AttrValue> for AttrValueRef<'a> {
     }
 }
 
+impl<'a> From<AttrValueRef<'a>> for AttrValue {
+    fn from(value: AttrValueRef<'a>) -> Self {
+        match value {
+            AttrValueRef::AlignmentHorizontal(horizontal_alignment) => {
+                Self::AlignmentHorizontal(horizontal_alignment)
+            }
+            AttrValueRef::AlignmentVertical(vertical_alignment) => {
+                Self::AlignmentVertical(vertical_alignment)
+            }
+            AttrValueRef::Borders(borders) => Self::Borders(borders),
+            AttrValueRef::Color(color) => Self::Color(color),
+            AttrValueRef::Direction(direction) => Self::Direction(direction),
+            AttrValueRef::Flag(flag) => Self::Flag(flag),
+            AttrValueRef::InputType(input_type) => Self::InputType(input_type.to_owned()),
+            AttrValueRef::Layout(layout) => Self::Layout(layout.to_owned()),
+            AttrValueRef::Length(length) => Self::Length(length),
+            AttrValueRef::Number(number) => Self::Number(number),
+            AttrValueRef::Shape(shape) => Self::Shape(shape.to_owned()),
+            AttrValueRef::Size(size) => Self::Size(size),
+            AttrValueRef::String(string) => Self::String(string.to_owned()),
+            AttrValueRef::Style(style) => Self::Style(style),
+            AttrValueRef::Table(items) => Self::Table(items.to_owned()),
+            AttrValueRef::TextSpan(span) => Self::TextSpan(clone_span(span)),
+            AttrValueRef::TextLine(line) => Self::TextLine(clone_line(line)),
+            AttrValueRef::Text(text) => Self::Text(clone_text(text)),
+            AttrValueRef::TextModifiers(modifier) => Self::TextModifiers(modifier),
+            AttrValueRef::Title(title) => Self::Title(title.to_owned()),
+            AttrValueRef::Payload(prop_payload) => Self::Payload(prop_payload.into()),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use pretty_assertions::assert_eq;
@@ -943,6 +976,93 @@ mod tests {
         assert_eq!(
             AttrValueRef::from(&AttrValue::Payload(PropPayload::None)),
             AttrValueRef::Payload(PropPayloadRef::None)
+        );
+    }
+
+    #[test]
+    fn into_nonref_attrvalue() {
+        assert_eq!(
+            AttrValue::from(AttrValueRef::Flag(true)),
+            AttrValue::Flag(true)
+        );
+        assert_eq!(AttrValue::from(AttrValueRef::Size(1)), AttrValue::Size(1));
+        assert_eq!(
+            AttrValue::from(AttrValueRef::AlignmentHorizontal(
+                HorizontalAlignment::Center
+            )),
+            AttrValue::AlignmentHorizontal(HorizontalAlignment::Center)
+        );
+        assert_eq!(
+            AttrValue::from(AttrValueRef::AlignmentVertical(VerticalAlignment::Bottom)),
+            AttrValue::AlignmentVertical(VerticalAlignment::Bottom)
+        );
+        assert_eq!(
+            AttrValue::from(AttrValueRef::Borders(Borders::default())),
+            AttrValue::Borders(Borders::default())
+        );
+        assert_eq!(
+            AttrValue::from(AttrValueRef::Color(Color::Black)),
+            AttrValue::Color(Color::Black)
+        );
+        assert_eq!(
+            AttrValue::from(AttrValueRef::Direction(Direction::Down)),
+            AttrValue::Direction(Direction::Down)
+        );
+        assert_eq!(
+            AttrValue::from(AttrValueRef::InputType(&InputType::Color)),
+            AttrValue::InputType(InputType::Color)
+        );
+        assert_eq!(
+            AttrValue::from(AttrValueRef::Layout(&Layout::default())),
+            AttrValue::Layout(Layout::default())
+        );
+        assert_eq!(
+            AttrValue::from(AttrValueRef::Length(1)),
+            AttrValue::Length(1)
+        );
+        assert_eq!(
+            AttrValue::from(AttrValueRef::Number(1)),
+            AttrValue::Number(1)
+        );
+        assert_eq!(
+            AttrValue::from(AttrValueRef::Shape(&Shape::Layer)),
+            AttrValue::Shape(Shape::Layer)
+        );
+        assert_eq!(
+            AttrValue::from(AttrValueRef::String("hello")),
+            AttrValue::String("hello".to_string())
+        );
+        assert_eq!(
+            AttrValue::from(AttrValueRef::Style(Style::default())),
+            AttrValue::Style(Style::default())
+        );
+        assert_eq!(
+            AttrValue::from(AttrValueRef::Table(&Table::new())),
+            AttrValue::Table(Table::new())
+        );
+        assert_eq!(
+            AttrValue::from(AttrValueRef::TextSpan(&SpanStatic::from("hello"))),
+            AttrValue::TextSpan(SpanStatic::from("hello"))
+        );
+        assert_eq!(
+            AttrValue::from(AttrValueRef::TextLine(&LineStatic::from("hello"))),
+            AttrValue::TextLine(LineStatic::from("hello"))
+        );
+        assert_eq!(
+            AttrValue::from(AttrValueRef::Text(&TextStatic::from("hello"))),
+            AttrValue::Text(TextStatic::from("hello"))
+        );
+        assert_eq!(
+            AttrValue::from(AttrValueRef::TextModifiers(TextModifiers::default())),
+            AttrValue::TextModifiers(TextModifiers::default())
+        );
+        assert_eq!(
+            AttrValue::from(AttrValueRef::Title(&Title::default())),
+            AttrValue::Title(Title::default())
+        );
+        assert_eq!(
+            AttrValue::from(AttrValueRef::Payload(PropPayloadRef::None)),
+            AttrValue::Payload(PropPayload::None)
         );
     }
 

--- a/crates/tuirealm/src/core/props/mod.rs
+++ b/crates/tuirealm/src/core/props/mod.rs
@@ -11,6 +11,7 @@ mod layout;
 mod prop_value;
 mod prop_value_ref;
 mod props_store;
+mod queryresult;
 mod shape;
 mod texts;
 
@@ -25,6 +26,7 @@ pub use layout::Layout;
 pub use prop_value::{PropPayload, PropValue};
 pub use prop_value_ref::{PropPayloadRef, PropValueRef};
 pub use props_store::Props;
+pub use queryresult::QueryResult;
 pub use shape::Shape;
 pub use texts::{LineStatic, SpanStatic, Table, TableBuilder, TextStatic, Title};
 

--- a/crates/tuirealm/src/core/props/mod.rs
+++ b/crates/tuirealm/src/core/props/mod.rs
@@ -3,11 +3,13 @@
 // -- modules
 mod any;
 mod attr_value;
+mod attr_value_ref;
 mod borders;
 mod direction;
 mod input_type;
 mod layout;
 mod prop_value;
+mod prop_value_ref;
 mod props_store;
 mod shape;
 mod texts;
@@ -15,11 +17,13 @@ mod texts;
 // -- exports
 pub use any::{AnyPropBox, PropBound};
 pub use attr_value::AttrValue;
+pub use attr_value_ref::AttrValueRef;
 pub use borders::{BorderSides, BorderType, Borders};
 pub use direction::Direction;
 pub use input_type::InputType;
 pub use layout::Layout;
 pub use prop_value::{PropPayload, PropValue};
+pub use prop_value_ref::{PropPayloadRef, PropValueRef};
 pub use props_store::Props;
 pub use shape::Shape;
 pub use texts::{LineStatic, SpanStatic, Table, TableBuilder, TextStatic, Title};

--- a/crates/tuirealm/src/core/props/prop_value.rs
+++ b/crates/tuirealm/src/core/props/prop_value.rs
@@ -7,7 +7,7 @@ use super::{
     Color, HorizontalAlignment, InputType, LineStatic, Shape, SpanStatic, Style, Table, TextStatic,
     VerticalAlignment,
 };
-use crate::props::AnyPropBox;
+use crate::props::{AnyPropBox, PropPayloadRef, PropValueRef};
 
 // -- Prop value
 
@@ -56,6 +56,12 @@ pub enum PropValue {
 }
 
 impl PropPayload {
+    /// Create a [`PropPayloadRef`] from the current value.
+    #[inline]
+    pub fn as_payload_ref<'a>(&'a self) -> PropPayloadRef<'a> {
+        self.into()
+    }
+
     // -- unwrappers
 
     /// Unwrap a Single value from PropPayload
@@ -208,6 +214,12 @@ impl PropPayload {
 }
 
 impl PropValue {
+    /// Create a [`PropValueRef`] from the current value.
+    #[inline]
+    pub fn as_value_ref<'a>(&'a self) -> PropValueRef<'a> {
+        self.into()
+    }
+
     // -- unwrappers
 
     /// Unwrap PropValue as Bool.

--- a/crates/tuirealm/src/core/props/prop_value_ref.rs
+++ b/crates/tuirealm/src/core/props/prop_value_ref.rs
@@ -7,6 +7,7 @@ use ratatui::text::{Line, Span, Text};
 
 use super::{Color, HorizontalAlignment, InputType, Shape, Style, Table, VerticalAlignment};
 use crate::props::{AnyPropBox, PropPayload, PropValue};
+use crate::utils::{clone_line, clone_span, clone_text};
 
 // -- Prop value
 
@@ -201,6 +202,20 @@ impl<'a> From<&'a PropPayload> for PropPayloadRef<'a> {
             PropPayload::Linked(prop_payloads) => Self::Linked(prop_payloads),
             PropPayload::Any(prop_bound) => Self::Any(prop_bound),
             PropPayload::None => Self::None,
+        }
+    }
+}
+
+impl<'a> From<PropPayloadRef<'a>> for PropPayload {
+    fn from(value: PropPayloadRef) -> Self {
+        match value {
+            PropPayloadRef::Single(prop_value) => Self::Single(prop_value.into()),
+            PropPayloadRef::Pair((a, b)) => Self::Pair((a.into(), b.into())),
+            PropPayloadRef::Vec(prop_values) => Self::Vec(prop_values.to_owned()),
+            PropPayloadRef::Map(hash_map) => Self::Map(hash_map.to_owned()),
+            PropPayloadRef::Linked(prop_payloads) => Self::Linked(prop_payloads.to_owned()),
+            PropPayloadRef::Any(prop_bound) => Self::Any((*prop_bound).clone()),
+            PropPayloadRef::None => Self::None,
         }
     }
 }
@@ -749,6 +764,43 @@ impl<'a> From<&'a PropValue> for PropValueRef<'a> {
             PropValue::TextSpan(span) => Self::TextSpan(span),
             PropValue::TextLine(line) => Self::TextLine(line),
             PropValue::Text(text) => Self::Text(text),
+        }
+    }
+}
+
+impl<'a> From<PropValueRef<'a>> for PropValue {
+    fn from(value: PropValueRef<'a>) -> Self {
+        match value {
+            PropValueRef::Bool(flag) => Self::Bool(flag),
+            PropValueRef::U8(num) => Self::U8(num),
+            PropValueRef::U16(num) => Self::U16(num),
+            PropValueRef::U32(num) => Self::U32(num),
+            PropValueRef::U64(num) => Self::U64(num),
+            PropValueRef::U128(num) => Self::U128(num),
+            PropValueRef::Usize(num) => Self::Usize(num),
+            PropValueRef::I8(num) => Self::I8(num),
+            PropValueRef::I16(num) => Self::I16(num),
+            PropValueRef::I32(num) => Self::I32(num),
+            PropValueRef::I64(num) => Self::I64(num),
+            PropValueRef::I128(num) => Self::I128(num),
+            PropValueRef::Isize(num) => Self::Isize(num),
+            PropValueRef::F64(num) => Self::F64(num),
+            PropValueRef::F32(num) => Self::F32(num),
+            PropValueRef::Str(str) => Self::Str(str.to_owned()),
+            PropValueRef::AlignmentHorizontal(horizontal_alignment) => {
+                Self::AlignmentHorizontal(horizontal_alignment)
+            }
+            PropValueRef::AlignmentVertical(vertical_alignment) => {
+                Self::AlignmentVertical(vertical_alignment)
+            }
+            PropValueRef::Color(color) => Self::Color(color),
+            PropValueRef::InputType(input_type) => Self::InputType(input_type.to_owned()),
+            PropValueRef::Shape(shape) => Self::Shape(shape.to_owned()),
+            PropValueRef::Style(style) => Self::Style(style),
+            PropValueRef::Table(items) => Self::Table(items.to_owned()),
+            PropValueRef::TextSpan(span) => Self::TextSpan(clone_span(span)),
+            PropValueRef::TextLine(line) => Self::TextLine(clone_line(line)),
+            PropValueRef::Text(text) => Self::Text(clone_text(text)),
         }
     }
 }
@@ -1373,6 +1425,57 @@ mod tests {
     }
 
     #[test]
+    fn into_nonref_proppayload() {
+        assert_eq!(
+            PropPayload::from(PropPayloadRef::Single(PropValueRef::Bool(true))),
+            PropPayload::Single(PropValue::Bool(true))
+        );
+        assert_eq!(
+            PropPayload::from(PropPayloadRef::Pair((
+                PropValueRef::Bool(true),
+                PropValueRef::Bool(true)
+            ))),
+            PropPayload::Pair((PropValue::Bool(true), PropValue::Bool(true)))
+        );
+        assert_eq!(
+            PropPayload::from(PropPayloadRef::Vec([PropValue::Bool(true)].as_slice())),
+            PropPayload::Vec(vec![PropValue::Bool(true)])
+        );
+        assert_eq!(
+            PropPayload::from(PropPayloadRef::Map(&HashMap::from([(
+                "key".to_string(),
+                PropValue::Bool(true)
+            )]))),
+            PropPayload::Map(HashMap::from([("key".to_string(), PropValue::Bool(true))]))
+        );
+        assert_eq!(
+            PropPayload::from(PropPayloadRef::Linked(&LinkedList::new())),
+            PropPayload::Linked(LinkedList::new())
+        );
+        assert_eq!(PropPayload::from(PropPayloadRef::None), PropPayload::None);
+
+        #[derive(Debug, Clone, PartialEq)]
+        struct CloneableType {
+            field1: String,
+        }
+
+        assert_eq!(
+            PropPayload::from(PropPayloadRef::Any(
+                &CloneableType {
+                    field1: "Hello".to_string(),
+                }
+                .to_any_prop()
+            )),
+            PropPayload::Any(
+                CloneableType {
+                    field1: "Hello".to_string(),
+                }
+                .to_any_prop()
+            )
+        );
+    }
+
+    #[test]
     fn from_nonref_propvalue() {
         assert_eq!(
             PropValueRef::from(&PropValue::Bool(true)),
@@ -1462,6 +1565,83 @@ mod tests {
         assert_eq!(
             PropValueRef::from(&PropValue::Text(TextStatic::from("hello"))),
             PropValueRef::Text(&TextStatic::from("hello"))
+        );
+    }
+
+    #[test]
+    fn into_nonref_propvalue() {
+        assert_eq!(
+            PropValue::from(PropValueRef::Bool(true)),
+            PropValue::Bool(true)
+        );
+
+        assert_eq!(PropValue::from(PropValueRef::U8(1)), PropValueRef::U8(1));
+        assert_eq!(PropValue::from(PropValueRef::U16(1)), PropValue::U16(1));
+        assert_eq!(PropValue::from(PropValueRef::U32(1)), PropValue::U32(1));
+        assert_eq!(PropValue::from(PropValueRef::U64(1)), PropValue::U64(1));
+        assert_eq!(PropValue::from(PropValueRef::U128(1)), PropValue::U128(1));
+        assert_eq!(PropValue::from(PropValueRef::Usize(1)), PropValue::Usize(1));
+        assert_eq!(PropValue::from(PropValueRef::I8(1)), PropValueRef::I8(1));
+        assert_eq!(PropValue::from(PropValueRef::I16(1)), PropValue::I16(1));
+        assert_eq!(PropValue::from(PropValueRef::I32(1)), PropValue::I32(1));
+        assert_eq!(PropValue::from(PropValueRef::I64(1)), PropValue::I64(1));
+        assert_eq!(PropValue::from(PropValueRef::I128(1)), PropValue::I128(1));
+        assert_eq!(PropValue::from(PropValueRef::Isize(1)), PropValue::Isize(1));
+        assert_eq!(PropValue::from(PropValueRef::F32(1.0)), PropValue::F32(1.0));
+        assert_eq!(PropValue::from(PropValueRef::F64(1.0)), PropValue::F64(1.0));
+
+        assert_eq!(
+            PropValue::from(PropValueRef::Str("hello")),
+            PropValue::Str("hello".to_string())
+        );
+
+        assert_eq!(
+            PropValue::from(PropValueRef::AlignmentHorizontal(
+                HorizontalAlignment::Center
+            )),
+            PropValue::AlignmentHorizontal(HorizontalAlignment::Center)
+        );
+        assert_eq!(
+            PropValue::from(PropValueRef::AlignmentVertical(VerticalAlignment::Bottom)),
+            PropValue::AlignmentVertical(VerticalAlignment::Bottom)
+        );
+
+        assert_eq!(
+            PropValue::from(PropValueRef::Color(Color::Black)),
+            PropValue::Color(Color::Black)
+        );
+
+        assert_eq!(
+            PropValue::from(PropValueRef::InputType(&InputType::Color)),
+            PropValue::InputType(InputType::Color)
+        );
+
+        assert_eq!(
+            PropValue::from(PropValueRef::Shape(&Shape::Layer)),
+            PropValue::Shape(Shape::Layer)
+        );
+
+        assert_eq!(
+            PropValue::from(PropValueRef::Style(Style::default())),
+            PropValue::Style(Style::default())
+        );
+
+        assert_eq!(
+            PropValue::from(PropValueRef::Table(&Table::new())),
+            PropValue::Table(Table::new())
+        );
+
+        assert_eq!(
+            PropValue::from(PropValueRef::TextSpan(&SpanStatic::from("hello"))),
+            PropValue::TextSpan(SpanStatic::from("hello"))
+        );
+        assert_eq!(
+            PropValue::from(PropValueRef::TextLine(&LineStatic::from("hello"))),
+            PropValue::TextLine(LineStatic::from("hello"))
+        );
+        assert_eq!(
+            PropValue::from(PropValueRef::Text(&TextStatic::from("hello"))),
+            PropValue::Text(TextStatic::from("hello"))
         );
     }
 }

--- a/crates/tuirealm/src/core/props/prop_value_ref.rs
+++ b/crates/tuirealm/src/core/props/prop_value_ref.rs
@@ -109,23 +109,23 @@ impl<'a> PropPayloadRef<'a> {
     // -- as reference
 
     /// Get a Single value from PropPayload, or None
-    pub fn as_single(&self) -> Option<PropValueRef<'a>> {
+    pub fn as_single(self) -> Option<PropValueRef<'a>> {
         match self {
-            PropPayloadRef::Single(v) => Some(*v),
+            PropPayloadRef::Single(v) => Some(v),
             _ => None,
         }
     }
 
     /// Get a Pair value from PropPayload, or None
-    pub fn as_pair(&self) -> Option<(PropValueRef<'a>, PropValueRef<'a>)> {
+    pub fn as_pair(self) -> Option<(PropValueRef<'a>, PropValueRef<'a>)> {
         match self {
-            PropPayloadRef::Pair(v) => Some((v.0, v.1)),
+            PropPayloadRef::Pair(v) => Some(v),
             _ => None,
         }
     }
 
     /// Get a Vec value from PropPayload, or None
-    pub fn as_vec(&self) -> Option<&'a [PropValue]> {
+    pub fn as_vec(self) -> Option<&'a [PropValue]> {
         match self {
             PropPayloadRef::Vec(v) => Some(v),
             _ => None,
@@ -133,7 +133,7 @@ impl<'a> PropPayloadRef<'a> {
     }
 
     /// Get a Map value from PropPayload, or None
-    pub fn as_map(&self) -> Option<&'a HashMap<String, PropValue>> {
+    pub fn as_map(self) -> Option<&'a HashMap<String, PropValue>> {
         match self {
             PropPayloadRef::Map(v) => Some(v),
             _ => None,
@@ -141,7 +141,7 @@ impl<'a> PropPayloadRef<'a> {
     }
 
     /// Get a Linked value from PropPayload, or None
-    pub fn as_linked(&self) -> Option<&'a LinkedList<PropPayload>> {
+    pub fn as_linked(self) -> Option<&'a LinkedList<PropPayload>> {
         match self {
             PropPayloadRef::Linked(v) => Some(v),
             _ => None,
@@ -149,7 +149,7 @@ impl<'a> PropPayloadRef<'a> {
     }
 
     /// Get a Any value from PropPayload, or None
-    pub fn as_any(&self) -> Option<&dyn Any> {
+    pub fn as_any(self) -> Option<&'a dyn Any> {
         match self {
             PropPayloadRef::Any(v) => Some(v.as_ref()),
             _ => None,
@@ -460,142 +460,127 @@ impl<'a> PropValueRef<'a> {
     // -- as reference
 
     /// Get a Bool value from PropValue, or None
-    pub fn as_bool(&self) -> Option<bool> {
+    pub fn as_bool(self) -> Option<bool> {
         match self {
-            // cheap copy, so no reference
-            PropValueRef::Bool(v) => Some(*v),
+            PropValueRef::Bool(v) => Some(v),
             _ => None,
         }
     }
 
     /// Get a u8 value from PropValue, or None
-    pub fn as_u8(&self) -> Option<u8> {
+    pub fn as_u8(self) -> Option<u8> {
         match self {
-            // cheap copy, so no reference
-            PropValueRef::U8(v) => Some(*v),
+            PropValueRef::U8(v) => Some(v),
             _ => None,
         }
     }
 
     /// Get a u16 value from PropValue, or None
-    pub fn as_u16(&self) -> Option<u16> {
+    pub fn as_u16(self) -> Option<u16> {
         match self {
-            // cheap copy, so no reference
-            PropValueRef::U16(v) => Some(*v),
+            PropValueRef::U16(v) => Some(v),
             _ => None,
         }
     }
 
     /// Get a u32 value from PropValue, or None
-    pub fn as_u32(&self) -> Option<u32> {
+    pub fn as_u32(self) -> Option<u32> {
         match self {
-            // cheap copy, so no reference
-            PropValueRef::U32(v) => Some(*v),
+            PropValueRef::U32(v) => Some(v),
             _ => None,
         }
     }
 
     /// Get a u64 value from PropValue, or None
-    pub fn as_u64(&self) -> Option<u64> {
+    pub fn as_u64(self) -> Option<u64> {
         match self {
-            // cheap copy, so no reference
-            PropValueRef::U64(v) => Some(*v),
+            PropValueRef::U64(v) => Some(v),
             _ => None,
         }
     }
 
     /// Get a u128 value from PropValue, or None
-    pub fn as_u128(&self) -> Option<u128> {
+    pub fn as_u128(self) -> Option<u128> {
         match self {
-            // cheap copy, so no reference
-            PropValueRef::U128(v) => Some(*v),
+            PropValueRef::U128(v) => Some(v),
             _ => None,
         }
     }
 
     /// Get a usize value from PropValue, or None
-    pub fn as_usize(&self) -> Option<usize> {
+    pub fn as_usize(self) -> Option<usize> {
         match self {
-            // cheap copy, so no reference
-            PropValueRef::Usize(v) => Some(*v),
+            PropValueRef::Usize(v) => Some(v),
             _ => None,
         }
     }
 
     /// Get a i8 value from PropValue, or None
-    pub fn as_i8(&self) -> Option<i8> {
+    pub fn as_i8(self) -> Option<i8> {
         match self {
-            // cheap copy, so no reference
-            PropValueRef::I8(v) => Some(*v),
+            PropValueRef::I8(v) => Some(v),
             _ => None,
         }
     }
 
     /// Get a i16 value from PropValue, or None
-    pub fn as_i16(&self) -> Option<i16> {
+    pub fn as_i16(self) -> Option<i16> {
         match self {
-            // cheap copy, so no reference
-            PropValueRef::I16(v) => Some(*v),
+            PropValueRef::I16(v) => Some(v),
             _ => None,
         }
     }
 
     /// Get a i32 value from PropValue, or None
-    pub fn as_i32(&self) -> Option<i32> {
+    pub fn as_i32(self) -> Option<i32> {
         match self {
-            // cheap copy, so no reference
-            PropValueRef::I32(v) => Some(*v),
+            PropValueRef::I32(v) => Some(v),
             _ => None,
         }
     }
 
     /// Get a i64 value from PropValue, or None
-    pub fn as_i64(&self) -> Option<i64> {
+    pub fn as_i64(self) -> Option<i64> {
         match self {
-            // cheap copy, so no reference
-            PropValueRef::I64(v) => Some(*v),
+            PropValueRef::I64(v) => Some(v),
             _ => None,
         }
     }
 
     /// Get a i128 value from PropValue, or None
-    pub fn as_i128(&self) -> Option<i128> {
+    pub fn as_i128(self) -> Option<i128> {
         match self {
-            // cheap copy, so no reference
-            PropValueRef::I128(v) => Some(*v),
+            PropValueRef::I128(v) => Some(v),
             _ => None,
         }
     }
 
     /// Get a isize value from PropValue, or None
-    pub fn as_isize(&self) -> Option<isize> {
+    pub fn as_isize(self) -> Option<isize> {
         match self {
-            // cheap copy, so no reference
-            PropValueRef::Isize(v) => Some(*v),
+            PropValueRef::Isize(v) => Some(v),
             _ => None,
         }
     }
 
     /// Get a f32 value from PropValue, or None
-    pub fn as_f32(&self) -> Option<f32> {
+    pub fn as_f32(self) -> Option<f32> {
         match self {
-            // cheap copy, so no reference
-            PropValueRef::F32(v) => Some(*v),
+            PropValueRef::F32(v) => Some(v),
             _ => None,
         }
     }
 
     /// Get a f64 value from PropValue, or None
-    pub fn as_f64(&self) -> Option<f64> {
+    pub fn as_f64(self) -> Option<f64> {
         match self {
-            // cheap copy, so no reference
-            PropValueRef::F64(v) => Some(*v),
+            PropValueRef::F64(v) => Some(v),
             _ => None,
         }
     }
 
     /// Get a String value from PropValue, or None
-    pub fn as_str(&self) -> Option<&'a str> {
+    pub fn as_str(self) -> Option<&'a str> {
         match self {
             PropValueRef::Str(v) => Some(v),
             _ => None,
@@ -603,34 +588,31 @@ impl<'a> PropValueRef<'a> {
     }
 
     /// Get a Horizontal Alignment value from PropValue, or None
-    pub fn as_alignment_horizontal(&self) -> Option<HorizontalAlignment> {
+    pub fn as_alignment_horizontal(self) -> Option<HorizontalAlignment> {
         match self {
-            // cheap copy, so no reference
-            PropValueRef::AlignmentHorizontal(v) => Some(*v),
+            PropValueRef::AlignmentHorizontal(v) => Some(v),
             _ => None,
         }
     }
 
     /// Get a Vertical Alignment value from PropValue, or None
-    pub fn as_alignment_vertical(&self) -> Option<VerticalAlignment> {
+    pub fn as_alignment_vertical(self) -> Option<VerticalAlignment> {
         match self {
-            // cheap copy, so no reference
-            PropValueRef::AlignmentVertical(v) => Some(*v),
+            PropValueRef::AlignmentVertical(v) => Some(v),
             _ => None,
         }
     }
 
     /// Get a Color value from PropValue, or None
-    pub fn as_color(&self) -> Option<Color> {
+    pub fn as_color(self) -> Option<Color> {
         match self {
-            // cheap copy, so no reference
-            PropValueRef::Color(v) => Some(*v),
+            PropValueRef::Color(v) => Some(v),
             _ => None,
         }
     }
 
     /// Get a InputType value from PropValue, or None
-    pub fn as_input_type(&self) -> Option<&'a InputType> {
+    pub fn as_input_type(self) -> Option<&'a InputType> {
         match self {
             PropValueRef::InputType(v) => Some(v),
             _ => None,
@@ -638,7 +620,7 @@ impl<'a> PropValueRef<'a> {
     }
 
     /// Get a Shape value from PropValue, or None
-    pub fn as_shape(&self) -> Option<&'a Shape> {
+    pub fn as_shape(self) -> Option<&'a Shape> {
         match self {
             PropValueRef::Shape(v) => Some(v),
             _ => None,
@@ -646,15 +628,15 @@ impl<'a> PropValueRef<'a> {
     }
 
     /// Get a Style value from PropValue, or None
-    pub fn as_style(&self) -> Option<Style> {
+    pub fn as_style(self) -> Option<Style> {
         match self {
-            PropValueRef::Style(v) => Some(*v),
+            PropValueRef::Style(v) => Some(v),
             _ => None,
         }
     }
 
     /// Get a Table value from PropValue, or None
-    pub fn as_table(&self) -> Option<&Table> {
+    pub fn as_table(self) -> Option<&'a Table> {
         match self {
             PropValueRef::Table(v) => Some(v),
             _ => None,
@@ -662,7 +644,7 @@ impl<'a> PropValueRef<'a> {
     }
 
     /// Get a [`SpanStatic`] value from PropValue, or None
-    pub fn as_textspan(&self) -> Option<&'a Span<'a>> {
+    pub fn as_textspan(self) -> Option<&'a Span<'a>> {
         match self {
             PropValueRef::TextSpan(v) => Some(v),
             _ => None,
@@ -670,7 +652,7 @@ impl<'a> PropValueRef<'a> {
     }
 
     /// Get a [`LineStatic`] value from PropValue, or None
-    pub fn as_textline(&self) -> Option<&'a Line<'a>> {
+    pub fn as_textline(self) -> Option<&'a Line<'a>> {
         match self {
             PropValueRef::TextLine(v) => Some(v),
             _ => None,
@@ -678,7 +660,7 @@ impl<'a> PropValueRef<'a> {
     }
 
     /// Get a [`TextStatic`] value from PropValue, or None
-    pub fn as_text(&self) -> Option<&'a Text<'a>> {
+    pub fn as_text(self) -> Option<&'a Text<'a>> {
         match self {
             PropValueRef::Text(v) => Some(v),
             _ => None,

--- a/crates/tuirealm/src/core/props/prop_value_ref.rs
+++ b/crates/tuirealm/src/core/props/prop_value_ref.rs
@@ -1,0 +1,968 @@
+//! This module exposes the prop values
+
+use std::any::Any;
+use std::collections::{HashMap, LinkedList};
+
+use ratatui::text::{Line, Span, Text};
+
+use super::{Color, HorizontalAlignment, InputType, Shape, Style, Table, VerticalAlignment};
+use crate::props::{AnyPropBox, PropPayload, PropValue};
+
+// -- Prop value
+
+/// The payload contains the actual value for user defined properties
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum PropPayloadRef<'a> {
+    Single(PropValueRef<'a>),
+    Pair((PropValueRef<'a>, PropValueRef<'a>)),
+    Vec(&'a [PropValue]),
+    Map(&'a HashMap<String, PropValue>),
+    Linked(&'a LinkedList<PropPayload>),
+    Any(&'a AnyPropBox),
+    None,
+}
+
+/// Value describes the value contained in a `PropPayload`
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum PropValueRef<'a> {
+    Bool(bool),
+    U8(u8),
+    U16(u16),
+    U32(u32),
+    U64(u64),
+    U128(u128),
+    Usize(usize),
+    I8(i8),
+    I16(i16),
+    I32(i32),
+    I64(i64),
+    I128(i128),
+    Isize(isize),
+    F64(f64),
+    F32(f32),
+    Str(&'a str),
+    // -- tui props
+    AlignmentHorizontal(HorizontalAlignment),
+    AlignmentVertical(VerticalAlignment),
+    Color(Color),
+    InputType(&'a InputType),
+    Shape(&'a Shape),
+    Style(Style),
+    Table(&'a Table),
+    TextSpan(&'a Span<'a>),
+    TextLine(&'a Line<'a>),
+    Text(&'a Text<'a>),
+}
+
+impl<'a> PropPayloadRef<'a> {
+    // -- unwrappers
+
+    /// Unwrap a Single value from PropPayload
+    pub fn unwrap_single(self) -> PropValueRef<'a> {
+        match self {
+            PropPayloadRef::Single(v) => v,
+            _ => panic!("Called `unwrap_single` on a bad value"),
+        }
+    }
+
+    /// Unwrap a Pair value from PropPayload
+    pub fn unwrap_pair(self) -> (PropValueRef<'a>, PropValueRef<'a>) {
+        match self {
+            PropPayloadRef::Pair(v) => v,
+            _ => panic!("Called `unwrap_pair` on a bad value"),
+        }
+    }
+
+    /// Unwrap a Vec value from PropPayload
+    pub fn unwrap_vec(self) -> &'a [PropValue] {
+        match self {
+            PropPayloadRef::Vec(v) => v,
+            _ => panic!("Called `unwrap_vec` on a bad value"),
+        }
+    }
+
+    /// Unwrap a Map value from PropPayload
+    pub fn unwrap_map(self) -> &'a HashMap<String, PropValue> {
+        match self {
+            PropPayloadRef::Map(v) => v,
+            _ => panic!("Called `unwrap_map` on a bad value"),
+        }
+    }
+
+    /// Unwrap a Linked list from PropPayload
+    pub fn unwrap_linked(self) -> &'a LinkedList<PropPayload> {
+        match self {
+            PropPayloadRef::Linked(v) => v,
+            _ => panic!("Called `unwrap_linked` on a bad value"),
+        }
+    }
+
+    /// Unwrap a Any from PropPayload
+    pub fn unwrap_any(self) -> &'a AnyPropBox {
+        match self {
+            PropPayloadRef::Any(v) => v,
+            _ => panic!("Called `unwrap_any` on a bad value"),
+        }
+    }
+
+    // -- as reference
+
+    /// Get a Single value from PropPayload, or None
+    pub fn as_single(&self) -> Option<PropValueRef<'a>> {
+        match self {
+            PropPayloadRef::Single(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Get a Pair value from PropPayload, or None
+    pub fn as_pair(&self) -> Option<(PropValueRef<'a>, PropValueRef<'a>)> {
+        match self {
+            PropPayloadRef::Pair(v) => Some((v.0, v.1)),
+            _ => None,
+        }
+    }
+
+    /// Get a Vec value from PropPayload, or None
+    pub fn as_vec(&self) -> Option<&'a [PropValue]> {
+        match self {
+            PropPayloadRef::Vec(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Get a Map value from PropPayload, or None
+    pub fn as_map(&self) -> Option<&'a HashMap<String, PropValue>> {
+        match self {
+            PropPayloadRef::Map(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Get a Linked value from PropPayload, or None
+    pub fn as_linked(&self) -> Option<&'a LinkedList<PropPayload>> {
+        match self {
+            PropPayloadRef::Linked(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Get a Any value from PropPayload, or None
+    pub fn as_any(&self) -> Option<&dyn Any> {
+        match self {
+            PropPayloadRef::Any(v) => Some(v.as_ref()),
+            _ => None,
+        }
+    }
+}
+
+impl<'a> PropValueRef<'a> {
+    // -- unwrappers
+
+    /// Unwrap PropValue as Bool.
+    /// Panics otherwise
+    pub fn unwrap_bool(self) -> bool {
+        match self {
+            PropValueRef::Bool(v) => v,
+            _ => panic!("Called `unwrap_bool` on a bad value"),
+        }
+    }
+
+    /// Unwrap PropValue as u8.
+    /// Panics otherwise
+    pub fn unwrap_u8(self) -> u8 {
+        match self {
+            PropValueRef::U8(v) => v,
+            _ => panic!("Called `unwrap_u8` on a bad value"),
+        }
+    }
+
+    /// Unwrap PropValue as u16.
+    /// Panics otherwise
+    pub fn unwrap_u16(self) -> u16 {
+        match self {
+            PropValueRef::U16(v) => v,
+            _ => panic!("Called `unwrap_u16` on a bad value"),
+        }
+    }
+
+    /// Unwrap PropValue as Bool.
+    /// Panics otherwise
+    pub fn unwrap_u32(self) -> u32 {
+        match self {
+            PropValueRef::U32(v) => v,
+            _ => panic!("Called `unwrap_u32` on a bad value"),
+        }
+    }
+
+    /// Unwrap PropValue as u64.
+    /// Panics otherwise
+    pub fn unwrap_u64(self) -> u64 {
+        match self {
+            PropValueRef::U64(v) => v,
+            _ => panic!("Called `unwrap_u64` on a bad value"),
+        }
+    }
+
+    /// Unwrap PropValue as u128.
+    /// Panics otherwise
+    pub fn unwrap_u128(self) -> u128 {
+        match self {
+            PropValueRef::U128(v) => v,
+            _ => panic!("Called `unwrap_u128` on a bad value"),
+        }
+    }
+
+    /// Unwrap PropValue as usize.
+    /// Panics otherwise
+    pub fn unwrap_usize(self) -> usize {
+        match self {
+            PropValueRef::Usize(v) => v,
+            _ => panic!("Called `unwrap_usize` on a bad value"),
+        }
+    }
+
+    /// Unwrap PropValue as i8.
+    /// Panics otherwise
+    pub fn unwrap_i8(self) -> i8 {
+        match self {
+            PropValueRef::I8(v) => v,
+            _ => panic!("Called `unwrap_i8` on a bad value"),
+        }
+    }
+
+    /// Unwrap PropValue as i16.
+    /// Panics otherwise
+    pub fn unwrap_i16(self) -> i16 {
+        match self {
+            PropValueRef::I16(v) => v,
+            _ => panic!("Called `unwrap_i16` on a bad value"),
+        }
+    }
+
+    /// Unwrap PropValue as i32.
+    /// Panics otherwise
+    pub fn unwrap_i32(self) -> i32 {
+        match self {
+            PropValueRef::I32(v) => v,
+            _ => panic!("Called `unwrap_i32` on a bad value"),
+        }
+    }
+
+    /// Unwrap PropValue as i64.
+    /// Panics otherwise
+    pub fn unwrap_i64(self) -> i64 {
+        match self {
+            PropValueRef::I64(v) => v,
+            _ => panic!("Called `unwrap_i64` on a bad value"),
+        }
+    }
+
+    /// Unwrap PropValue as i128.
+    /// Panics otherwise
+    pub fn unwrap_i128(self) -> i128 {
+        match self {
+            PropValueRef::I128(v) => v,
+            _ => panic!("Called `unwrap_i128` on a bad value"),
+        }
+    }
+
+    /// Unwrap PropValue as isize.
+    /// Panics otherwise
+    pub fn unwrap_isize(self) -> isize {
+        match self {
+            PropValueRef::Isize(v) => v,
+            _ => panic!("Called `unwrap_isize` on a bad value"),
+        }
+    }
+
+    /// Unwrap PropValue as f32.
+    /// Panics otherwise
+    pub fn unwrap_f32(self) -> f32 {
+        match self {
+            PropValueRef::F32(v) => v,
+            _ => panic!("Called `unwrap_f32` on a bad value"),
+        }
+    }
+
+    /// Unwrap PropValue as f64.
+    /// Panics otherwise
+    pub fn unwrap_f64(self) -> f64 {
+        match self {
+            PropValueRef::F64(v) => v,
+            _ => panic!("Called `unwrap_f64` on a bad value"),
+        }
+    }
+
+    /// Unwrap PropValue as String.
+    /// Panics otherwise
+    pub fn unwrap_str(self) -> &'a str {
+        match self {
+            PropValueRef::Str(v) => v,
+            _ => panic!("Called `unwrap_str` on a bad value"),
+        }
+    }
+
+    /// Unwrap PropValue as Horizontal Alignment.
+    /// Panics otherwise
+    pub fn unwrap_alignment_horizontal(self) -> HorizontalAlignment {
+        match self {
+            PropValueRef::AlignmentHorizontal(v) => v,
+            _ => panic!("Called `unwrap_alignment_horizontal` on a bad value"),
+        }
+    }
+
+    /// Unwrap PropValue as Vertical Alignment.
+    /// Panics otherwise
+    pub fn unwrap_alignment_vertical(self) -> VerticalAlignment {
+        match self {
+            PropValueRef::AlignmentVertical(v) => v,
+            _ => panic!("Called `unwrap_alignment_vertical` on a bad value"),
+        }
+    }
+
+    /// Unwrap PropValue as InputType.
+    /// Panics otherwise
+    pub fn unwrap_input_type(self) -> &'a InputType {
+        match self {
+            PropValueRef::InputType(v) => v,
+            _ => panic!("Called `unwrap_input_type` on a bad value"),
+        }
+    }
+
+    /// Unwrap PropValue as Shape.
+    /// Panics otherwise
+    pub fn unwrap_shape(self) -> &'a Shape {
+        match self {
+            PropValueRef::Shape(v) => v,
+            _ => panic!("Called `unwrap_shape` on a bad value"),
+        }
+    }
+
+    /// Unwrap PropValue as Style.
+    /// Panics otherwise
+    pub fn unwrap_style(self) -> Style {
+        match self {
+            PropValueRef::Style(v) => v,
+            _ => panic!("Called `unwrap_style` on a bad value"),
+        }
+    }
+
+    /// Unwrap PropValue as [`SpanStatic`].
+    /// Panics otherwise
+    pub fn unwrap_textspan(self) -> &'a Span<'a> {
+        match self {
+            PropValueRef::TextSpan(v) => v,
+            _ => panic!("Called `unwrap_textspan` on a bad value"),
+        }
+    }
+
+    /// Unwrap PropValue as [`LineStatic`].
+    /// Panics otherwise
+    pub fn unwrap_textline(self) -> &'a Line<'a> {
+        match self {
+            PropValueRef::TextLine(b) => b,
+            _ => panic!("Called `unwrap_textline` on a bad value"),
+        }
+    }
+
+    /// Unwrap PropValue as [`TextStatic`].
+    /// Panics otherwise
+    pub fn unwrap_text(self) -> &'a Text<'a> {
+        match self {
+            PropValueRef::Text(v) => v,
+            _ => panic!("Called `unwrap_text` on a bad value"),
+        }
+    }
+
+    // -- as reference
+
+    /// Get a Bool value from PropValue, or None
+    pub fn as_bool(&self) -> Option<bool> {
+        match self {
+            // cheap copy, so no reference
+            PropValueRef::Bool(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Get a u8 value from PropValue, or None
+    pub fn as_u8(&self) -> Option<u8> {
+        match self {
+            // cheap copy, so no reference
+            PropValueRef::U8(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Get a u16 value from PropValue, or None
+    pub fn as_u16(&self) -> Option<u16> {
+        match self {
+            // cheap copy, so no reference
+            PropValueRef::U16(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Get a u32 value from PropValue, or None
+    pub fn as_u32(&self) -> Option<u32> {
+        match self {
+            // cheap copy, so no reference
+            PropValueRef::U32(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Get a u64 value from PropValue, or None
+    pub fn as_u64(&self) -> Option<u64> {
+        match self {
+            // cheap copy, so no reference
+            PropValueRef::U64(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Get a u128 value from PropValue, or None
+    pub fn as_u128(&self) -> Option<u128> {
+        match self {
+            // cheap copy, so no reference
+            PropValueRef::U128(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Get a usize value from PropValue, or None
+    pub fn as_usize(&self) -> Option<usize> {
+        match self {
+            // cheap copy, so no reference
+            PropValueRef::Usize(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Get a i8 value from PropValue, or None
+    pub fn as_i8(&self) -> Option<i8> {
+        match self {
+            // cheap copy, so no reference
+            PropValueRef::I8(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Get a i16 value from PropValue, or None
+    pub fn as_i16(&self) -> Option<i16> {
+        match self {
+            // cheap copy, so no reference
+            PropValueRef::I16(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Get a i32 value from PropValue, or None
+    pub fn as_i32(&self) -> Option<i32> {
+        match self {
+            // cheap copy, so no reference
+            PropValueRef::I32(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Get a i64 value from PropValue, or None
+    pub fn as_i64(&self) -> Option<i64> {
+        match self {
+            // cheap copy, so no reference
+            PropValueRef::I64(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Get a i128 value from PropValue, or None
+    pub fn as_i128(&self) -> Option<i128> {
+        match self {
+            // cheap copy, so no reference
+            PropValueRef::I128(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Get a isize value from PropValue, or None
+    pub fn as_isize(&self) -> Option<isize> {
+        match self {
+            // cheap copy, so no reference
+            PropValueRef::Isize(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Get a f32 value from PropValue, or None
+    pub fn as_f32(&self) -> Option<f32> {
+        match self {
+            // cheap copy, so no reference
+            PropValueRef::F32(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Get a f64 value from PropValue, or None
+    pub fn as_f64(&self) -> Option<f64> {
+        match self {
+            // cheap copy, so no reference
+            PropValueRef::F64(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Get a String value from PropValue, or None
+    pub fn as_str(&self) -> Option<&'a str> {
+        match self {
+            PropValueRef::Str(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Get a Horizontal Alignment value from PropValue, or None
+    pub fn as_alignment_horizontal(&self) -> Option<HorizontalAlignment> {
+        match self {
+            // cheap copy, so no reference
+            PropValueRef::AlignmentHorizontal(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Get a Vertical Alignment value from PropValue, or None
+    pub fn as_alignment_vertical(&self) -> Option<VerticalAlignment> {
+        match self {
+            // cheap copy, so no reference
+            PropValueRef::AlignmentVertical(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Get a InputType value from PropValue, or None
+    pub fn as_input_type(&self) -> Option<&'a InputType> {
+        match self {
+            PropValueRef::InputType(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Get a Shape value from PropValue, or None
+    pub fn as_shape(&self) -> Option<&'a Shape> {
+        match self {
+            PropValueRef::Shape(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Get a Style value from PropValue, or None
+    pub fn as_style(&self) -> Option<Style> {
+        match self {
+            PropValueRef::Style(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Get a [`SpanStatic`] value from PropValue, or None
+    pub fn as_textspan(&self) -> Option<&'a Span<'a>> {
+        match self {
+            PropValueRef::TextSpan(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Get a [`LineStatic`] value from PropValue, or None
+    pub fn as_textline(&self) -> Option<&'a Line<'a>> {
+        match self {
+            PropValueRef::TextLine(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Get a [`TextStatic`] value from PropValue, or None
+    pub fn as_text(&self) -> Option<&'a Text<'a>> {
+        match self {
+            PropValueRef::Text(v) => Some(v),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use pretty_assertions::{assert_eq, assert_ne};
+
+    use super::*;
+    use crate::props::{LineStatic, PropBound, SpanStatic, TextStatic};
+    use crate::ratatui::widgets::canvas::Map;
+
+    #[test]
+    fn prop_values() {
+        // test that values can be created without compile errors
+        let _ = PropPayloadRef::Single(PropValueRef::Usize(2));
+        let _ = PropPayloadRef::Pair((PropValueRef::Bool(true), PropValueRef::Usize(128)));
+        let _ = PropPayloadRef::Vec(&[
+            PropValue::U16(1),
+            PropValue::U32(2),
+            PropValue::U64(3),
+            PropValue::U128(4),
+        ]);
+        let mut map: HashMap<String, PropValue> = HashMap::new();
+        map.insert(String::from("a"), PropValue::I8(4));
+        assert_eq!(*map.get("a").unwrap(), PropValue::I8(4));
+        map.insert(String::from("b"), PropValue::I16(-8));
+        assert_eq!(*map.get("b").unwrap(), PropValue::I16(-8));
+        map.insert(String::from("c"), PropValue::I32(16));
+        assert_eq!(*map.get("c").unwrap(), PropValue::I32(16));
+        map.insert(String::from("d"), PropValue::I64(-32));
+        assert_eq!(*map.get("d").unwrap(), PropValue::I64(-32));
+        map.insert(String::from("e"), PropValue::I128(64));
+        assert_eq!(*map.get("e").unwrap(), PropValue::I128(64));
+        map.insert(String::from("g"), PropValue::InputType(InputType::Number));
+        assert_eq!(
+            *map.get("g").unwrap(),
+            PropValue::InputType(InputType::Number)
+        );
+        map.insert(String::from("h"), PropValue::U8(0));
+        assert_eq!(*map.get("h").unwrap(), PropValue::U8(0));
+        map.insert(String::from("i"), PropValue::Bool(true));
+        assert_eq!(*map.get("i").unwrap(), PropValue::Bool(true));
+        map.insert(String::from("j"), PropValue::U16(256));
+        assert_eq!(*map.get("j").unwrap(), PropValue::U16(256));
+        map.insert(String::from("k"), PropValue::U32(65536));
+        assert_eq!(*map.get("k").unwrap(), PropValue::U32(65536));
+        map.insert(String::from("l"), PropValue::U64(10000000000));
+        assert_eq!(*map.get("l").unwrap(), PropValue::U64(10000000000));
+        map.insert(String::from("m"), PropValue::Isize(200));
+        assert_eq!(*map.get("m").unwrap(), PropValue::Isize(200));
+        map.insert(String::from("n"), PropValue::F32(0.23));
+        assert_eq!(*map.get("n").unwrap(), PropValue::F32(0.23));
+        map.insert(
+            String::from("p"),
+            PropValue::Style(Style::default().fg(Color::Red)),
+        );
+        assert_eq!(
+            *map.get("p").unwrap(),
+            PropValue::Style(Style::default().fg(Color::Red))
+        );
+        map.insert(String::from("s"), PropValue::InputType(InputType::Number));
+        assert_eq!(
+            *map.get("s").unwrap(),
+            PropValue::InputType(InputType::Number)
+        );
+        map.insert(
+            String::from("t"),
+            PropValue::Shape(Shape::Map(Map::default())),
+        );
+        assert_eq!(
+            *map.get("t").unwrap(),
+            PropValue::Shape(Shape::Map(Map::default()))
+        );
+        map.insert(
+            String::from("u"),
+            PropValue::AlignmentHorizontal(HorizontalAlignment::Center),
+        );
+        assert_eq!(
+            *map.get("u").unwrap(),
+            PropValue::AlignmentHorizontal(HorizontalAlignment::Center)
+        );
+
+        let _ = PropPayloadRef::Map(&map);
+        let mut link: LinkedList<PropPayload> = LinkedList::new();
+        link.push_back(PropPayload::Single(PropValue::Usize(1)));
+        link.push_back(PropPayload::Pair((
+            PropValue::Usize(2),
+            PropValue::Usize(4),
+        )));
+        let _ = PropPayloadRef::Linked(&link);
+    }
+
+    #[test]
+    fn unwrap_prop_values() {
+        assert_eq!(
+            PropValueRef::AlignmentHorizontal(HorizontalAlignment::Center)
+                .unwrap_alignment_horizontal(),
+            HorizontalAlignment::Center
+        );
+        assert_eq!(
+            PropValueRef::AlignmentVertical(VerticalAlignment::Top).unwrap_alignment_vertical(),
+            VerticalAlignment::Top
+        );
+        assert!(PropValueRef::Bool(true).unwrap_bool());
+        assert_eq!(PropValueRef::F32(0.32).unwrap_f32(), 0.32);
+        assert_eq!(PropValueRef::F64(0.32).unwrap_f64(), 0.32);
+        assert_eq!(PropValueRef::I128(5).unwrap_i128(), 5);
+        assert_eq!(PropValueRef::I64(5).unwrap_i64(), 5);
+        assert_eq!(PropValueRef::I32(5).unwrap_i32(), 5);
+        assert_eq!(PropValueRef::I16(5).unwrap_i16(), 5);
+        assert_eq!(PropValueRef::I8(5).unwrap_i8(), 5);
+        assert_eq!(PropValueRef::Isize(5).unwrap_isize(), 5);
+        assert_eq!(PropValueRef::U128(5).unwrap_u128(), 5);
+        assert_eq!(PropValueRef::U64(5).unwrap_u64(), 5);
+        assert_eq!(PropValueRef::U32(5).unwrap_u32(), 5);
+        assert_eq!(PropValueRef::U16(5).unwrap_u16(), 5);
+        assert_eq!(PropValueRef::U8(5).unwrap_u8(), 5);
+        assert_eq!(PropValueRef::Usize(5).unwrap_usize(), 5);
+        assert_eq!(
+            PropValueRef::InputType(&InputType::Number).unwrap_input_type(),
+            &InputType::Number
+        );
+        assert_eq!(
+            PropValueRef::Shape(&Shape::Layer).unwrap_shape(),
+            &Shape::Layer
+        );
+        assert_eq!(
+            PropValueRef::Str(&String::from("ciao")).unwrap_str(),
+            "ciao".to_string()
+        );
+        assert_eq!(
+            PropValueRef::Style(Style::default()).unwrap_style(),
+            Style::default()
+        );
+        assert_eq!(
+            PropValueRef::TextSpan(&SpanStatic::from("ciao")).unwrap_textspan(),
+            &SpanStatic::from("ciao")
+        );
+        assert_eq!(
+            PropValueRef::TextLine(&LineStatic::from("ciao")).unwrap_textline(),
+            &LineStatic::from("ciao")
+        );
+        assert_eq!(
+            PropValueRef::Text(&TextStatic::from("ciao")).unwrap_text(),
+            &TextStatic::from("ciao")
+        );
+    }
+
+    #[test]
+    fn as_prop_value() {
+        assert_eq!(PropValueRef::Bool(true).as_bool(), Some(true));
+        assert_eq!(PropValueRef::U8(0).as_bool(), None);
+
+        assert_eq!(PropValueRef::U8(1).as_u8(), Some(1));
+        assert_eq!(PropValueRef::Bool(true).as_u8(), None);
+
+        assert_eq!(PropValueRef::U16(1).as_u16(), Some(1));
+        assert_eq!(PropValueRef::Bool(true).as_u16(), None);
+
+        assert_eq!(PropValueRef::U32(1).as_u32(), Some(1));
+        assert_eq!(PropValueRef::Bool(true).as_u32(), None);
+
+        assert_eq!(PropValueRef::U64(1).as_u64(), Some(1));
+        assert_eq!(PropValueRef::Bool(true).as_u64(), None);
+
+        assert_eq!(PropValueRef::U128(1).as_u128(), Some(1));
+        assert_eq!(PropValueRef::Bool(true).as_u128(), None);
+
+        assert_eq!(PropValueRef::Usize(1).as_usize(), Some(1));
+        assert_eq!(PropValueRef::Bool(true).as_usize(), None);
+
+        assert_eq!(PropValueRef::I8(-1).as_i8(), Some(-1));
+        assert_eq!(PropValueRef::Bool(true).as_i8(), None);
+
+        assert_eq!(PropValueRef::I16(-1).as_i16(), Some(-1));
+        assert_eq!(PropValueRef::Bool(true).as_i16(), None);
+
+        assert_eq!(PropValueRef::I32(-1).as_i32(), Some(-1));
+        assert_eq!(PropValueRef::Bool(true).as_i32(), None);
+
+        assert_eq!(PropValueRef::I64(-1).as_i64(), Some(-1));
+        assert_eq!(PropValueRef::Bool(true).as_i64(), None);
+
+        assert_eq!(PropValueRef::I128(-1).as_i128(), Some(-1));
+        assert_eq!(PropValueRef::Bool(true).as_i128(), None);
+
+        assert_eq!(PropValueRef::Isize(-1).as_isize(), Some(-1));
+        assert_eq!(PropValueRef::Bool(true).as_isize(), None);
+
+        assert_eq!(PropValueRef::F32(1.1).as_f32(), Some(1.1));
+        assert_eq!(PropValueRef::Bool(true).as_f32(), None);
+
+        assert_eq!(PropValueRef::F64(1.1).as_f64(), Some(1.1));
+        assert_eq!(PropValueRef::Bool(true).as_f64(), None);
+
+        assert_eq!(PropValueRef::Str("hello").as_str(), Some("hello"));
+        assert_eq!(PropValueRef::Bool(true).as_str(), None);
+
+        assert_eq!(
+            PropValueRef::AlignmentHorizontal(HorizontalAlignment::Center)
+                .as_alignment_horizontal(),
+            Some(HorizontalAlignment::Center)
+        );
+        assert_eq!(PropValueRef::Bool(true).as_alignment_horizontal(), None);
+
+        assert_eq!(
+            PropValueRef::AlignmentVertical(VerticalAlignment::Top).as_alignment_vertical(),
+            Some(VerticalAlignment::Top)
+        );
+        assert_eq!(PropValueRef::Bool(true).as_alignment_vertical(), None);
+
+        assert_eq!(
+            PropValueRef::InputType(&InputType::Color).as_input_type(),
+            Some(&InputType::Color)
+        );
+        assert_eq!(PropValueRef::Bool(true).as_input_type(), None);
+
+        assert_eq!(
+            PropValueRef::Shape(&Shape::Layer).as_shape(),
+            Some(&Shape::Layer)
+        );
+        assert_eq!(PropValueRef::Bool(true).as_shape(), None);
+
+        assert_eq!(
+            PropValueRef::Style(Style::new()).as_style(),
+            Some(Style::new())
+        );
+        assert_eq!(PropValueRef::Bool(true).as_style(), None);
+
+        assert_eq!(
+            PropValueRef::TextSpan(&SpanStatic::from("hello")).as_textspan(),
+            Some(&SpanStatic::from("hello"))
+        );
+        assert_eq!(PropValueRef::Bool(true).as_textspan(), None);
+
+        assert_eq!(
+            PropValueRef::TextLine(&LineStatic::from("hello")).as_textline(),
+            Some(&LineStatic::from("hello"))
+        );
+        assert_eq!(PropValueRef::Bool(true).as_textline(), None);
+
+        assert_eq!(
+            PropValueRef::Text(&TextStatic::from("hello")).as_text(),
+            Some(&TextStatic::from("hello"))
+        );
+        assert_eq!(PropValueRef::Bool(true).as_text(), None);
+    }
+
+    #[test]
+    fn unwrap_prop_payloads() {
+        assert!(
+            !PropPayloadRef::Single(PropValueRef::Bool(false))
+                .unwrap_single()
+                .unwrap_bool(),
+        );
+        assert_eq!(
+            PropPayloadRef::Pair((PropValueRef::Bool(false), PropValueRef::Bool(false)))
+                .unwrap_pair(),
+            (PropValueRef::Bool(false), PropValueRef::Bool(false))
+        );
+        assert_eq!(
+            PropPayloadRef::Vec(&[PropValue::Bool(false), PropValue::Bool(false)]).unwrap_vec(),
+            &[PropValue::Bool(false), PropValue::Bool(false)]
+        );
+    }
+
+    #[test]
+    fn as_prop_payloads() {
+        assert_eq!(
+            PropPayloadRef::Single(PropValueRef::Bool(true)).as_single(),
+            Some(PropValueRef::Bool(true))
+        );
+        assert_eq!(PropPayloadRef::None.as_single(), None);
+
+        assert_eq!(
+            PropPayloadRef::Pair((PropValueRef::Bool(true), PropValueRef::Bool(true))).as_pair(),
+            Some((PropValueRef::Bool(true), PropValueRef::Bool(true)))
+        );
+        assert_eq!(PropPayloadRef::None.as_pair(), None);
+
+        assert_eq!(
+            PropPayloadRef::Vec(&[PropValue::Bool(true)]).as_vec(),
+            Some([PropValue::Bool(true)].as_slice())
+        );
+        assert_eq!(PropPayloadRef::None.as_vec(), None);
+
+        assert_eq!(
+            PropPayloadRef::Map(&HashMap::from([(
+                "hello".to_string(),
+                PropValue::Bool(true)
+            )]))
+            .as_map(),
+            Some(&HashMap::from([(
+                "hello".to_string(),
+                PropValue::Bool(true)
+            )]))
+        );
+        assert_eq!(PropPayloadRef::None.as_map(), None);
+
+        assert_eq!(
+            PropPayloadRef::Linked(&LinkedList::new()).as_linked(),
+            Some(&LinkedList::new())
+        );
+        assert_eq!(PropPayloadRef::None.as_linked(), None);
+    }
+
+    #[test]
+    fn any() {
+        #[derive(Debug, Clone, Copy, PartialEq)]
+        struct SomeCustomType {
+            field1: bool,
+            field2: bool,
+        }
+
+        #[derive(Debug, Clone, Copy, PartialEq)]
+        struct SomeDifferentCustomType {
+            field1: bool,
+        }
+
+        let input = SomeCustomType {
+            field1: true,
+            field2: false,
+        };
+        let any_data = input.to_any_prop();
+        let single_value = PropPayloadRef::Any(&any_data);
+
+        assert_eq!(
+            single_value,
+            PropPayloadRef::Any(
+                &SomeCustomType {
+                    field1: true,
+                    field2: false
+                }
+                .to_any_prop()
+            )
+        );
+        assert_ne!(
+            single_value,
+            PropPayloadRef::Any(
+                &SomeCustomType {
+                    field1: false,
+                    field2: true
+                }
+                .to_any_prop()
+            )
+        );
+
+        assert_ne!(
+            single_value,
+            PropPayloadRef::Any(&SomeDifferentCustomType { field1: true }.to_any_prop())
+        );
+
+        #[derive(Debug, Clone, PartialEq)]
+        struct CloneableType {
+            field1: String,
+        }
+
+        let any_data = CloneableType {
+            field1: "Hello".to_string(),
+        }
+        .to_any_prop();
+        let input = PropPayloadRef::Any(&any_data);
+
+        let input_downcasted = input
+            .as_any()
+            .unwrap()
+            .downcast_ref::<CloneableType>()
+            .expect("Erased type should be CloneableType");
+        let copied_downcasted = input
+            .as_any()
+            .unwrap()
+            .downcast_ref::<CloneableType>()
+            .expect("Erased type should be CloneableType");
+        // should be copied and so have the same memory pointer
+        assert_eq!(
+            input_downcasted.field1.as_ptr(),
+            copied_downcasted.field1.as_ptr()
+        );
+    }
+}

--- a/crates/tuirealm/src/core/props/prop_value_ref.rs
+++ b/crates/tuirealm/src/core/props/prop_value_ref.rs
@@ -191,6 +191,20 @@ impl<'a> PartialEq<PropPayloadRef<'a>> for PropPayload {
     }
 }
 
+impl<'a> From<&'a PropPayload> for PropPayloadRef<'a> {
+    fn from(value: &'a PropPayload) -> Self {
+        match value {
+            PropPayload::Single(prop_value) => Self::Single(prop_value.into()),
+            PropPayload::Pair((a, b)) => Self::Pair((a.into(), b.into())),
+            PropPayload::Vec(prop_values) => Self::Vec(prop_values.as_slice()),
+            PropPayload::Map(hash_map) => Self::Map(hash_map),
+            PropPayload::Linked(prop_payloads) => Self::Linked(prop_payloads),
+            PropPayload::Any(prop_bound) => Self::Any(prop_bound),
+            PropPayload::None => Self::None,
+        }
+    }
+}
+
 impl<'a> PropValueRef<'a> {
     // -- unwrappers
 
@@ -699,6 +713,43 @@ impl<'a> PartialEq<PropValue> for PropValueRef<'a> {
 impl<'a> PartialEq<PropValueRef<'a>> for PropValue {
     fn eq(&self, other: &PropValueRef<'a>) -> bool {
         *other == *self
+    }
+}
+
+impl<'a> From<&'a PropValue> for PropValueRef<'a> {
+    fn from(value: &'a PropValue) -> Self {
+        match value {
+            PropValue::Bool(flag) => Self::Bool(*flag),
+            PropValue::U8(num) => Self::U8(*num),
+            PropValue::U16(num) => Self::U16(*num),
+            PropValue::U32(num) => Self::U32(*num),
+            PropValue::U64(num) => Self::U64(*num),
+            PropValue::U128(num) => Self::U128(*num),
+            PropValue::Usize(num) => Self::Usize(*num),
+            PropValue::I8(num) => Self::I8(*num),
+            PropValue::I16(num) => Self::I16(*num),
+            PropValue::I32(num) => Self::I32(*num),
+            PropValue::I64(num) => Self::I64(*num),
+            PropValue::I128(num) => Self::I128(*num),
+            PropValue::Isize(num) => Self::Isize(*num),
+            PropValue::F64(num) => Self::F64(*num),
+            PropValue::F32(num) => Self::F32(*num),
+            PropValue::Str(str) => Self::Str(str),
+            PropValue::AlignmentHorizontal(horizontal_alignment) => {
+                Self::AlignmentHorizontal(*horizontal_alignment)
+            }
+            PropValue::AlignmentVertical(vertical_alignment) => {
+                Self::AlignmentVertical(*vertical_alignment)
+            }
+            PropValue::Color(color) => Self::Color(*color),
+            PropValue::InputType(input_type) => Self::InputType(input_type),
+            PropValue::Shape(shape) => Self::Shape(shape),
+            PropValue::Style(style) => Self::Style(*style),
+            PropValue::Table(items) => Self::Table(items),
+            PropValue::TextSpan(span) => Self::TextSpan(span),
+            PropValue::TextLine(line) => Self::TextLine(line),
+            PropValue::Text(text) => Self::Text(text),
+        }
     }
 }
 
@@ -1265,5 +1316,152 @@ mod tests {
                 == PropValue::Text(TextStatic::from("hello"))
         );
         assert!(!(PropValueRef::Text(&TextStatic::from("hello")) == PropValue::Bool(false)));
+    }
+
+    #[test]
+    fn from_nonref_proppayload() {
+        assert_eq!(
+            PropPayloadRef::from(&PropPayload::Single(PropValue::Bool(true))),
+            PropPayloadRef::Single(PropValueRef::Bool(true))
+        );
+        assert_eq!(
+            PropPayloadRef::from(&PropPayload::Pair((
+                PropValue::Bool(true),
+                PropValue::Bool(true)
+            ))),
+            PropPayloadRef::Pair((PropValueRef::Bool(true), PropValueRef::Bool(true)))
+        );
+        assert_eq!(
+            PropPayloadRef::from(&PropPayload::Vec(vec![PropValue::Bool(true)])),
+            PropPayloadRef::Vec([PropValue::Bool(true)].as_slice())
+        );
+        assert_eq!(
+            PropPayloadRef::from(&PropPayload::Map(HashMap::from([(
+                "key".to_string(),
+                PropValue::Bool(true)
+            )]))),
+            PropPayloadRef::Map(&HashMap::from([("key".to_string(), PropValue::Bool(true))]))
+        );
+        assert_eq!(
+            PropPayloadRef::from(&PropPayload::Linked(LinkedList::new())),
+            PropPayloadRef::Linked(&LinkedList::new())
+        );
+        assert_eq!(
+            PropPayloadRef::from(&PropPayload::None),
+            PropPayloadRef::None
+        );
+
+        #[derive(Debug, Clone, PartialEq)]
+        struct CloneableType {
+            field1: String,
+        }
+
+        assert_eq!(
+            PropPayloadRef::from(&PropPayload::Any(
+                CloneableType {
+                    field1: "Hello".to_string(),
+                }
+                .to_any_prop()
+            )),
+            PropPayloadRef::Any(
+                &CloneableType {
+                    field1: "Hello".to_string(),
+                }
+                .to_any_prop()
+            )
+        );
+    }
+
+    #[test]
+    fn from_nonref_propvalue() {
+        assert_eq!(
+            PropValueRef::from(&PropValue::Bool(true)),
+            PropValue::Bool(true)
+        );
+
+        assert_eq!(PropValueRef::from(&PropValue::U8(1)), PropValueRef::U8(1));
+        assert_eq!(PropValueRef::from(&PropValue::U16(1)), PropValueRef::U16(1));
+        assert_eq!(PropValueRef::from(&PropValue::U32(1)), PropValueRef::U32(1));
+        assert_eq!(PropValueRef::from(&PropValue::U64(1)), PropValueRef::U64(1));
+        assert_eq!(
+            PropValueRef::from(&PropValue::U128(1)),
+            PropValueRef::U128(1)
+        );
+        assert_eq!(
+            PropValueRef::from(&PropValue::Usize(1)),
+            PropValueRef::Usize(1)
+        );
+        assert_eq!(PropValueRef::from(&PropValue::I8(1)), PropValueRef::I8(1));
+        assert_eq!(PropValueRef::from(&PropValue::I16(1)), PropValueRef::I16(1));
+        assert_eq!(PropValueRef::from(&PropValue::I32(1)), PropValueRef::I32(1));
+        assert_eq!(PropValueRef::from(&PropValue::I64(1)), PropValueRef::I64(1));
+        assert_eq!(
+            PropValueRef::from(&PropValue::I128(1)),
+            PropValueRef::I128(1)
+        );
+        assert_eq!(
+            PropValueRef::from(&PropValue::Isize(1)),
+            PropValueRef::Isize(1)
+        );
+        assert_eq!(
+            PropValueRef::from(&PropValue::F32(1.0)),
+            PropValueRef::F32(1.0)
+        );
+        assert_eq!(
+            PropValueRef::from(&PropValue::F64(1.0)),
+            PropValueRef::F64(1.0)
+        );
+
+        assert_eq!(
+            PropValueRef::from(&PropValue::Str("hello".to_string())),
+            PropValueRef::Str("hello")
+        );
+
+        assert_eq!(
+            PropValueRef::from(&PropValue::AlignmentHorizontal(HorizontalAlignment::Center)),
+            PropValueRef::AlignmentHorizontal(HorizontalAlignment::Center)
+        );
+        assert_eq!(
+            PropValueRef::from(&PropValue::AlignmentVertical(VerticalAlignment::Bottom)),
+            PropValueRef::AlignmentVertical(VerticalAlignment::Bottom)
+        );
+
+        assert_eq!(
+            PropValueRef::from(&PropValue::Color(Color::Black)),
+            PropValueRef::Color(Color::Black)
+        );
+
+        assert_eq!(
+            PropValueRef::from(&PropValue::InputType(InputType::Color)),
+            PropValueRef::InputType(&InputType::Color)
+        );
+
+        assert_eq!(
+            PropValueRef::from(&PropValue::Shape(Shape::Layer)),
+            PropValueRef::Shape(&Shape::Layer)
+        );
+
+        assert_eq!(
+            PropValueRef::from(&PropValue::Style(Style::default())),
+            PropValueRef::Style(Style::default())
+        );
+
+        assert_eq!(
+            PropValueRef::from(&PropValue::Table(Table::new())),
+            PropValueRef::Table(&Table::new())
+        );
+
+        assert_eq!(
+            PropValueRef::from(&PropValue::TextSpan(SpanStatic::from("hello"))),
+            PropValueRef::TextSpan(&SpanStatic::from("hello"))
+        );
+        assert_eq!(
+            PropValueRef::from(&PropValue::TextLine(LineStatic::from("hello"))),
+            PropValueRef::TextLine(&LineStatic::from("hello"))
+        );
+        assert_eq!(
+            PropValueRef::from(&PropValue::Text(TextStatic::from("hello"))),
+            PropValueRef::Text(&TextStatic::from("hello"))
+        );
     }
 }

--- a/crates/tuirealm/src/core/props/prop_value_ref.rs
+++ b/crates/tuirealm/src/core/props/prop_value_ref.rs
@@ -156,6 +156,41 @@ impl<'a> PropPayloadRef<'a> {
     }
 }
 
+impl<'a> PartialEq<PropPayload> for PropPayloadRef<'a> {
+    fn eq(&self, other: &PropPayload) -> bool {
+        match (other, self) {
+            (PropPayload::Single(a), Self::Single(b)) => return *a == *b,
+            (PropPayload::Pair((a1, a2)), Self::Pair((b1, b2))) => return a1 == b1 && a2 == b2,
+            _ => (),
+        }
+
+        match other {
+            PropPayload::Single(_) | PropPayload::Pair(_) => false,
+            // PropPayload::Single(prop_value) => Some(prop_value) == self.as_single(),
+            // PropPayload::Pair((a, b)) => Some((a, b)) == self.as_pair(),
+            PropPayload::Vec(prop_values) => Some(prop_values.as_slice()) == self.as_vec(),
+            PropPayload::Map(hash_map) => Some(hash_map) == self.as_map(),
+            PropPayload::Linked(prop_payloads) => Some(prop_payloads) == self.as_linked(),
+            PropPayload::Any(prop_bound) => {
+                if let Self::Any(any) = self {
+                    &prop_bound == any
+                } else {
+                    false
+                }
+            }
+            PropPayload::None => *self == Self::None,
+        }
+    }
+}
+
+// reverse impl to not have position-dependent implementations
+// ex. allow `PropPayload == PropPayloadRef` AND `PropPayloadRef == PropPayload`, without this, it would only allow one of them
+impl<'a> PartialEq<PropPayloadRef<'a>> for PropPayload {
+    fn eq(&self, other: &PropPayloadRef<'a>) -> bool {
+        *other == *self
+    }
+}
+
 impl<'a> PropValueRef<'a> {
     // -- unwrappers
 
@@ -321,6 +356,15 @@ impl<'a> PropValueRef<'a> {
         }
     }
 
+    /// Unwrap PropValue as Color.
+    /// Panics otherwise
+    pub fn unwrap_color(self) -> Color {
+        match self {
+            PropValueRef::Color(v) => v,
+            _ => panic!("Called `unwrap_color` on a bad value"),
+        }
+    }
+
     /// Unwrap PropValue as InputType.
     /// Panics otherwise
     pub fn unwrap_input_type(self) -> &'a InputType {
@@ -345,6 +389,15 @@ impl<'a> PropValueRef<'a> {
         match self {
             PropValueRef::Style(v) => v,
             _ => panic!("Called `unwrap_style` on a bad value"),
+        }
+    }
+
+    /// Unwrap PropValue as Table.
+    /// Panics otherwise
+    pub fn unwrap_table(self) -> &'a Table {
+        match self {
+            PropValueRef::Table(v) => v,
+            _ => panic!("Called `unwrap_table` on a bad value"),
         }
     }
 
@@ -538,6 +591,15 @@ impl<'a> PropValueRef<'a> {
         }
     }
 
+    /// Get a Color value from PropValue, or None
+    pub fn as_color(&self) -> Option<Color> {
+        match self {
+            // cheap copy, so no reference
+            PropValueRef::Color(v) => Some(*v),
+            _ => None,
+        }
+    }
+
     /// Get a InputType value from PropValue, or None
     pub fn as_input_type(&self) -> Option<&'a InputType> {
         match self {
@@ -558,6 +620,14 @@ impl<'a> PropValueRef<'a> {
     pub fn as_style(&self) -> Option<Style> {
         match self {
             PropValueRef::Style(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Get a Table value from PropValue, or None
+    pub fn as_table(&self) -> Option<&Table> {
+        match self {
+            PropValueRef::Table(v) => Some(v),
             _ => None,
         }
     }
@@ -584,6 +654,51 @@ impl<'a> PropValueRef<'a> {
             PropValueRef::Text(v) => Some(v),
             _ => None,
         }
+    }
+}
+
+impl<'a> PartialEq<PropValue> for PropValueRef<'a> {
+    fn eq(&self, other: &PropValue) -> bool {
+        match other {
+            PropValue::Bool(bool) => Some(*bool) == self.as_bool(),
+            PropValue::U8(num) => Some(*num) == self.as_u8(),
+            PropValue::U16(num) => Some(*num) == self.as_u16(),
+            PropValue::U32(num) => Some(*num) == self.as_u32(),
+            PropValue::U64(num) => Some(*num) == self.as_u64(),
+            PropValue::U128(num) => Some(*num) == self.as_u128(),
+            PropValue::Usize(num) => Some(*num) == self.as_usize(),
+            PropValue::I8(num) => Some(*num) == self.as_i8(),
+            PropValue::I16(num) => Some(*num) == self.as_i16(),
+            PropValue::I32(num) => Some(*num) == self.as_i32(),
+            PropValue::I64(num) => Some(*num) == self.as_i64(),
+            PropValue::I128(num) => Some(*num) == self.as_i128(),
+            PropValue::Isize(num) => Some(*num) == self.as_isize(),
+            PropValue::F64(num) => Some(*num) == self.as_f64(),
+            PropValue::F32(num) => Some(*num) == self.as_f32(),
+            PropValue::Str(string) => Some(string.as_str()) == self.as_str(),
+            PropValue::AlignmentHorizontal(horizontal_alignment) => {
+                Some(*horizontal_alignment) == self.as_alignment_horizontal()
+            }
+            PropValue::AlignmentVertical(vertical_alignment) => {
+                Some(*vertical_alignment) == self.as_alignment_vertical()
+            }
+            PropValue::Color(color) => Some(*color) == self.as_color(),
+            PropValue::InputType(input_type) => Some(input_type) == self.as_input_type(),
+            PropValue::Shape(shape) => Some(shape) == self.as_shape(),
+            PropValue::Style(style) => Some(*style) == self.as_style(),
+            PropValue::Table(items) => Some(items) == self.as_table(),
+            PropValue::TextSpan(span) => Some(span) == self.as_textspan(),
+            PropValue::TextLine(line) => Some(line) == self.as_textline(),
+            PropValue::Text(text) => Some(text) == self.as_text(),
+        }
+    }
+}
+
+// reverse impl to not have position-dependent implementations
+// ex. allow `PropValue == PropValueRef` AND `PropValueRef == PropValue`, without this, it would only allow one of them
+impl<'a> PartialEq<PropValueRef<'a>> for PropValue {
+    fn eq(&self, other: &PropValueRef<'a>) -> bool {
+        *other == *self
     }
 }
 
@@ -689,6 +804,7 @@ mod tests {
             PropValueRef::AlignmentVertical(VerticalAlignment::Top).unwrap_alignment_vertical(),
             VerticalAlignment::Top
         );
+        assert_eq!(PropValue::Color(Color::Black).unwrap_color(), Color::Black);
         assert!(PropValueRef::Bool(true).unwrap_bool());
         assert_eq!(PropValueRef::F32(0.32).unwrap_f32(), 0.32);
         assert_eq!(PropValueRef::F64(0.32).unwrap_f64(), 0.32);
@@ -719,6 +835,10 @@ mod tests {
         assert_eq!(
             PropValueRef::Style(Style::default()).unwrap_style(),
             Style::default()
+        );
+        assert_eq!(
+            PropValue::Table(vec![vec![LineStatic::from("test")]]).unwrap_table(),
+            vec![vec![LineStatic::from("test")]]
         );
         assert_eq!(
             PropValueRef::TextSpan(&SpanStatic::from("ciao")).unwrap_textspan(),
@@ -798,6 +918,12 @@ mod tests {
         assert_eq!(PropValueRef::Bool(true).as_alignment_vertical(), None);
 
         assert_eq!(
+            PropValue::Color(Color::Black).as_color(),
+            Some(Color::Black)
+        );
+        assert_eq!(PropValue::Bool(true).as_color(), None);
+
+        assert_eq!(
             PropValueRef::InputType(&InputType::Color).as_input_type(),
             Some(&InputType::Color)
         );
@@ -814,6 +940,12 @@ mod tests {
             Some(Style::new())
         );
         assert_eq!(PropValueRef::Bool(true).as_style(), None);
+
+        assert_eq!(
+            PropValue::Table(Table::new()).as_table(),
+            Some(&Table::new())
+        );
+        assert_eq!(PropValue::Bool(true).as_table(), None);
 
         assert_eq!(
             PropValueRef::TextSpan(&SpanStatic::from("hello")).as_textspan(),
@@ -964,5 +1096,174 @@ mod tests {
             input_downcasted.field1.as_ptr(),
             copied_downcasted.field1.as_ptr()
         );
+    }
+
+    #[test]
+    fn eq_nonref_proppayload() {
+        assert!(
+            PropPayloadRef::Single(PropValueRef::Bool(true))
+                == PropPayload::Single(PropValue::Bool(true))
+        );
+        assert!(!(PropPayloadRef::Single(PropValueRef::Bool(true)) == PropPayload::None));
+
+        assert!(
+            PropPayloadRef::Pair((PropValueRef::Bool(true), PropValueRef::Bool(true)))
+                == PropPayload::Pair((PropValue::Bool(true), PropValue::Bool(true)))
+        );
+        assert!(
+            !(PropPayloadRef::Pair((PropValueRef::Bool(true), PropValueRef::Bool(true)))
+                == PropPayload::None)
+        );
+
+        assert!(
+            PropPayloadRef::Vec(&[PropValue::Bool(true)])
+                == PropPayload::Vec(vec![PropValue::Bool(true)])
+        );
+        assert!(!(PropPayloadRef::Vec(&[PropValue::Bool(true)]) == PropPayload::None));
+
+        assert!(
+            PropPayloadRef::Map(&HashMap::from([("key".to_string(), PropValue::Bool(true))]))
+                == PropPayload::Map(HashMap::from([("key".to_string(), PropValue::Bool(true))]))
+        );
+        assert!(
+            !(PropPayloadRef::Map(&HashMap::from([("key".to_string(), PropValue::Bool(true))]))
+                == PropPayload::None)
+        );
+
+        assert!(
+            PropPayloadRef::Linked(&LinkedList::new()) == PropPayload::Linked(LinkedList::new())
+        );
+        assert!(!(PropPayloadRef::Linked(&LinkedList::new()) == PropPayload::None));
+
+        #[derive(Debug, Clone, PartialEq)]
+        struct CloneableType {
+            field1: String,
+        }
+
+        assert!(
+            PropPayloadRef::Any(
+                &CloneableType {
+                    field1: "Hello".to_string(),
+                }
+                .to_any_prop()
+            ) == PropPayload::Any(
+                CloneableType {
+                    field1: "Hello".to_string(),
+                }
+                .to_any_prop()
+            )
+        );
+        assert!(
+            !(PropPayloadRef::Any(
+                &CloneableType {
+                    field1: "Hello".to_string(),
+                }
+                .to_any_prop()
+            ) == PropPayload::None)
+        );
+    }
+
+    #[test]
+    fn eq_nonref_propvalue() {
+        assert!(PropValueRef::Bool(true) == PropValue::Bool(true));
+        assert!(PropValueRef::Bool(false) == PropValue::Bool(false));
+        assert!(!(PropValueRef::Bool(true) == PropValue::U8(0)));
+
+        assert!(PropValueRef::U8(1) == PropValue::U8(1));
+        assert!(!(PropValueRef::U8(1) == PropValue::Bool(false)));
+
+        assert!(PropValueRef::U16(1) == PropValue::U16(1));
+        assert!(!(PropValueRef::U16(1) == PropValue::Bool(false)));
+
+        assert!(PropValueRef::U32(1) == PropValue::U32(1));
+        assert!(!(PropValueRef::U32(1) == PropValue::Bool(false)));
+
+        assert!(PropValueRef::U64(1) == PropValue::U64(1));
+        assert!(!(PropValueRef::U64(1) == PropValue::Bool(false)));
+
+        assert!(PropValueRef::U128(1) == PropValue::U128(1));
+        assert!(!(PropValueRef::U128(1) == PropValue::Bool(false)));
+
+        assert!(PropValueRef::Usize(1) == PropValue::Usize(1));
+        assert!(!(PropValueRef::Usize(1) == PropValue::Bool(false)));
+
+        assert!(PropValueRef::I8(1) == PropValue::I8(1));
+        assert!(!(PropValueRef::I8(1) == PropValue::Bool(false)));
+
+        assert!(PropValueRef::I16(1) == PropValue::I16(1));
+        assert!(!(PropValueRef::I16(1) == PropValue::Bool(false)));
+
+        assert!(PropValueRef::I32(1) == PropValue::I32(1));
+        assert!(!(PropValueRef::I32(1) == PropValue::Bool(false)));
+
+        assert!(PropValueRef::I64(1) == PropValue::I64(1));
+        assert!(!(PropValueRef::I64(1) == PropValue::Bool(false)));
+
+        assert!(PropValueRef::I128(1) == PropValue::I128(1));
+        assert!(!(PropValueRef::I128(1) == PropValue::Bool(false)));
+
+        assert!(PropValueRef::Isize(1) == PropValue::Isize(1));
+        assert!(!(PropValueRef::Isize(1) == PropValue::Bool(false)));
+
+        assert!(PropValueRef::F32(1.0) == PropValue::F32(1.0));
+        assert!(!(PropValueRef::F32(1.0) == PropValue::Bool(false)));
+
+        assert!(PropValueRef::F64(1.0) == PropValue::F64(1.0));
+        assert!(!(PropValueRef::F64(1.0) == PropValue::Bool(false)));
+
+        assert!(PropValueRef::Str("hello") == PropValue::Str("hello".to_string()));
+        assert!(!(PropValueRef::Str("hello") == PropValue::Bool(false)));
+
+        assert!(
+            PropValueRef::AlignmentHorizontal(HorizontalAlignment::Center)
+                == PropValue::AlignmentHorizontal(HorizontalAlignment::Center)
+        );
+        assert!(
+            !(PropValueRef::AlignmentHorizontal(HorizontalAlignment::Center)
+                == PropValue::Bool(false))
+        );
+
+        assert!(
+            PropValueRef::AlignmentVertical(VerticalAlignment::Bottom)
+                == PropValue::AlignmentVertical(VerticalAlignment::Bottom)
+        );
+        assert!(
+            !(PropValueRef::AlignmentVertical(VerticalAlignment::Bottom) == PropValue::Bool(false))
+        );
+
+        assert!(PropValueRef::Color(Color::Black) == PropValue::Color(Color::Black));
+        assert!(!(PropValueRef::Color(Color::Black) == PropValue::Bool(false)));
+
+        assert!(
+            PropValueRef::InputType(&InputType::Color) == PropValue::InputType(InputType::Color)
+        );
+        assert!(!(PropValueRef::InputType(&InputType::Color) == PropValue::Bool(false)));
+
+        assert!(PropValueRef::Shape(&Shape::Layer) == PropValue::Shape(Shape::Layer));
+        assert!(!(PropValueRef::Shape(&Shape::Layer) == PropValue::Bool(false)));
+
+        assert!(PropValueRef::Style(Style::default()) == PropValue::Style(Style::default()));
+        assert!(!(PropValueRef::Style(Style::default()) == PropValue::Bool(false)));
+
+        assert!(PropValueRef::Table(&Table::new()) == PropValue::Table(Table::new()));
+        assert!(!(PropValueRef::Table(&Table::new()) == PropValue::Bool(false)));
+
+        assert!(
+            PropValueRef::TextSpan(&SpanStatic::from("hello"))
+                == PropValue::TextSpan(SpanStatic::from("hello"))
+        );
+        assert!(!(PropValueRef::TextSpan(&SpanStatic::from("hello")) == PropValue::Bool(false)));
+
+        assert!(
+            PropValueRef::TextLine(&LineStatic::from("hello"))
+                == PropValue::TextLine(LineStatic::from("hello"))
+        );
+        assert!(!(PropValueRef::TextLine(&LineStatic::from("hello")) == PropValue::Bool(false)));
+
+        assert!(
+            PropValueRef::Text(&TextStatic::from("hello"))
+                == PropValue::Text(TextStatic::from("hello"))
+        );
+        assert!(!(PropValueRef::Text(&TextStatic::from("hello")) == PropValue::Bool(false)));
     }
 }

--- a/crates/tuirealm/src/core/props/props_store.rs
+++ b/crates/tuirealm/src/core/props/props_store.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::props::{AttrValue, Attribute};
+use crate::props::{AttrValue, Attribute, QueryResult};
 
 /// The props struct holds all the attributes associated to the component.
 /// Properties have been designed to be versatile for all kind of components, but without introducing
@@ -19,6 +19,11 @@ impl Props {
     /// Get, if any, the attribute associated to the selector by mutable reference.
     pub fn get_mut(&mut self, query: Attribute) -> Option<&mut AttrValue> {
         self.attrs.get_mut(&query)
+    }
+
+    /// Get, if any, the attribute associated to the selector by reference and return as a type compatible with [`Component::query`](crate::component::Component::query).
+    pub fn get_for_query<'a>(&'a self, query: Attribute) -> Option<QueryResult<'a>> {
+        self.get(query).map(QueryResult::from)
     }
 
     /// Set a new attribute into Properties

--- a/crates/tuirealm/src/core/props/queryresult.rs
+++ b/crates/tuirealm/src/core/props/queryresult.rs
@@ -1,0 +1,258 @@
+use std::fmt::Debug;
+
+use crate::props::{AttrValue, AttrValueRef};
+
+/// The Resulting value of a [`Component::query`](crate::component::Component::query) call.
+///
+/// Where possible the [`Borrowed`](Self::Borrowed) variant should be used over the [`Owned`](Self::Owned) variant.
+///
+/// For handling both cases *readonly*, [`as_ref`](Self::as_ref) can be used.
+/// For handling both cases *mutably*, [`into_attr`](Self::into_attr) can be used.
+///
+/// Practically, this means only [`PropPayload::Any`](crate::props::PropPayload::Any) should require use of [`Owned`](Self::Owned).
+///
+/// This enum practically mirrors [`Cow`](std::borrow::Cow), only that no [`ToOwned`] or [`Borrow`](std::borrow::Borrow) trait implementations are required,
+/// which cannot be implemented on types with lifetimes.
+#[derive(Debug, Clone)]
+pub enum QueryResult<'a> {
+    Owned(AttrValue),
+    Borrowed(AttrValueRef<'a>),
+}
+
+impl<'a> PartialEq for QueryResult<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Owned(l0), Self::Owned(r0)) => l0 == r0,
+            (Self::Borrowed(l0), Self::Borrowed(r0)) => l0 == r0,
+            (Self::Owned(l0), Self::Borrowed(r0)) | (Self::Borrowed(r0), Self::Owned(l0)) => {
+                l0 == r0
+            }
+        }
+    }
+}
+
+impl<'a> PartialEq<AttrValue> for QueryResult<'a> {
+    fn eq(&self, other: &AttrValue) -> bool {
+        match self {
+            QueryResult::Owned(attr_value) => attr_value == other,
+            QueryResult::Borrowed(attr_value_ref) => attr_value_ref == other,
+        }
+    }
+}
+
+impl<'a> PartialEq<QueryResult<'a>> for AttrValue {
+    fn eq(&self, other: &QueryResult<'a>) -> bool {
+        other == self
+    }
+}
+
+impl<'a> PartialEq<AttrValueRef<'a>> for QueryResult<'a> {
+    fn eq(&self, other: &AttrValueRef<'a>) -> bool {
+        match self {
+            QueryResult::Owned(attr_value) => attr_value == other,
+            QueryResult::Borrowed(attr_value_ref) => attr_value_ref == other,
+        }
+    }
+}
+
+impl<'a> PartialEq<QueryResult<'a>> for AttrValueRef<'a> {
+    fn eq(&self, other: &QueryResult<'a>) -> bool {
+        other == self
+    }
+}
+
+impl<'a> QueryResult<'a> {
+    /// Convert the result to be of variant [`Owned`](Self::Owned)
+    pub fn to_attr(self) -> Self {
+        match self {
+            QueryResult::Owned(v) => Self::Owned(v),
+            QueryResult::Borrowed(v) => Self::Owned(v.into()),
+        }
+    }
+
+    /// Convert the current result into a [`AttrValue`].
+    pub fn into_attr(self) -> AttrValue {
+        match self {
+            QueryResult::Owned(v) => v,
+            QueryResult::Borrowed(v) => v.into(),
+        }
+    }
+
+    /// Convert the current result into a [`AttrValue`].
+    ///
+    /// Alias of [`into_attr`](Self::into_attr).
+    #[inline]
+    pub fn into_owned(self) -> AttrValue {
+        self.into_attr()
+    }
+
+    /// Get the current data as a [`AttrValueRef`].
+    pub fn as_ref(&'a self) -> AttrValueRef<'a> {
+        match self {
+            QueryResult::Owned(attr_value) => attr_value.as_attr_ref(),
+            QueryResult::Borrowed(attr_value_ref) => *attr_value_ref,
+        }
+    }
+}
+
+impl<'a> From<AttrValue> for QueryResult<'a> {
+    fn from(value: AttrValue) -> Self {
+        Self::Owned(value)
+    }
+}
+
+impl<'a> From<&'a AttrValue> for QueryResult<'a> {
+    fn from(value: &'a AttrValue) -> Self {
+        Self::Borrowed(value.as_attr_ref())
+    }
+}
+
+impl<'a> From<AttrValueRef<'a>> for QueryResult<'a> {
+    fn from(value: AttrValueRef<'a>) -> Self {
+        Self::Borrowed(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn should_allow_from_either() {
+        assert_eq!(
+            QueryResult::from(AttrValue::Size(0)),
+            QueryResult::Owned(AttrValue::Size(0))
+        );
+
+        assert_eq!(
+            QueryResult::from(AttrValueRef::Size(0)),
+            QueryResult::Borrowed(AttrValueRef::Size(0))
+        );
+    }
+
+    #[test]
+    fn should_allow_to_owned() {
+        assert_eq!(
+            QueryResult::Owned(AttrValue::Size(0)).to_attr(),
+            QueryResult::Owned(AttrValue::Size(0))
+        );
+
+        assert_eq!(
+            QueryResult::Borrowed(AttrValueRef::Size(0)).to_attr(),
+            QueryResult::Owned(AttrValue::Size(0))
+        );
+    }
+
+    #[test]
+    fn should_allow_into_owned() {
+        assert_eq!(
+            QueryResult::Owned(AttrValue::Size(0)).into_attr(),
+            AttrValue::Size(0)
+        );
+
+        assert_eq!(
+            QueryResult::Borrowed(AttrValueRef::Size(0)).into_attr(),
+            AttrValue::Size(0)
+        );
+
+        assert_eq!(
+            QueryResult::Owned(AttrValue::Size(0)).into_owned(),
+            AttrValue::Size(0)
+        );
+
+        assert_eq!(
+            QueryResult::Borrowed(AttrValueRef::Size(0)).into_owned(),
+            AttrValue::Size(0)
+        );
+    }
+
+    #[test]
+    fn should_allow_asref() {
+        assert_eq!(
+            QueryResult::Owned(AttrValue::Size(0)).as_ref(),
+            AttrValueRef::Size(0)
+        );
+
+        assert_eq!(
+            QueryResult::Borrowed(AttrValueRef::Size(0)).as_ref(),
+            AttrValueRef::Size(0)
+        );
+    }
+
+    #[test]
+    fn should_compare_itself() {
+        assert_eq!(
+            QueryResult::Owned(AttrValue::Size(0)),
+            QueryResult::Owned(AttrValue::Size(0))
+        );
+        assert_ne!(
+            QueryResult::Owned(AttrValue::Size(1)),
+            QueryResult::Owned(AttrValue::Size(0))
+        );
+
+        assert_eq!(
+            QueryResult::Borrowed(AttrValueRef::Size(0)),
+            QueryResult::Borrowed(AttrValueRef::Size(0))
+        );
+        assert_ne!(
+            QueryResult::Borrowed(AttrValueRef::Size(1)),
+            QueryResult::Borrowed(AttrValueRef::Size(0))
+        );
+
+        assert_eq!(
+            QueryResult::Borrowed(AttrValueRef::Size(0)),
+            QueryResult::Owned(AttrValue::Size(0))
+        );
+        assert_eq!(
+            QueryResult::Owned(AttrValue::Size(0)),
+            QueryResult::Borrowed(AttrValueRef::Size(0))
+        );
+
+        assert_ne!(
+            QueryResult::Borrowed(AttrValueRef::Size(1)),
+            QueryResult::Owned(AttrValue::Size(0))
+        );
+        assert_ne!(
+            QueryResult::Owned(AttrValue::Size(1)),
+            QueryResult::Borrowed(AttrValueRef::Size(0))
+        );
+    }
+
+    #[test]
+    fn should_compare_attrvalue() {
+        assert_eq!(QueryResult::Owned(AttrValue::Size(0)), AttrValue::Size(0));
+        assert_ne!(QueryResult::Owned(AttrValue::Size(1)), AttrValue::Size(0));
+
+        assert_eq!(
+            QueryResult::Borrowed(AttrValueRef::Size(0)),
+            AttrValue::Size(0)
+        );
+        assert_ne!(
+            QueryResult::Borrowed(AttrValueRef::Size(1)),
+            AttrValue::Size(0)
+        );
+    }
+
+    #[test]
+    fn should_compare_attrvalueref() {
+        assert_eq!(
+            QueryResult::Owned(AttrValue::Size(0)),
+            AttrValueRef::Size(0)
+        );
+        assert_ne!(
+            QueryResult::Owned(AttrValue::Size(1)),
+            AttrValueRef::Size(0)
+        );
+
+        assert_eq!(
+            QueryResult::Borrowed(AttrValueRef::Size(0)),
+            AttrValueRef::Size(0)
+        );
+        assert_ne!(
+            QueryResult::Borrowed(AttrValueRef::Size(1)),
+            AttrValueRef::Size(0)
+        );
+    }
+}

--- a/crates/tuirealm/src/core/subscription.rs
+++ b/crates/tuirealm/src/core/subscription.rs
@@ -5,7 +5,7 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use crate::event::{Event, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
-use crate::props::{AttrValue, Attribute};
+use crate::props::{AttrValue, Attribute, QueryResult};
 use crate::state::State;
 
 /// Public type to define a subscription.
@@ -82,7 +82,7 @@ where
 
     /// Returns whether to forward event to component
     #[must_use]
-    pub(crate) fn forward<HasAttrFn, GetStateFn, MountedFn>(
+    pub(crate) fn forward<'a, HasAttrFn, GetStateFn, MountedFn>(
         &self,
         ev: &Event<UserEvent>,
         has_attr_fn: HasAttrFn,
@@ -90,7 +90,7 @@ where
         mounted_fn: MountedFn,
     ) -> bool
     where
-        HasAttrFn: Fn(&ComponentId, Attribute) -> Option<AttrValue>,
+        HasAttrFn: Fn(&ComponentId, Attribute) -> Option<QueryResult<'a>>,
         GetStateFn: Fn(&ComponentId) -> Option<State>,
         MountedFn: Fn(&ComponentId) -> bool,
     {
@@ -237,14 +237,14 @@ where
 
     /// Returns whether the subscription clause is satisfied
     #[must_use]
-    pub(crate) fn forward<HasAttrFn, GetStateFn, MountedFn>(
+    pub(crate) fn forward<'a, HasAttrFn, GetStateFn, MountedFn>(
         &self,
         has_attr_fn: HasAttrFn,
         get_state_fn: GetStateFn,
         mounted_fn: MountedFn,
     ) -> bool
     where
-        HasAttrFn: Fn(&ComponentId, Attribute) -> Option<AttrValue>,
+        HasAttrFn: Fn(&ComponentId, Attribute) -> Option<QueryResult<'a>>,
         GetStateFn: Fn(&ComponentId) -> Option<State>,
         MountedFn: Fn(&ComponentId) -> bool,
     {
@@ -254,14 +254,14 @@ where
 
     /// Function to recursively check forwarding.
     #[must_use]
-    fn check_forwarding<HasAttrFn, GetStateFn, MountedFn>(
+    fn check_forwarding<'a, HasAttrFn, GetStateFn, MountedFn>(
         &self,
         has_attr_fn: HasAttrFn,
         get_state_fn: GetStateFn,
         mounted_fn: MountedFn,
     ) -> (bool, HasAttrFn, GetStateFn, MountedFn)
     where
-        HasAttrFn: Fn(&ComponentId, Attribute) -> Option<AttrValue>,
+        HasAttrFn: Fn(&ComponentId, Attribute) -> Option<QueryResult<'a>>,
         GetStateFn: Fn(&ComponentId) -> Option<State>,
         MountedFn: Fn(&ComponentId) -> bool,
     {
@@ -337,14 +337,14 @@ where
     // -- privates
 
     #[must_use]
-    fn has_attribute<HasAttrFn>(
+    fn has_attribute<'a, HasAttrFn>(
         id: &ComponentId,
         query: &Attribute,
         value: &AttrValue,
         has_attr_fn: HasAttrFn,
     ) -> (bool, HasAttrFn)
     where
-        HasAttrFn: Fn(&ComponentId, Attribute) -> Option<AttrValue>,
+        HasAttrFn: Fn(&ComponentId, Attribute) -> Option<QueryResult<'a>>,
     {
         (
             match has_attr_fn(id, *query) {

--- a/crates/tuirealm/src/core/view.rs
+++ b/crates/tuirealm/src/core/view.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 use crate::component::AppComponent;
 use crate::event::Event;
 use crate::injector::Injector;
-use crate::props::{AttrValue, Attribute};
+use crate::props::{AttrValue, Attribute, QueryResult};
 use crate::ratatui::layout::Rect;
 use crate::state::State;
 
@@ -176,7 +176,11 @@ where
     /// Query view component for a certain `AttrValue`
     /// Returns error if the component doesn't exist
     /// Returns None if the attribute doesn't exist.
-    pub fn query(&self, id: &ComponentId, query: Attribute) -> ViewResult<Option<AttrValue>> {
+    pub fn query<'a>(
+        &'a self,
+        id: &ComponentId,
+        query: Attribute,
+    ) -> ViewResult<Option<QueryResult<'a>>> {
         match self.components.get(id) {
             None => Err(ViewError::ComponentNotFound),
             Some(c) => Ok(c.query(query)),
@@ -403,8 +407,9 @@ mod test {
         assert_eq!(
             view.query(&MockComponentId::InputFoo, Attribute::Focus)
                 .ok()
-                .flatten(),
-            Some(AttrValue::Flag(true))
+                .flatten()
+                .unwrap(),
+            AttrValue::Flag(true)
         );
         // mount another component
         assert!(
@@ -418,14 +423,16 @@ mod test {
         assert_eq!(
             view.query(&MockComponentId::InputFoo, Attribute::Focus)
                 .ok()
-                .flatten(),
-            Some(AttrValue::Flag(false))
+                .flatten()
+                .unwrap(),
+            AttrValue::Flag(false)
         );
         assert_eq!(
             view.query(&MockComponentId::InputBar, Attribute::Focus)
                 .ok()
-                .flatten(),
-            Some(AttrValue::Flag(true))
+                .flatten()
+                .unwrap(),
+            AttrValue::Flag(true)
         );
         // Remount foo
         assert!(
@@ -444,8 +451,9 @@ mod test {
         assert_eq!(
             view.query(&MockComponentId::InputBar, Attribute::Focus)
                 .ok()
-                .flatten(),
-            Some(AttrValue::Flag(true))
+                .flatten()
+                .unwrap(),
+            AttrValue::Flag(true)
         );
         // Blur bar
         assert!(view.blur().is_ok());
@@ -454,14 +462,16 @@ mod test {
         assert_eq!(
             view.query(&MockComponentId::InputFoo, Attribute::Focus)
                 .ok()
-                .flatten(),
-            Some(AttrValue::Flag(true))
+                .flatten()
+                .unwrap(),
+            AttrValue::Flag(true)
         );
         assert_eq!(
             view.query(&MockComponentId::InputBar, Attribute::Focus)
                 .ok()
-                .flatten(),
-            Some(AttrValue::Flag(false))
+                .flatten()
+                .unwrap(),
+            AttrValue::Flag(false)
         );
     }
 
@@ -490,8 +500,9 @@ mod test {
         assert_eq!(
             view.query(&MockComponentId::InputFoo, Attribute::Focus)
                 .ok()
-                .flatten(),
-            Some(AttrValue::Flag(true))
+                .flatten()
+                .unwrap(),
+            AttrValue::Flag(true)
         );
         assert_eq!(
             view.query(&MockComponentId::InputBar, Attribute::Focus)
@@ -515,8 +526,9 @@ mod test {
         assert_eq!(
             view.query(&MockComponentId::InputFoo, Attribute::Focus)
                 .ok()
-                .flatten(),
-            Some(AttrValue::Flag(true))
+                .flatten()
+                .unwrap(),
+            AttrValue::Flag(true)
         );
         assert_eq!(
             view.query(&MockComponentId::InputBar, Attribute::Focus)
@@ -735,8 +747,9 @@ mod test {
         assert_eq!(
             view.query(&MockComponentId::InputFoo, Attribute::Focus)
                 .ok()
+                .flatten()
                 .unwrap(),
-            Some(AttrValue::Flag(true))
+            AttrValue::Flag(true)
         );
     }
 

--- a/crates/tuirealm/src/mock/components.rs
+++ b/crates/tuirealm/src/mock/components.rs
@@ -6,7 +6,7 @@ use super::{MockEvent, MockMsg};
 use crate::command::{Cmd, CmdResult, Direction};
 use crate::component::{AppComponent, Component};
 use crate::event::{Event, Key, KeyEvent, KeyModifiers};
-use crate::props::{AttrValue, Attribute, Props};
+use crate::props::{AttrValue, Attribute, Props, QueryResult};
 use crate::state::{State, StateValue};
 
 /// Mocked component implementing `Component`
@@ -27,8 +27,8 @@ impl Default for MockInput {
 impl Component for MockInput {
     fn view(&mut self, _: &mut Frame, _: crate::ratatui::layout::Rect) {}
 
-    fn query(&self, attr: Attribute) -> Option<AttrValue> {
-        self.props.get(attr).cloned()
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+        self.props.get_for_query(attr)
     }
 
     fn attr(&mut self, query: Attribute, attr: AttrValue) {

--- a/crates/tuirealm/src/utils/mod.rs
+++ b/crates/tuirealm/src/utils/mod.rs
@@ -3,5 +3,36 @@
 pub mod parser;
 mod types;
 
+use std::borrow::Cow;
+
+use ratatui::text::{Line, Span, Text};
 // export types
 pub use types::{Email, PhoneNumber};
+
+use crate::props::{LineStatic, SpanStatic, TextStatic};
+
+/// Convert a `&Span` to a `Span` by using [`Cow::Owned`].
+///
+/// Note that a normal [`Span::clone`] (and by extension `Cow::clone`) will preserve the `Cow` Variant.
+pub fn clone_span<'a, 'b: 'a>(span: &'b Span<'a>) -> SpanStatic {
+    Span {
+        content: Cow::Owned(span.content.to_string()),
+        ..*span
+    }
+}
+
+/// Convert a `&Line` to a `Line` by using [`Cow::Owned`].
+pub fn clone_line<'a, 'b: 'a>(line: &'b Line<'a>) -> LineStatic {
+    Line {
+        spans: line.spans.iter().map(clone_span).collect(),
+        ..*line
+    }
+}
+
+/// Convert a `&Text` to a `Text` by using [`Cow::Owned`].
+pub fn clone_text<'a, 'b: 'a>(text: &'b Text<'a>) -> TextStatic {
+    Text {
+        lines: text.lines.iter().map(clone_line).collect(),
+        ..*text
+    }
+}


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

Fixes #121

## Description

This PR changes `Component::query` to be able to return borrowed data, to lessen cloning where not necessary.

Note that i am not *quite* happy with this implementation, but aside from using a separate function (ex `query_owned & query_borrowed`), this is the best solution available. Why:
- We cannot just return `AttrValueRef` from `::query` due to `PropPayload::Any` not being able to be used *unless* they actually store it as `PropPayload::Any`, which would be very sub-optimal
- We cannot just return `&AttrValue` due to a similar reason but much more broad: attributes would have to be stored as `AttrValue` or not be able to be returned at all (ex in `CommonProps`)
- We cannot use `std::borrow::Cow` as that requires `ToOwned` which conflicts with `Clone` and so `Copy`, even if, we couldnt implement `std::borrow::Borrow` which `ToOwned` requires due to having to use lifetimes (those traits dont allow for that)
- I did not want to do a `query_borrowed` and `query_owned` function way, as that could lead to confusion as to which can be used and lead to different data being returned in either accidentally. Basically this would require calling both functions every time if the first didnt return anything, which is easier handled with a `Cow` return.

But `Cow` is the most appropriate option here, so we just made our own CoW-ish enum.

As a downside of this change, *another* function has to be added in between `query` and unwrapping the value, unless you directly use `if let Some(Very(Long(Variants)))`.

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
