### PR TITLE
`CmdResult::Visual` and actually use `CmdResult::Invalid`

### DIFF
--- a/crates/tuirealm-stdlib/examples/table.rs
+++ b/crates/tuirealm-stdlib/examples/table.rs
@@ -242,7 +242,7 @@ impl Default for TableBeta {
                         .add_row()
                         .add_col(Line::from("KeyCode::PageUp"))
                         .add_col(Line::from("OnKey"))
-                        .add_col(Line::from("ove cursor up by 8"))
+                        .add_col(Line::from("Move cursor up by 8"))
                         .add_row()
                         .add_col(Line::from("KeyCode::End"))
                         .add_col(Line::from("OnKey"))

--- a/crates/tuirealm-stdlib/src/components/bar_chart.rs
+++ b/crates/tuirealm-stdlib/src/components/bar_chart.rs
@@ -334,7 +334,7 @@ impl Component for BarChart {
                 Cmd::GoTo(Position::End) => {
                     self.states.cursor_at_end(self.data_len());
                 }
-                _ => {}
+                _ => return CmdResult::Invalid(cmd),
             }
         }
         CmdResult::None

--- a/crates/tuirealm-stdlib/src/components/bar_chart.rs
+++ b/crates/tuirealm-stdlib/src/components/bar_chart.rs
@@ -336,6 +336,7 @@ impl Component for BarChart {
                 }
                 _ => return CmdResult::Invalid(cmd),
             }
+            return CmdResult::Visual;
         }
         CmdResult::None
     }
@@ -407,22 +408,25 @@ mod test {
         // -> Right
         assert_eq!(
             component.perform(Cmd::Move(Direction::Right)),
-            CmdResult::None
+            CmdResult::Visual
         );
         assert_eq!(component.states.cursor, 1);
         // <- Left
         assert_eq!(
             component.perform(Cmd::Move(Direction::Left)),
-            CmdResult::None
+            CmdResult::Visual
         );
         assert_eq!(component.states.cursor, 0);
         // End
-        assert_eq!(component.perform(Cmd::GoTo(Position::End)), CmdResult::None);
+        assert_eq!(
+            component.perform(Cmd::GoTo(Position::End)),
+            CmdResult::Visual
+        );
         assert_eq!(component.states.cursor, 11);
         // Home
         assert_eq!(
             component.perform(Cmd::GoTo(Position::Begin)),
-            CmdResult::None
+            CmdResult::Visual
         );
         assert_eq!(component.states.cursor, 0);
     }

--- a/crates/tuirealm-stdlib/src/components/canvas.rs
+++ b/crates/tuirealm-stdlib/src/components/canvas.rs
@@ -250,8 +250,8 @@ impl Component for Canvas {
         State::None
     }
 
-    fn perform(&mut self, _cmd: Cmd) -> CmdResult {
-        CmdResult::None
+    fn perform(&mut self, cmd: Cmd) -> CmdResult {
+        CmdResult::Invalid(cmd)
     }
 }
 

--- a/crates/tuirealm-stdlib/src/components/chart/chart.rs
+++ b/crates/tuirealm-stdlib/src/components/chart/chart.rs
@@ -405,7 +405,7 @@ impl Component for Chart {
                 Cmd::GoTo(Position::End) => {
                     self.states.cursor_at_end(self.max_dataset_len());
                 }
-                _ => {}
+                _ => return CmdResult::Invalid(cmd),
             }
         }
         CmdResult::None

--- a/crates/tuirealm-stdlib/src/components/chart/chart.rs
+++ b/crates/tuirealm-stdlib/src/components/chart/chart.rs
@@ -407,6 +407,7 @@ impl Component for Chart {
                 }
                 _ => return CmdResult::Invalid(cmd),
             }
+            return CmdResult::Visual;
         }
         CmdResult::None
     }
@@ -525,22 +526,25 @@ mod test {
         // -> Right
         assert_eq!(
             component.perform(Cmd::Move(Direction::Right)),
-            CmdResult::None
+            CmdResult::Visual
         );
         assert_eq!(component.states.cursor, 1);
         // <- Left
         assert_eq!(
             component.perform(Cmd::Move(Direction::Left)),
-            CmdResult::None
+            CmdResult::Visual
         );
         assert_eq!(component.states.cursor, 0);
         // End
-        assert_eq!(component.perform(Cmd::GoTo(Position::End)), CmdResult::None);
+        assert_eq!(
+            component.perform(Cmd::GoTo(Position::End)),
+            CmdResult::Visual
+        );
         assert_eq!(component.states.cursor, 11);
         // Home
         assert_eq!(
             component.perform(Cmd::GoTo(Position::Begin)),
-            CmdResult::None
+            CmdResult::Visual
         );
         assert_eq!(component.states.cursor, 0);
         // component funcs

--- a/crates/tuirealm-stdlib/src/components/checkbox.rs
+++ b/crates/tuirealm-stdlib/src/components/checkbox.rs
@@ -304,12 +304,12 @@ impl Component for Checkbox {
             Cmd::Move(Direction::Right) => {
                 // Increment choice
                 self.states.next_choice(self.rewindable());
-                CmdResult::None
+                CmdResult::Visual
             }
             Cmd::Move(Direction::Left) => {
                 // Decrement choice
                 self.states.prev_choice(self.rewindable());
-                CmdResult::None
+                CmdResult::Visual
             }
             Cmd::Toggle => {
                 self.states.toggle();
@@ -440,7 +440,7 @@ mod test {
         // Handle events
         assert_eq!(
             component.perform(Cmd::Move(Direction::Left)),
-            CmdResult::None,
+            CmdResult::Visual,
         );
         assert_eq!(component.state(), State::Vec(vec![StateValue::Usize(1)]));
         // Toggle
@@ -451,13 +451,13 @@ mod test {
         // Left again
         assert_eq!(
             component.perform(Cmd::Move(Direction::Left)),
-            CmdResult::None,
+            CmdResult::Visual,
         );
         assert_eq!(component.states.choice, 0);
         // Right
         assert_eq!(
             component.perform(Cmd::Move(Direction::Right)),
-            CmdResult::None,
+            CmdResult::Visual,
         );
         // Toggle
         assert_eq!(
@@ -467,31 +467,31 @@ mod test {
         // Right again
         assert_eq!(
             component.perform(Cmd::Move(Direction::Right)),
-            CmdResult::None,
+            CmdResult::Visual,
         );
         assert_eq!(component.states.choice, 2);
         // Right again
         assert_eq!(
             component.perform(Cmd::Move(Direction::Right)),
-            CmdResult::None,
+            CmdResult::Visual,
         );
         assert_eq!(component.states.choice, 3);
         // Right again
         assert_eq!(
             component.perform(Cmd::Move(Direction::Right)),
-            CmdResult::None,
+            CmdResult::Visual,
         );
         assert_eq!(component.states.choice, 4);
         // Right again
         assert_eq!(
             component.perform(Cmd::Move(Direction::Right)),
-            CmdResult::None,
+            CmdResult::Visual,
         );
         assert_eq!(component.states.choice, 5);
         // Right again
         assert_eq!(
             component.perform(Cmd::Move(Direction::Right)),
-            CmdResult::None,
+            CmdResult::Visual,
         );
         assert_eq!(component.states.choice, 5);
         // Submit

--- a/crates/tuirealm-stdlib/src/components/checkbox.rs
+++ b/crates/tuirealm-stdlib/src/components/checkbox.rs
@@ -319,7 +319,7 @@ impl Component for Checkbox {
                 // Return Submit
                 CmdResult::Submit(self.state())
             }
-            _ => CmdResult::None,
+            _ => CmdResult::Invalid(cmd),
         }
     }
 }

--- a/crates/tuirealm-stdlib/src/components/gauge.rs
+++ b/crates/tuirealm-stdlib/src/components/gauge.rs
@@ -157,8 +157,8 @@ impl Component for Gauge {
         State::None
     }
 
-    fn perform(&mut self, _cmd: Cmd) -> CmdResult {
-        CmdResult::None
+    fn perform(&mut self, cmd: Cmd) -> CmdResult {
+        CmdResult::Invalid(cmd)
     }
 }
 

--- a/crates/tuirealm-stdlib/src/components/input.rs
+++ b/crates/tuirealm-stdlib/src/components/input.rs
@@ -487,7 +487,7 @@ impl Component for Input {
                     CmdResult::Changed(self.state())
                 }
             }
-            _ => CmdResult::None,
+            _ => CmdResult::Invalid(cmd),
         }
     }
 }

--- a/crates/tuirealm-stdlib/src/components/input.rs
+++ b/crates/tuirealm-stdlib/src/components/input.rs
@@ -461,19 +461,19 @@ impl Component for Input {
             Cmd::Submit => CmdResult::Submit(self.state()),
             Cmd::Move(Direction::Left) => {
                 self.states.decr_cursor();
-                CmdResult::None
+                CmdResult::Visual
             }
             Cmd::Move(Direction::Right) => {
                 self.states.incr_cursor();
-                CmdResult::None
+                CmdResult::Visual
             }
             Cmd::GoTo(Position::Begin) => {
                 self.states.cursor_at_begin();
-                CmdResult::None
+                CmdResult::Visual
             }
             Cmd::GoTo(Position::End) => {
                 self.states.cursor_at_end();
-                CmdResult::None
+                CmdResult::Visual
             }
             Cmd::Type(ch) => {
                 // Push char to input
@@ -643,7 +643,7 @@ mod tests {
         component.states.cursor = 1;
         assert_eq!(
             component.perform(Cmd::Move(Direction::Right)), // between 'e' and 'l'
-            CmdResult::None
+            CmdResult::Visual
         );
         assert_eq!(component.states.cursor, 2);
         // Put a character here
@@ -659,34 +659,40 @@ mod tests {
         // Move left
         assert_eq!(
             component.perform(Cmd::Move(Direction::Left)),
-            CmdResult::None
+            CmdResult::Visual
         );
         assert_eq!(component.states.cursor, 2);
         // Go at the end
         component.states.cursor = 6;
         // Move right
-        assert_eq!(component.perform(Cmd::GoTo(Position::End)), CmdResult::None);
+        assert_eq!(
+            component.perform(Cmd::GoTo(Position::End)),
+            CmdResult::Visual
+        );
         assert_eq!(component.states.cursor, 6);
         // Move left
         assert_eq!(
             component.perform(Cmd::Move(Direction::Left)),
-            CmdResult::None
+            CmdResult::Visual
         );
         assert_eq!(component.states.cursor, 5);
         // Go at the beginning
         component.states.cursor = 0;
         assert_eq!(
             component.perform(Cmd::Move(Direction::Left)),
-            CmdResult::None
+            CmdResult::Visual
         );
         //assert_eq!(component.render().unwrap().cursor, 0); // Should stay
         assert_eq!(component.states.cursor, 0);
         // End - begin
-        assert_eq!(component.perform(Cmd::GoTo(Position::End)), CmdResult::None);
+        assert_eq!(
+            component.perform(Cmd::GoTo(Position::End)),
+            CmdResult::Visual
+        );
         assert_eq!(component.states.cursor, 6);
         assert_eq!(
             component.perform(Cmd::GoTo(Position::Begin)),
-            CmdResult::None
+            CmdResult::Visual
         );
         assert_eq!(component.states.cursor, 0);
         // Update value

--- a/crates/tuirealm-stdlib/src/components/label.rs
+++ b/crates/tuirealm-stdlib/src/components/label.rs
@@ -107,8 +107,8 @@ impl Component for Label {
         State::None
     }
 
-    fn perform(&mut self, _cmd: Cmd) -> CmdResult {
-        CmdResult::None
+    fn perform(&mut self, cmd: Cmd) -> CmdResult {
+        CmdResult::Invalid(cmd)
     }
 }
 

--- a/crates/tuirealm-stdlib/src/components/line_gauge.rs
+++ b/crates/tuirealm-stdlib/src/components/line_gauge.rs
@@ -191,8 +191,8 @@ impl Component for LineGauge {
         State::None
     }
 
-    fn perform(&mut self, _cmd: Cmd) -> CmdResult {
-        CmdResult::None
+    fn perform(&mut self, cmd: Cmd) -> CmdResult {
+        CmdResult::Invalid(cmd)
     }
 }
 

--- a/crates/tuirealm-stdlib/src/components/list.rs
+++ b/crates/tuirealm-stdlib/src/components/list.rs
@@ -397,7 +397,7 @@ impl Component for List {
                     CmdResult::Changed(self.state())
                 }
             }
-            _ => CmdResult::None,
+            _ => CmdResult::Invalid(cmd),
         }
     }
 }

--- a/crates/tuirealm-stdlib/src/components/paragraph.rs
+++ b/crates/tuirealm-stdlib/src/components/paragraph.rs
@@ -148,8 +148,8 @@ impl Component for Paragraph {
         State::None
     }
 
-    fn perform(&mut self, _cmd: Cmd) -> CmdResult {
-        CmdResult::None
+    fn perform(&mut self, cmd: Cmd) -> CmdResult {
+        CmdResult::Invalid(cmd)
     }
 }
 

--- a/crates/tuirealm-stdlib/src/components/phantom.rs
+++ b/crates/tuirealm-stdlib/src/components/phantom.rs
@@ -30,8 +30,8 @@ impl Component for Phantom {
         State::None
     }
 
-    fn perform(&mut self, _cmd: Cmd) -> CmdResult {
-        CmdResult::None
+    fn perform(&mut self, cmd: Cmd) -> CmdResult {
+        CmdResult::Invalid(cmd)
     }
 }
 

--- a/crates/tuirealm-stdlib/src/components/radio.rs
+++ b/crates/tuirealm-stdlib/src/components/radio.rs
@@ -270,7 +270,7 @@ impl Component for Radio {
                 // Return Submit
                 CmdResult::Submit(self.state())
             }
-            _ => CmdResult::None,
+            _ => CmdResult::Invalid(cmd),
         }
     }
 }

--- a/crates/tuirealm-stdlib/src/components/select.rs
+++ b/crates/tuirealm-stdlib/src/components/select.rs
@@ -383,7 +383,7 @@ impl Component for Select {
                     CmdResult::Submit(self.state())
                 } else {
                     self.states.open_tab();
-                    CmdResult::None
+                    CmdResult::Visual
                 }
             }
             _ => CmdResult::Invalid(cmd),
@@ -543,7 +543,7 @@ mod test {
         // Tab should be closed
         assert_eq!(component.states.is_tab_open(), false);
         // Re open
-        assert_eq!(component.perform(Cmd::Submit), CmdResult::None);
+        assert_eq!(component.perform(Cmd::Submit), CmdResult::Visual);
         assert_eq!(component.states.is_tab_open(), true);
         // Move arrows
         assert_eq!(

--- a/crates/tuirealm-stdlib/src/components/select.rs
+++ b/crates/tuirealm-stdlib/src/components/select.rs
@@ -386,7 +386,7 @@ impl Component for Select {
                     CmdResult::None
                 }
             }
-            _ => CmdResult::None,
+            _ => CmdResult::Invalid(cmd),
         }
     }
 }

--- a/crates/tuirealm-stdlib/src/components/span.rs
+++ b/crates/tuirealm-stdlib/src/components/span.rs
@@ -131,8 +131,8 @@ impl Component for Span {
         State::None
     }
 
-    fn perform(&mut self, _cmd: Cmd) -> CmdResult {
-        CmdResult::None
+    fn perform(&mut self, cmd: Cmd) -> CmdResult {
+        CmdResult::Invalid(cmd)
     }
 }
 

--- a/crates/tuirealm-stdlib/src/components/sparkline.rs
+++ b/crates/tuirealm-stdlib/src/components/sparkline.rs
@@ -156,8 +156,8 @@ impl Component for Sparkline {
         State::None
     }
 
-    fn perform(&mut self, _cmd: Cmd) -> CmdResult {
-        CmdResult::None
+    fn perform(&mut self, cmd: Cmd) -> CmdResult {
+        CmdResult::Invalid(cmd)
     }
 }
 

--- a/crates/tuirealm-stdlib/src/components/spinner.rs
+++ b/crates/tuirealm-stdlib/src/components/spinner.rs
@@ -150,8 +150,8 @@ impl Component for Spinner {
         State::None
     }
 
-    fn perform(&mut self, _cmd: Cmd) -> CmdResult {
-        CmdResult::None
+    fn perform(&mut self, cmd: Cmd) -> CmdResult {
+        CmdResult::Invalid(cmd)
     }
 }
 

--- a/crates/tuirealm-stdlib/src/components/table.rs
+++ b/crates/tuirealm-stdlib/src/components/table.rs
@@ -512,7 +512,7 @@ impl Component for Table {
                     CmdResult::Changed(self.state())
                 }
             }
-            _ => CmdResult::None,
+            _ => CmdResult::Invalid(cmd),
         }
     }
 }

--- a/crates/tuirealm-stdlib/src/components/textarea.rs
+++ b/crates/tuirealm-stdlib/src/components/textarea.rs
@@ -276,7 +276,7 @@ impl Component for Textarea {
             Cmd::GoTo(Position::End) => {
                 self.states.list_index_at_last();
             }
-            _ => {}
+            _ => return CmdResult::Invalid(cmd),
         }
         if prev != self.states.list_index {
             CmdResult::Changed(self.state())
@@ -372,7 +372,10 @@ mod tests {
             CmdResult::None
         );
         // Unhandled command
-        assert_eq!(component.perform(Cmd::Delete), CmdResult::None);
+        assert_eq!(
+            component.perform(Cmd::Delete),
+            CmdResult::Invalid(Cmd::Delete)
+        );
     }
 
     #[test]

--- a/crates/tuirealm-stdlib/tests/component_bar_chart.rs
+++ b/crates/tuirealm-stdlib/tests/component_bar_chart.rs
@@ -50,8 +50,14 @@ fn test_bar_chart_disabled() {
 #[test]
 fn test_bar_chart_unhandled_cmd() {
     let mut component = BarChart::default().data(&[("Q1", 100)]);
-    assert_eq!(component.perform(Cmd::Delete), CmdResult::None);
-    assert_eq!(component.perform(Cmd::Submit), CmdResult::None);
+    assert_eq!(
+        component.perform(Cmd::Delete),
+        CmdResult::Invalid(Cmd::Delete)
+    );
+    assert_eq!(
+        component.perform(Cmd::Submit),
+        CmdResult::Invalid(Cmd::Submit)
+    );
 }
 
 #[test]

--- a/crates/tuirealm-stdlib/tests/component_bar_chart.rs
+++ b/crates/tuirealm-stdlib/tests/component_bar_chart.rs
@@ -18,11 +18,11 @@ fn test_bar_chart_move_cursor() {
     let mut component = BarChart::default().data(&[("Q1", 100), ("Q2", 200), ("Q3", 300)]);
     assert_eq!(
         component.perform(Cmd::Move(Direction::Right)),
-        CmdResult::None
+        CmdResult::Visual
     );
     assert_eq!(
         component.perform(Cmd::Move(Direction::Left)),
-        CmdResult::None
+        CmdResult::Visual
     );
 }
 
@@ -31,9 +31,12 @@ fn test_bar_chart_goto() {
     let mut component = BarChart::default().data(&[("Q1", 100), ("Q2", 200), ("Q3", 300)]);
     assert_eq!(
         component.perform(Cmd::GoTo(Position::Begin)),
-        CmdResult::None
+        CmdResult::Visual
     );
-    assert_eq!(component.perform(Cmd::GoTo(Position::End)), CmdResult::None);
+    assert_eq!(
+        component.perform(Cmd::GoTo(Position::End)),
+        CmdResult::Visual
+    );
 }
 
 #[test]

--- a/crates/tuirealm-stdlib/tests/component_canvas.rs
+++ b/crates/tuirealm-stdlib/tests/component_canvas.rs
@@ -17,7 +17,10 @@ fn test_canvas_state_is_none() {
 #[test]
 fn test_canvas_perform_returns_none() {
     let mut component = Canvas::default();
-    assert_eq!(component.perform(Cmd::Submit), CmdResult::None);
+    assert_eq!(
+        component.perform(Cmd::Submit),
+        CmdResult::Invalid(Cmd::Submit)
+    );
 }
 
 #[test]

--- a/crates/tuirealm-stdlib/tests/component_chart.rs
+++ b/crates/tuirealm-stdlib/tests/component_chart.rs
@@ -55,7 +55,10 @@ fn test_chart_disabled() {
 #[test]
 fn test_chart_unhandled_cmd() {
     let mut component = Chart::default().data([make_dataset()]);
-    assert_eq!(component.perform(Cmd::Delete), CmdResult::None);
+    assert_eq!(
+        component.perform(Cmd::Delete),
+        CmdResult::Invalid(Cmd::Delete)
+    );
 }
 
 #[test]

--- a/crates/tuirealm-stdlib/tests/component_chart.rs
+++ b/crates/tuirealm-stdlib/tests/component_chart.rs
@@ -25,11 +25,11 @@ fn test_chart_move_cursor() {
     let mut component = Chart::default().data([make_dataset()]);
     assert_eq!(
         component.perform(Cmd::Move(Direction::Right)),
-        CmdResult::None
+        CmdResult::Visual
     );
     assert_eq!(
         component.perform(Cmd::Move(Direction::Left)),
-        CmdResult::None
+        CmdResult::Visual
     );
 }
 
@@ -38,9 +38,12 @@ fn test_chart_goto() {
     let mut component = Chart::default().data([make_dataset()]);
     assert_eq!(
         component.perform(Cmd::GoTo(Position::Begin)),
-        CmdResult::None
+        CmdResult::Visual
     );
-    assert_eq!(component.perform(Cmd::GoTo(Position::End)), CmdResult::None);
+    assert_eq!(
+        component.perform(Cmd::GoTo(Position::End)),
+        CmdResult::Visual
+    );
 }
 
 #[test]

--- a/crates/tuirealm-stdlib/tests/component_checkbox.rs
+++ b/crates/tuirealm-stdlib/tests/component_checkbox.rs
@@ -59,7 +59,10 @@ fn test_checkbox_submit() {
 #[test]
 fn test_checkbox_unhandled_cmd() {
     let mut component = Checkbox::default().choices(["A", "B"]);
-    assert_eq!(component.perform(Cmd::Delete), CmdResult::None);
+    assert_eq!(
+        component.perform(Cmd::Delete),
+        CmdResult::Invalid(Cmd::Delete)
+    );
 }
 
 #[test]

--- a/crates/tuirealm-stdlib/tests/component_gauge.rs
+++ b/crates/tuirealm-stdlib/tests/component_gauge.rs
@@ -14,9 +14,12 @@ fn test_gauge_state_is_none() {
 }
 
 #[test]
-fn test_gauge_perform_returns_none() {
+fn test_gauge_perform_unhandled_cmd() {
     let mut component = Gauge::default().progress(0.5);
-    assert_eq!(component.perform(Cmd::Submit), CmdResult::None);
+    assert_eq!(
+        component.perform(Cmd::Submit),
+        CmdResult::Invalid(Cmd::Submit)
+    );
 }
 
 #[test]

--- a/crates/tuirealm-stdlib/tests/component_input.rs
+++ b/crates/tuirealm-stdlib/tests/component_input.rs
@@ -73,11 +73,11 @@ fn test_input_move_cursor() {
     let mut component = Input::default().input_type(InputType::Text).value("abc");
     assert_eq!(
         component.perform(Cmd::Move(Direction::Left)),
-        CmdResult::None
+        CmdResult::Visual
     );
     assert_eq!(
         component.perform(Cmd::Move(Direction::Right)),
-        CmdResult::None
+        CmdResult::Visual
     );
 }
 
@@ -86,9 +86,12 @@ fn test_input_goto_begin_end() {
     let mut component = Input::default().input_type(InputType::Text).value("hello");
     assert_eq!(
         component.perform(Cmd::GoTo(Position::Begin)),
-        CmdResult::None
+        CmdResult::Visual
     );
-    assert_eq!(component.perform(Cmd::GoTo(Position::End)), CmdResult::None);
+    assert_eq!(
+        component.perform(Cmd::GoTo(Position::End)),
+        CmdResult::Visual
+    );
 }
 
 #[test]

--- a/crates/tuirealm-stdlib/tests/component_input.rs
+++ b/crates/tuirealm-stdlib/tests/component_input.rs
@@ -119,10 +119,13 @@ fn test_input_with_max_length() {
 #[test]
 fn test_input_unhandled_cmd() {
     let mut component = Input::default().input_type(InputType::Text);
-    assert_eq!(component.perform(Cmd::Toggle), CmdResult::None);
+    assert_eq!(
+        component.perform(Cmd::Toggle),
+        CmdResult::Invalid(Cmd::Toggle)
+    );
     assert_eq!(
         component.perform(Cmd::Scroll(Direction::Down)),
-        CmdResult::None
+        CmdResult::Invalid(Cmd::Scroll(Direction::Down))
     );
 }
 

--- a/crates/tuirealm-stdlib/tests/component_label.rs
+++ b/crates/tuirealm-stdlib/tests/component_label.rs
@@ -16,9 +16,18 @@ fn test_label_state_is_none() {
 #[test]
 fn test_label_perform_returns_none() {
     let mut component = Label::default().text("hello");
-    assert_eq!(component.perform(Cmd::Submit), CmdResult::None);
-    assert_eq!(component.perform(Cmd::Type('a')), CmdResult::None);
-    assert_eq!(component.perform(Cmd::Delete), CmdResult::None);
+    assert_eq!(
+        component.perform(Cmd::Submit),
+        CmdResult::Invalid(Cmd::Submit)
+    );
+    assert_eq!(
+        component.perform(Cmd::Type('a')),
+        CmdResult::Invalid(Cmd::Type('a'))
+    );
+    assert_eq!(
+        component.perform(Cmd::Delete),
+        CmdResult::Invalid(Cmd::Delete)
+    );
 }
 
 #[test]

--- a/crates/tuirealm-stdlib/tests/component_line_gauge.rs
+++ b/crates/tuirealm-stdlib/tests/component_line_gauge.rs
@@ -14,9 +14,12 @@ fn test_line_gauge_state_is_none() {
 }
 
 #[test]
-fn test_line_gauge_perform_returns_none() {
+fn test_line_gauge_unhandled_cmd() {
     let mut component = LineGauge::default().progress(0.5);
-    assert_eq!(component.perform(Cmd::Submit), CmdResult::None);
+    assert_eq!(
+        component.perform(Cmd::Submit),
+        CmdResult::Invalid(Cmd::Submit)
+    );
 }
 
 #[test]

--- a/crates/tuirealm-stdlib/tests/component_list.rs
+++ b/crates/tuirealm-stdlib/tests/component_list.rs
@@ -94,8 +94,14 @@ fn test_list_scroll_down() {
 #[test]
 fn test_list_unhandled_cmd() {
     let mut component = List::default().scroll(true).rows(vec![Line::from("A")]);
-    assert_eq!(component.perform(Cmd::Delete), CmdResult::None);
-    assert_eq!(component.perform(Cmd::Type('a')), CmdResult::None);
+    assert_eq!(
+        component.perform(Cmd::Delete),
+        CmdResult::Invalid(Cmd::Delete)
+    );
+    assert_eq!(
+        component.perform(Cmd::Type('a')),
+        CmdResult::Invalid(Cmd::Type('a'))
+    );
 }
 
 #[test]

--- a/crates/tuirealm-stdlib/tests/component_paragraph.rs
+++ b/crates/tuirealm-stdlib/tests/component_paragraph.rs
@@ -15,9 +15,12 @@ fn test_paragraph_state_is_none() {
 }
 
 #[test]
-fn test_paragraph_perform_returns_none() {
+fn test_paragraph_unhandled_cmd() {
     let mut component = Paragraph::default().text(vec![Line::from("hello")]);
-    assert_eq!(component.perform(Cmd::Submit), CmdResult::None);
+    assert_eq!(
+        component.perform(Cmd::Submit),
+        CmdResult::Invalid(Cmd::Submit)
+    );
 }
 
 #[test]

--- a/crates/tuirealm-stdlib/tests/component_radio.rs
+++ b/crates/tuirealm-stdlib/tests/component_radio.rs
@@ -72,8 +72,14 @@ fn test_radio_submit() {
 #[test]
 fn test_radio_unhandled_cmd() {
     let mut component = Radio::default().choices(["A", "B"]);
-    assert_eq!(component.perform(Cmd::Delete), CmdResult::None);
-    assert_eq!(component.perform(Cmd::Toggle), CmdResult::None);
+    assert_eq!(
+        component.perform(Cmd::Delete),
+        CmdResult::Invalid(Cmd::Delete)
+    );
+    assert_eq!(
+        component.perform(Cmd::Toggle),
+        CmdResult::Invalid(Cmd::Toggle)
+    );
 }
 
 #[test]

--- a/crates/tuirealm-stdlib/tests/component_select.rs
+++ b/crates/tuirealm-stdlib/tests/component_select.rs
@@ -17,7 +17,7 @@ fn test_select_initial_state() {
 fn test_select_open_tab() {
     let mut component = Select::default().choices(["A", "B", "C"]).value(0);
     let result = component.perform(Cmd::Submit);
-    assert_eq!(result, CmdResult::None);
+    assert_eq!(result, CmdResult::Visual);
     assert_eq!(component.state(), State::None);
 }
 

--- a/crates/tuirealm-stdlib/tests/component_select.rs
+++ b/crates/tuirealm-stdlib/tests/component_select.rs
@@ -46,8 +46,14 @@ fn test_select_cancel_closes_tab() {
 #[test]
 fn test_select_unhandled_cmd() {
     let mut component = Select::default().choices(["A", "B"]);
-    assert_eq!(component.perform(Cmd::Delete), CmdResult::None);
-    assert_eq!(component.perform(Cmd::Toggle), CmdResult::None);
+    assert_eq!(
+        component.perform(Cmd::Delete),
+        CmdResult::Invalid(Cmd::Delete)
+    );
+    assert_eq!(
+        component.perform(Cmd::Toggle),
+        CmdResult::Invalid(Cmd::Toggle)
+    );
 }
 
 #[test]

--- a/crates/tuirealm-stdlib/tests/component_span.rs
+++ b/crates/tuirealm-stdlib/tests/component_span.rs
@@ -15,9 +15,12 @@ fn test_span_state_is_none() {
 }
 
 #[test]
-fn test_span_perform_returns_none() {
+fn test_span_unhandled_cmd() {
     let mut component = Span::default().spans([RatatuiSpan::raw("hello")]);
-    assert_eq!(component.perform(Cmd::Submit), CmdResult::None);
+    assert_eq!(
+        component.perform(Cmd::Submit),
+        CmdResult::Invalid(Cmd::Submit)
+    );
 }
 
 #[test]

--- a/crates/tuirealm-stdlib/tests/component_sparkline.rs
+++ b/crates/tuirealm-stdlib/tests/component_sparkline.rs
@@ -14,9 +14,12 @@ fn test_sparkline_state_is_none() {
 }
 
 #[test]
-fn test_sparkline_perform_returns_none() {
+fn test_sparkline_unhandled_cmd() {
     let mut component = Sparkline::default().data(&[1, 5, 3]);
-    assert_eq!(component.perform(Cmd::Submit), CmdResult::None);
+    assert_eq!(
+        component.perform(Cmd::Submit),
+        CmdResult::Invalid(Cmd::Submit)
+    );
 }
 
 #[test]

--- a/crates/tuirealm-stdlib/tests/component_spinner.rs
+++ b/crates/tuirealm-stdlib/tests/component_spinner.rs
@@ -14,10 +14,16 @@ fn test_spinner_state_is_none() {
 }
 
 #[test]
-fn test_spinner_perform_returns_none() {
+fn test_spinner_unhandled_cmd() {
     let mut component = Spinner::default().sequence("⠋⠙⠹⠸");
-    assert_eq!(component.perform(Cmd::Submit), CmdResult::None);
-    assert_eq!(component.perform(Cmd::Delete), CmdResult::None);
+    assert_eq!(
+        component.perform(Cmd::Submit),
+        CmdResult::Invalid(Cmd::Submit)
+    );
+    assert_eq!(
+        component.perform(Cmd::Delete),
+        CmdResult::Invalid(Cmd::Delete)
+    );
 }
 
 #[test]

--- a/crates/tuirealm-stdlib/tests/component_table.rs
+++ b/crates/tuirealm-stdlib/tests/component_table.rs
@@ -94,7 +94,10 @@ fn test_table_scroll() {
 #[test]
 fn test_table_unhandled_cmd() {
     let mut component = Table::default().scroll(true).table(make_table_data());
-    assert_eq!(component.perform(Cmd::Delete), CmdResult::None);
+    assert_eq!(
+        component.perform(Cmd::Delete),
+        CmdResult::Invalid(Cmd::Delete)
+    );
 }
 
 #[test]

--- a/crates/tuirealm-stdlib/tests/component_textarea.rs
+++ b/crates/tuirealm-stdlib/tests/component_textarea.rs
@@ -79,8 +79,14 @@ fn test_textarea_scroll() {
 #[test]
 fn test_textarea_unhandled_cmd() {
     let mut component = Textarea::default().text_rows([Span::from("A")]);
-    assert_eq!(component.perform(Cmd::Delete), CmdResult::None);
-    assert_eq!(component.perform(Cmd::Type('a')), CmdResult::None);
+    assert_eq!(
+        component.perform(Cmd::Delete),
+        CmdResult::Invalid(Cmd::Delete)
+    );
+    assert_eq!(
+        component.perform(Cmd::Type('a')),
+        CmdResult::Invalid(Cmd::Type('a'))
+    );
 }
 
 #[test]

--- a/crates/tuirealm-textarea/examples/editor.rs
+++ b/crates/tuirealm-textarea/examples/editor.rs
@@ -259,8 +259,8 @@ impl Default for Editor {
 
 impl AppComponent<Msg, NoUserEvent> for Editor {
     fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
-        match ev {
-            Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => Some(Msg::AppClose),
+        let result = match ev {
+            Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),
             Event::Keyboard(KeyEvent {
                 code: Key::Backspace,
                 ..
@@ -268,16 +268,10 @@ impl AppComponent<Msg, NoUserEvent> for Editor {
             | Event::Keyboard(KeyEvent {
                 code: Key::Char('h'),
                 modifiers: KeyModifiers::CONTROL,
-            }) => {
-                self.perform(Cmd::Delete);
-                Some(Msg::Redraw)
-            }
+            }) => self.perform(Cmd::Delete),
             Event::Keyboard(KeyEvent {
                 code: Key::Delete, ..
-            }) => {
-                self.perform(Cmd::Cancel);
-                Some(Msg::Redraw)
-            }
+            }) => self.perform(Cmd::Cancel),
             Event::Keyboard(KeyEvent {
                 code: Key::PageDown,
                 ..
@@ -285,139 +279,96 @@ impl AppComponent<Msg, NoUserEvent> for Editor {
             | Event::Keyboard(KeyEvent {
                 code: Key::Down,
                 modifiers: KeyModifiers::SHIFT,
-            }) => {
-                self.perform(Cmd::Scroll(Direction::Down));
-                Some(Msg::Redraw)
-            }
+            }) => self.perform(Cmd::Scroll(Direction::Down)),
             Event::Keyboard(KeyEvent {
                 code: Key::PageUp, ..
             })
             | Event::Keyboard(KeyEvent {
                 code: Key::Up,
                 modifiers: KeyModifiers::SHIFT,
-            }) => {
-                self.perform(Cmd::Scroll(Direction::Up));
-                Some(Msg::Redraw)
-            }
+            }) => self.perform(Cmd::Scroll(Direction::Up)),
             Event::Keyboard(KeyEvent {
                 code: Key::Down, ..
-            }) => {
-                self.perform(Cmd::Move(Direction::Down));
-                Some(Msg::Redraw)
-            }
+            }) => self.perform(Cmd::Move(Direction::Down)),
             Event::Keyboard(KeyEvent {
                 code: Key::Left,
                 modifiers: KeyModifiers::SHIFT,
-            }) => {
-                self.perform(Cmd::Custom(TEXTAREA_CMD_MOVE_WORD_BACK));
-                Some(Msg::Redraw)
-            }
+            }) => self.perform(Cmd::Custom(TEXTAREA_CMD_MOVE_WORD_BACK)),
             Event::Keyboard(KeyEvent {
                 code: Key::Left, ..
-            }) => {
-                self.perform(Cmd::Move(Direction::Left));
-                Some(Msg::Redraw)
-            }
+            }) => self.perform(Cmd::Move(Direction::Left)),
             Event::Keyboard(KeyEvent {
                 code: Key::Right,
                 modifiers: KeyModifiers::SHIFT,
-            }) => {
-                self.perform(Cmd::Custom(TEXTAREA_CMD_MOVE_WORD_FORWARD));
-                Some(Msg::Redraw)
-            }
+            }) => self.perform(Cmd::Custom(TEXTAREA_CMD_MOVE_WORD_FORWARD)),
             Event::Keyboard(KeyEvent {
                 code: Key::Right, ..
-            }) => {
-                self.perform(Cmd::Move(Direction::Right));
-                Some(Msg::Redraw)
-            }
+            }) => self.perform(Cmd::Move(Direction::Right)),
             Event::Keyboard(KeyEvent { code: Key::Up, .. }) => {
-                self.perform(Cmd::Move(Direction::Up));
-                Some(Msg::Redraw)
+                self.perform(Cmd::Move(Direction::Up))
             }
             Event::Keyboard(KeyEvent { code: Key::End, .. })
             | Event::Keyboard(KeyEvent {
                 code: Key::Char('e'),
                 modifiers: KeyModifiers::CONTROL,
-            }) => {
-                self.perform(Cmd::GoTo(Position::End));
-                Some(Msg::Redraw)
-            }
+            }) => self.perform(Cmd::GoTo(Position::End)),
             Event::Keyboard(KeyEvent {
                 code: Key::Enter, ..
             })
             | Event::Keyboard(KeyEvent {
                 code: Key::Char('m'),
                 modifiers: KeyModifiers::CONTROL,
-            }) => {
-                self.perform(Cmd::Custom(TEXTAREA_CMD_NEWLINE));
-                Some(Msg::Redraw)
-            }
+            }) => self.perform(Cmd::Custom(TEXTAREA_CMD_NEWLINE)),
             Event::Keyboard(KeyEvent {
                 code: Key::Home, ..
             })
             | Event::Keyboard(KeyEvent {
                 code: Key::Char('a'),
                 modifiers: KeyModifiers::CONTROL,
-            }) => {
-                self.perform(Cmd::GoTo(Position::Begin));
-                Some(Msg::Redraw)
-            }
+            }) => self.perform(Cmd::GoTo(Position::Begin)),
             #[cfg(feature = "search")]
             Event::Keyboard(KeyEvent {
                 code: Key::Char('s'),
                 modifiers: KeyModifiers::CONTROL,
-            }) => {
-                self.perform(Cmd::Custom(TEXTAREA_CMD_SEARCH_BACK));
-                Some(Msg::Redraw)
-            }
+            }) => self.perform(Cmd::Custom(TEXTAREA_CMD_SEARCH_BACK)),
             #[cfg(feature = "search")]
             Event::Keyboard(KeyEvent {
                 code: Key::Char('d'),
                 modifiers: KeyModifiers::CONTROL,
-            }) => {
-                self.perform(Cmd::Custom(TEXTAREA_CMD_SEARCH_FORWARD));
-                Some(Msg::Redraw)
-            }
+            }) => self.perform(Cmd::Custom(TEXTAREA_CMD_SEARCH_FORWARD)),
             Event::Keyboard(KeyEvent {
                 code: Key::Char('z'),
                 modifiers: KeyModifiers::CONTROL,
-            }) => {
-                self.perform(Cmd::Custom(TEXTAREA_CMD_UNDO));
-                Some(Msg::Redraw)
-            }
+            }) => self.perform(Cmd::Custom(TEXTAREA_CMD_UNDO)),
             Event::Keyboard(KeyEvent {
                 code: Key::Char('y'),
                 modifiers: KeyModifiers::CONTROL,
-            }) => {
-                self.perform(Cmd::Custom(TEXTAREA_CMD_REDO));
-                Some(Msg::Redraw)
-            }
-            Event::Keyboard(KeyEvent { code: Key::Tab, .. }) => {
-                self.perform(Cmd::Type('\t'));
-                Some(Msg::Redraw)
-            }
+            }) => self.perform(Cmd::Custom(TEXTAREA_CMD_REDO)),
+            Event::Keyboard(KeyEvent { code: Key::Tab, .. }) => self.perform(Cmd::Type('\t')),
             Event::Keyboard(KeyEvent {
                 code: Key::Char(ch),
                 ..
-            }) => {
-                self.perform(Cmd::Type(*ch));
-                Some(Msg::Redraw)
-            }
+            }) => self.perform(Cmd::Type(*ch)),
             Event::Keyboard(KeyEvent {
                 code: Key::Function(2),
                 ..
-            }) => Some(Msg::ChangeFocus(Id::Label)),
+            }) => return Some(Msg::ChangeFocus(Id::Label)),
             #[cfg(feature = "search")]
             Event::Keyboard(KeyEvent {
                 code: Key::Function(3),
                 ..
-            }) => Some(Msg::ChangeFocus(Id::Search)),
+            }) => return Some(Msg::ChangeFocus(Id::Search)),
             Event::Paste(text) => {
                 self.component.paste(text);
-                Some(Msg::Redraw)
+                CmdResult::Changed(State::None)
             }
-            _ => None,
+            _ => return None,
+        };
+
+        if matches!(result, CmdResult::None | CmdResult::Invalid(_)) {
+            None
+        } else {
+            Some(Msg::Redraw)
         }
     }
 }

--- a/crates/tuirealm-textarea/examples/single_line.rs
+++ b/crates/tuirealm-textarea/examples/single_line.rs
@@ -181,8 +181,8 @@ impl Default for Input {
 
 impl AppComponent<Msg, NoUserEvent> for Input {
     fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
-        match ev {
-            Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => Some(Msg::AppClose),
+        let result = match ev {
+            Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),
             Event::Keyboard(KeyEvent {
                 code: Key::Backspace,
                 ..
@@ -190,16 +190,10 @@ impl AppComponent<Msg, NoUserEvent> for Input {
             | Event::Keyboard(KeyEvent {
                 code: Key::Char('h'),
                 modifiers: KeyModifiers::CONTROL,
-            }) => {
-                self.perform(Cmd::Delete);
-                Some(Msg::Redraw)
-            }
+            }) => self.perform(Cmd::Delete),
             Event::Keyboard(KeyEvent {
                 code: Key::Delete, ..
-            }) => {
-                self.perform(Cmd::Cancel);
-                Some(Msg::Redraw)
-            }
+            }) => self.perform(Cmd::Cancel),
             Event::Keyboard(KeyEvent {
                 code: Key::PageDown,
                 ..
@@ -207,114 +201,77 @@ impl AppComponent<Msg, NoUserEvent> for Input {
             | Event::Keyboard(KeyEvent {
                 code: Key::Down,
                 modifiers: KeyModifiers::SHIFT,
-            }) => {
-                self.perform(Cmd::Scroll(Direction::Down));
-                Some(Msg::Redraw)
-            }
+            }) => self.perform(Cmd::Scroll(Direction::Down)),
             Event::Keyboard(KeyEvent {
                 code: Key::PageUp, ..
             })
             | Event::Keyboard(KeyEvent {
                 code: Key::Up,
                 modifiers: KeyModifiers::SHIFT,
-            }) => {
-                self.perform(Cmd::Scroll(Direction::Up));
-                Some(Msg::Redraw)
-            }
+            }) => self.perform(Cmd::Scroll(Direction::Up)),
             Event::Keyboard(KeyEvent {
                 code: Key::Down, ..
-            }) => {
-                self.perform(Cmd::Move(Direction::Down));
-                Some(Msg::Redraw)
-            }
+            }) => self.perform(Cmd::Move(Direction::Down)),
             Event::Keyboard(KeyEvent {
                 code: Key::Left,
                 modifiers: KeyModifiers::SHIFT,
-            }) => {
-                self.perform(Cmd::Custom(TEXTAREA_CMD_MOVE_WORD_BACK));
-                Some(Msg::Redraw)
-            }
+            }) => self.perform(Cmd::Custom(TEXTAREA_CMD_MOVE_WORD_BACK)),
             Event::Keyboard(KeyEvent {
                 code: Key::Left, ..
-            }) => {
-                self.perform(Cmd::Move(Direction::Left));
-                Some(Msg::Redraw)
-            }
+            }) => self.perform(Cmd::Move(Direction::Left)),
             Event::Keyboard(KeyEvent {
                 code: Key::Right,
                 modifiers: KeyModifiers::SHIFT,
-            }) => {
-                self.perform(Cmd::Custom(TEXTAREA_CMD_MOVE_WORD_FORWARD));
-                Some(Msg::Redraw)
-            }
+            }) => self.perform(Cmd::Custom(TEXTAREA_CMD_MOVE_WORD_FORWARD)),
             Event::Keyboard(KeyEvent {
                 code: Key::Right, ..
-            }) => {
-                self.perform(Cmd::Move(Direction::Right));
-                Some(Msg::Redraw)
-            }
+            }) => self.perform(Cmd::Move(Direction::Right)),
             Event::Keyboard(KeyEvent { code: Key::Up, .. }) => {
-                self.perform(Cmd::Move(Direction::Up));
-                Some(Msg::Redraw)
+                self.perform(Cmd::Move(Direction::Up))
             }
             Event::Keyboard(KeyEvent { code: Key::End, .. })
             | Event::Keyboard(KeyEvent {
                 code: Key::Char('e'),
                 modifiers: KeyModifiers::CONTROL,
-            }) => {
-                self.perform(Cmd::GoTo(Position::End));
-                Some(Msg::Redraw)
-            }
+            }) => self.perform(Cmd::GoTo(Position::End)),
             Event::Keyboard(KeyEvent {
                 code: Key::Enter, ..
             })
             | Event::Keyboard(KeyEvent {
                 code: Key::Char('m'),
                 modifiers: KeyModifiers::CONTROL,
-            }) => {
-                self.perform(Cmd::Custom(TEXTAREA_CMD_NEWLINE));
-                Some(Msg::Redraw)
-            }
+            }) => self.perform(Cmd::Custom(TEXTAREA_CMD_NEWLINE)),
             Event::Keyboard(KeyEvent {
                 code: Key::Home, ..
             })
             | Event::Keyboard(KeyEvent {
                 code: Key::Char('a'),
                 modifiers: KeyModifiers::CONTROL,
-            }) => {
-                self.perform(Cmd::GoTo(Position::Begin));
-                Some(Msg::Redraw)
-            }
+            }) => self.perform(Cmd::GoTo(Position::Begin)),
             Event::Keyboard(KeyEvent {
                 code: Key::Char('z'),
                 modifiers: KeyModifiers::CONTROL,
-            }) => {
-                self.perform(Cmd::Custom(TEXTAREA_CMD_UNDO));
-                Some(Msg::Redraw)
-            }
+            }) => self.perform(Cmd::Custom(TEXTAREA_CMD_UNDO)),
             Event::Keyboard(KeyEvent {
                 code: Key::Char('y'),
                 modifiers: KeyModifiers::CONTROL,
-            }) => {
-                self.perform(Cmd::Custom(TEXTAREA_CMD_REDO));
-                Some(Msg::Redraw)
-            }
-            Event::Keyboard(KeyEvent { code: Key::Tab, .. }) => {
-                self.perform(Cmd::Type('\t'));
-                Some(Msg::Redraw)
-            }
+            }) => self.perform(Cmd::Custom(TEXTAREA_CMD_REDO)),
+            Event::Keyboard(KeyEvent { code: Key::Tab, .. }) => self.perform(Cmd::Type('\t')),
             Event::Keyboard(KeyEvent {
                 code: Key::Char(ch),
                 ..
-            }) => {
-                self.perform(Cmd::Type(*ch));
-                Some(Msg::Redraw)
-            }
+            }) => self.perform(Cmd::Type(*ch)),
             Event::Paste(text) => {
                 self.component.paste(text);
-                Some(Msg::Redraw)
+                CmdResult::Changed(State::None)
             }
-            _ => None,
+            _ => return None,
+        };
+
+        if matches!(result, CmdResult::None | CmdResult::Invalid(_)) {
+            None
+        } else {
+            Some(Msg::Redraw)
         }
     }
 }

--- a/crates/tuirealm-textarea/src/lib.rs
+++ b/crates/tuirealm-textarea/src/lib.rs
@@ -669,7 +669,7 @@ impl Component for TextArea<'_> {
                 self.widget.insert_char(ch);
             }
             Cmd::Submit => return CmdResult::Submit(self.state()),
-            _ => return CmdResult::None,
+            _ => return CmdResult::Invalid(cmd),
         }
         if prev_lines != self.widget.lines() {
             CmdResult::Changed(self.state())
@@ -819,8 +819,8 @@ mod tests {
         let mut textarea = make_textarea();
         let result = textarea.perform(Cmd::Toggle);
         assert!(
-            matches!(result, CmdResult::None),
-            "unhandled command should return None"
+            matches!(result, CmdResult::Invalid(Cmd::Toggle)),
+            "unhandled command should return Invalid"
         );
     }
 }

--- a/crates/tuirealm-textarea/src/lib.rs
+++ b/crates/tuirealm-textarea/src/lib.rs
@@ -410,6 +410,17 @@ impl<'a> TextArea<'a> {
 
         None
     }
+
+    /// Move the cursor to a specific position, and return the appropriate [`CmdResult`].
+    fn move_cursor(&mut self, to: CursorMove) -> CmdResult {
+        let prev = self.widget.cursor();
+        self.widget.move_cursor(to);
+        if prev == self.widget.cursor() {
+            CmdResult::None
+        } else {
+            CmdResult::Visual
+        }
+    }
 }
 
 impl Component for TextArea<'_> {
@@ -577,25 +588,25 @@ impl Component for TextArea<'_> {
                 self.widget.delete_word();
             }
             Cmd::Custom(TEXTAREA_CMD_MOVE_PARAGRAPH_BACK) => {
-                self.widget.move_cursor(CursorMove::ParagraphBack);
+                return self.move_cursor(CursorMove::ParagraphBack);
             }
             Cmd::Custom(TEXTAREA_CMD_MOVE_PARAGRAPH_FORWARD) => {
-                self.widget.move_cursor(CursorMove::ParagraphForward);
+                return self.move_cursor(CursorMove::ParagraphForward);
             }
             Cmd::Custom(TEXTAREA_CMD_MOVE_WORD_BACK) => {
-                self.widget.move_cursor(CursorMove::WordBack);
+                return self.move_cursor(CursorMove::WordBack);
             }
             Cmd::Custom(TEXTAREA_CMD_MOVE_WORD_FORWARD) => {
-                self.widget.move_cursor(CursorMove::WordForward);
+                return self.move_cursor(CursorMove::WordForward);
             }
             Cmd::Custom(TEXTAREA_CMD_MOVE_BOTTOM) => {
                 if !self.single_line {
-                    self.widget.move_cursor(CursorMove::Bottom);
+                    return self.move_cursor(CursorMove::Bottom);
                 }
             }
             Cmd::Custom(TEXTAREA_CMD_MOVE_TOP) => {
                 if !self.single_line {
-                    self.widget.move_cursor(CursorMove::Top);
+                    return self.move_cursor(CursorMove::Top);
                 }
             }
             Cmd::Custom(TEXTAREA_CMD_REDO) => {
@@ -616,25 +627,25 @@ impl Component for TextArea<'_> {
                 self.widget.delete_char();
             }
             Cmd::GoTo(Position::Begin) => {
-                self.widget.move_cursor(CursorMove::Head);
+                return self.move_cursor(CursorMove::Head);
             }
             Cmd::GoTo(Position::End) => {
-                self.widget.move_cursor(CursorMove::End);
+                return self.move_cursor(CursorMove::End);
             }
             Cmd::Move(Direction::Down) => {
                 if !self.single_line {
-                    self.widget.move_cursor(CursorMove::Down);
+                    return self.move_cursor(CursorMove::Down);
                 }
             }
             Cmd::Move(Direction::Left) => {
-                self.widget.move_cursor(CursorMove::Back);
+                return self.move_cursor(CursorMove::Back);
             }
             Cmd::Move(Direction::Right) => {
-                self.widget.move_cursor(CursorMove::Forward);
+                return self.move_cursor(CursorMove::Forward);
             }
             Cmd::Move(Direction::Up) => {
                 if !self.single_line {
-                    self.widget.move_cursor(CursorMove::Up);
+                    return self.move_cursor(CursorMove::Up);
                 }
             }
             Cmd::Scroll(Direction::Down) => {
@@ -644,7 +655,12 @@ impl Component for TextArea<'_> {
                         .get(Attribute::ScrollStep)
                         .and_then(AttrValue::as_length)
                         .unwrap_or(8);
-                    (0..step).for_each(|_| self.widget.move_cursor(CursorMove::Down));
+                    let mut res = CmdResult::None;
+                    (0..step).for_each(|_| match self.move_cursor(CursorMove::Down) {
+                        CmdResult::None => (),
+                        v => res = v,
+                    });
+                    return res;
                 }
             }
             Cmd::Scroll(Direction::Up) => {
@@ -654,7 +670,12 @@ impl Component for TextArea<'_> {
                         .get(Attribute::ScrollStep)
                         .and_then(AttrValue::as_length)
                         .unwrap_or(8);
-                    (0..step).for_each(|_| self.widget.move_cursor(CursorMove::Up));
+                    let mut res = CmdResult::None;
+                    (0..step).for_each(|_| match self.move_cursor(CursorMove::Up) {
+                        CmdResult::None => (),
+                        v => res = v,
+                    });
+                    return res;
                 }
             }
             Cmd::Type('\t') => {
@@ -777,8 +798,8 @@ mod tests {
         textarea.perform(Cmd::Type('a'));
         let result = textarea.perform(Cmd::Move(Direction::Left));
         assert!(
-            matches!(result, CmdResult::None),
-            "cursor movement should return None (no content change)"
+            matches!(result, CmdResult::Visual),
+            "cursor movement should return Visual (no content change)"
         );
     }
 
@@ -789,8 +810,8 @@ mod tests {
         textarea.perform(Cmd::Type('b'));
         let result = textarea.perform(Cmd::GoTo(Position::Begin));
         assert!(
-            matches!(result, CmdResult::None),
-            "goto should return None (no content change)"
+            matches!(result, CmdResult::Visual),
+            "goto should return Visual (no content change)"
         );
     }
 

--- a/crates/tuirealm-textarea/tests/component_textarea.rs
+++ b/crates/tuirealm-textarea/tests/component_textarea.rs
@@ -120,17 +120,20 @@ fn test_textarea_cursor_movement() {
     component.perform(Cmd::Type('B'));
     assert_eq!(
         component.perform(Cmd::Move(Direction::Left)),
-        CmdResult::None
+        CmdResult::Visual
     );
     assert_eq!(
         component.perform(Cmd::Move(Direction::Right)),
-        CmdResult::None
+        CmdResult::Visual
     );
     assert_eq!(
         component.perform(Cmd::GoTo(Position::Begin)),
-        CmdResult::None
+        CmdResult::Visual
     );
-    assert_eq!(component.perform(Cmd::GoTo(Position::End)), CmdResult::None);
+    assert_eq!(
+        component.perform(Cmd::GoTo(Position::End)),
+        CmdResult::Visual
+    );
 }
 
 #[test]
@@ -139,10 +142,13 @@ fn test_textarea_vertical_movement() {
     component.perform(Cmd::Type('A'));
     component.perform(Cmd::Custom(TEXTAREA_CMD_NEWLINE));
     component.perform(Cmd::Type('B'));
-    assert_eq!(component.perform(Cmd::Move(Direction::Up)), CmdResult::None);
+    assert_eq!(
+        component.perform(Cmd::Move(Direction::Up)),
+        CmdResult::Visual
+    );
     assert_eq!(
         component.perform(Cmd::Move(Direction::Down)),
-        CmdResult::None
+        CmdResult::Visual
     );
 }
 
@@ -164,11 +170,11 @@ fn test_textarea_word_movement() {
     }
     assert_eq!(
         component.perform(Cmd::Custom(TEXTAREA_CMD_MOVE_WORD_BACK)),
-        CmdResult::None
+        CmdResult::Visual
     );
     assert_eq!(
         component.perform(Cmd::Custom(TEXTAREA_CMD_MOVE_WORD_FORWARD)),
-        CmdResult::None
+        CmdResult::Visual
     );
 }
 
@@ -222,11 +228,11 @@ fn test_textarea_move_top_bottom() {
     component.perform(Cmd::Type('C'));
     assert_eq!(
         component.perform(Cmd::Custom(TEXTAREA_CMD_MOVE_TOP)),
-        CmdResult::None
+        CmdResult::Visual
     );
     assert_eq!(
         component.perform(Cmd::Custom(TEXTAREA_CMD_MOVE_BOTTOM)),
-        CmdResult::None
+        CmdResult::Visual
     );
 }
 
@@ -248,11 +254,11 @@ fn test_textarea_scroll() {
     component.perform(Cmd::Type('C'));
     assert_eq!(
         component.perform(Cmd::Scroll(Direction::Up)),
-        CmdResult::None
+        CmdResult::Visual
     );
     assert_eq!(
         component.perform(Cmd::Scroll(Direction::Down)),
-        CmdResult::None
+        CmdResult::Visual
     );
 }
 

--- a/crates/tuirealm-textarea/tests/component_textarea.rs
+++ b/crates/tuirealm-textarea/tests/component_textarea.rs
@@ -259,7 +259,10 @@ fn test_textarea_scroll() {
 #[test]
 fn test_textarea_unhandled_cmd() {
     let mut component = TextArea::default();
-    assert_eq!(component.perform(Cmd::Toggle), CmdResult::None);
+    assert_eq!(
+        component.perform(Cmd::Toggle),
+        CmdResult::Invalid(Cmd::Toggle)
+    );
 }
 
 // Snapshot tests

--- a/crates/tuirealm-treeview/src/lib.rs
+++ b/crates/tuirealm-treeview/src/lib.rs
@@ -561,7 +561,7 @@ impl<V: NodeValue> Component for TreeView<V> {
                 self.states.open(self.tree.root());
                 CmdResult::None
             }
-            _ => CmdResult::None,
+            _ => CmdResult::Invalid(cmd),
         }
     }
 }

--- a/crates/tuirealm-treeview/src/lib.rs
+++ b/crates/tuirealm-treeview/src/lib.rs
@@ -554,12 +554,12 @@ impl<V: NodeValue> Component for TreeView<V> {
             Cmd::Custom(TREE_CMD_CLOSE) => {
                 // close selected node
                 self.states.close(self.tree.root());
-                CmdResult::None
+                CmdResult::Visual
             }
             Cmd::Custom(TREE_CMD_OPEN) => {
                 // close selected node
                 self.states.open(self.tree.root());
-                CmdResult::None
+                CmdResult::Visual
             }
             _ => CmdResult::Invalid(cmd),
         }
@@ -726,7 +726,7 @@ mod test {
         component.states.open(component.tree.root());
         assert_eq!(
             component.perform(Cmd::Custom(TREE_CMD_CLOSE)),
-            CmdResult::None
+            CmdResult::Visual
         );
         assert!(
             component
@@ -742,7 +742,7 @@ mod test {
             .initial_node("aA");
         assert_eq!(
             component.perform(Cmd::Custom(TREE_CMD_OPEN)),
-            CmdResult::None
+            CmdResult::Visual
         );
         assert!(
             component

--- a/crates/tuirealm-treeview/tests/component_treeview.rs
+++ b/crates/tuirealm-treeview/tests/component_treeview.rs
@@ -93,8 +93,14 @@ fn test_treeview_unhandled_cmd() {
         .borders(Borders::default())
         .with_tree(mock_tree())
         .initial_node("/");
-    assert_eq!(component.perform(Cmd::Delete), CmdResult::None);
-    assert_eq!(component.perform(Cmd::Type('a')), CmdResult::None);
+    assert_eq!(
+        component.perform(Cmd::Delete),
+        CmdResult::Invalid(Cmd::Delete)
+    );
+    assert_eq!(
+        component.perform(Cmd::Type('a')),
+        CmdResult::Invalid(Cmd::Type('a'))
+    );
 }
 
 // Snapshot tests

--- a/crates/tuirealm-treeview/tests/component_treeview.rs
+++ b/crates/tuirealm-treeview/tests/component_treeview.rs
@@ -48,11 +48,11 @@ fn test_treeview_open_close_node() {
         .initial_node("/");
     assert_eq!(
         component.perform(Cmd::Custom(TREE_CMD_CLOSE)),
-        CmdResult::None
+        CmdResult::Visual
     );
     assert_eq!(
         component.perform(Cmd::Custom(TREE_CMD_OPEN)),
-        CmdResult::None
+        CmdResult::Visual
     );
 }
 

--- a/crates/tuirealm/docs/en/advanced.md
+++ b/crates/tuirealm/docs/en/advanced.md
@@ -419,7 +419,7 @@ impl Component for Radio {
                 // Return Submit
                 CmdResult::Submit(self.state())
             }
-            _ => CmdResult::None,
+            _ => CmdResult::Invalid(cmd),
         }
     }
 

--- a/crates/tuirealm/docs/en/get-started.md
+++ b/crates/tuirealm/docs/en/get-started.md
@@ -667,7 +667,7 @@ impl Component for Counter {
                 self.states.incr();
                 CmdResult::Changed(self.state())
             }
-            _ => CmdResult::None,
+            _ => CmdResult::Invalid(cmd),
         }
     }
 }

--- a/crates/tuirealm/docs/zh-cn/advanced.md
+++ b/crates/tuirealm/docs/zh-cn/advanced.md
@@ -433,7 +433,7 @@ impl Component for Radio {
                 // 返回提交
                 CmdResult::Submit(self.state())
             }
-            _ => CmdResult::None,
+            _ => CmdResult::Invalid(cmd),
         }
     }
 

--- a/crates/tuirealm/examples/arbitrary_data.rs
+++ b/crates/tuirealm/examples/arbitrary_data.rs
@@ -253,8 +253,8 @@ impl Component for StdLabel {
         State::None
     }
 
-    fn perform(&mut self, _: Cmd) -> CmdResult {
-        CmdResult::None
+    fn perform(&mut self, cmd: Cmd) -> CmdResult {
+        CmdResult::Invalid(cmd)
     }
 }
 

--- a/crates/tuirealm/examples/async_ports.rs
+++ b/crates/tuirealm/examples/async_ports.rs
@@ -262,8 +262,8 @@ impl Component for Label {
         State::None
     }
 
-    fn perform(&mut self, _: Cmd) -> CmdResult {
-        CmdResult::None
+    fn perform(&mut self, cmd: Cmd) -> CmdResult {
+        CmdResult::Invalid(cmd)
     }
 }
 

--- a/crates/tuirealm/examples/demo/components/counter.rs
+++ b/crates/tuirealm/examples/demo/components/counter.rs
@@ -156,7 +156,7 @@ impl Component for Counter {
                 self.states.incr();
                 CmdResult::Changed(self.state())
             }
-            _ => CmdResult::None,
+            _ => CmdResult::Invalid(cmd),
         }
     }
 }

--- a/crates/tuirealm/examples/demo/components/label.rs
+++ b/crates/tuirealm/examples/demo/components/label.rs
@@ -115,8 +115,8 @@ impl Component for Label {
         State::None
     }
 
-    fn perform(&mut self, _: Cmd) -> CmdResult {
-        CmdResult::None
+    fn perform(&mut self, cmd: Cmd) -> CmdResult {
+        CmdResult::Invalid(cmd)
     }
 }
 

--- a/crates/tuirealm/examples/event_display.rs
+++ b/crates/tuirealm/examples/event_display.rs
@@ -202,8 +202,8 @@ impl Component for Label {
         State::None
     }
 
-    fn perform(&mut self, _: Cmd) -> CmdResult {
-        CmdResult::None
+    fn perform(&mut self, cmd: Cmd) -> CmdResult {
+        CmdResult::Invalid(cmd)
     }
 }
 
@@ -240,8 +240,8 @@ impl Component for EventDisplay {
         State::None
     }
 
-    fn perform(&mut self, _: Cmd) -> CmdResult {
-        CmdResult::None
+    fn perform(&mut self, cmd: Cmd) -> CmdResult {
+        CmdResult::Invalid(cmd)
     }
 }
 

--- a/crates/tuirealm/examples/inline_display.rs
+++ b/crates/tuirealm/examples/inline_display.rs
@@ -179,8 +179,8 @@ impl Component for Label {
         State::None
     }
 
-    fn perform(&mut self, _: Cmd) -> CmdResult {
-        CmdResult::None
+    fn perform(&mut self, cmd: Cmd) -> CmdResult {
+        CmdResult::Invalid(cmd)
     }
 }
 
@@ -216,8 +216,8 @@ impl Component for ProgressBar {
         State::None
     }
 
-    fn perform(&mut self, _cmd: Cmd) -> CmdResult {
-        CmdResult::None
+    fn perform(&mut self, cmd: Cmd) -> CmdResult {
+        CmdResult::Invalid(cmd)
     }
 }
 

--- a/crates/tuirealm/examples/user_events/components/label.rs
+++ b/crates/tuirealm/examples/user_events/components/label.rs
@@ -87,8 +87,8 @@ impl Component for Label {
         State::None
     }
 
-    fn perform(&mut self, _: Cmd) -> CmdResult {
-        CmdResult::None
+    fn perform(&mut self, cmd: Cmd) -> CmdResult {
+        CmdResult::Invalid(cmd)
     }
 }
 

--- a/crates/tuirealm/src/core/command.rs
+++ b/crates/tuirealm/src/core/command.rs
@@ -79,6 +79,10 @@ pub enum CmdResult {
     Custom(&'static str, State),
     /// An array of Command results.
     Batch(Vec<CmdResult>),
+    /// The component visually changed, but the state did not change.
+    ///
+    /// If state *did* change, always use [`Changed`](CmdResult::Changed) instead.
+    Visual,
     /// Nothing changed, nothing needs to be done.
     None,
 }

--- a/crates/tuirealm/src/core/command.rs
+++ b/crates/tuirealm/src/core/command.rs
@@ -61,21 +61,24 @@ pub enum Position {
 
 /// A command result describes the output of a [`Cmd`] performed on a Component.
 /// It reports a "logical" change on the `Component`.
-/// The `AppComponent` then, must return a certain user defined `Msg` based on the value of the [`CmdResult`].
+/// The [`AppComponent`](crate::component::AppComponent) then needs to handle this result and return a user defined `Msg` based on the value of the [`CmdResult`].
 #[derive(Debug, PartialEq, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum CmdResult {
     /// The component has changed state. The new state is reported.
-    /// Box is used to reduce size
+    ///
+    /// This implies the component has visually changes and needs to be redrawn.
     Changed(State),
-    /// Value submit result
+    /// Command resulted in a submit action, this contains the submitted state.
     Submit(State),
-    /// The command could not be applied. Useful to report errors
+    /// The command issues is unsupported for this component.
+    ///
+    /// This should basically be treated the same as [`None`](CmdResult::None), but may be useful for debugging.
     Invalid(Cmd),
-    /// Custom cmd result
+    /// Custom result with a name and a state attached.
     Custom(&'static str, State),
-    /// An array of Command result
+    /// An array of Command results.
     Batch(Vec<CmdResult>),
-    /// No result to report
+    /// Nothing changed, nothing needs to be done.
     None,
 }

--- a/crates/tuirealm/src/mock/components.rs
+++ b/crates/tuirealm/src/mock/components.rs
@@ -53,7 +53,7 @@ impl Component for MockInput {
                 self.states.input(ch);
                 CmdResult::Changed(self.state())
             }
-            _ => CmdResult::None,
+            _ => CmdResult::Invalid(cmd),
         }
     }
 }


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

Fixes #198

## Description

This PR actually makes use of `CmdResult::Invalid` within all crates that have components and adds the new `CmdResult::Visual` (and makes use of it).

I hope i got all places changes correctly.
I know that there might be some places where `CmdResult::Visual` could be done more strictly (check previous and changed position).

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
