### PR TITLE
Change `stdlib::TextArea` to use `AttrValue::Text`

### DIFF
--- a/crates/tuirealm-stdlib/examples/textarea.rs
+++ b/crates/tuirealm-stdlib/examples/textarea.rs
@@ -8,10 +8,9 @@ use tuirealm::application::PollStrategy;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::component::{AppComponent, Component};
 use tuirealm::event::{Event, Key, KeyEvent, NoUserEvent};
-use tuirealm::props::{BorderType, Borders, Color, HorizontalAlignment, Title};
+use tuirealm::props::{BorderType, Borders, Color, HorizontalAlignment, Style, Title};
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
-use tuirealm::ratatui::style::Stylize;
-use tuirealm::ratatui::text::Span;
+use tuirealm::ratatui::text::{Line, Span};
 use tuirealm::terminal::TerminalAdapter;
 
 mod utils;
@@ -130,21 +129,27 @@ impl Default for TextareaAlfa {
                 .step(4)
                 .highlighted_str("🎵")
                 .text_rows([
-                    Span::raw("I was a little too tall, could've used a few pounds,")
-                        .underlined()
-                        .fg(Color::Green),
-                    Span::from("Tight pants points, hardly renowned"),
-                    Span::from("She was a black-haired beauty with big dark eyes"),
-                    Span::from("And points of her own, sittin' way up high"),
-                    Span::from("Way up firm and high"),
-                    Span::from("Out past the cornfields where the woods got heavy"),
-                    Span::from("Out in the back seat of my '60 Chevy"),
-                    Span::from("Workin' on mysteries without any clues"),
-                    Span::from("Workin' on our night moves"),
-                    Span::from("Tryin' to make some front page drive-in news"),
-                    Span::from("Workin' on our night moves"),
-                    Span::from("In the summertime"),
-                    Span::from("Umm, in the sweet summertime"),
+                    Line::from(Span::styled(
+                        "I was a little too tall, could've used a few pounds,",
+                        Style::new().underlined().fg(Color::Green),
+                    )),
+                    Line::from_iter([
+                        Span::raw("Tight"),
+                        Span::styled(" pants ", Style::new().italic()),
+                        Span::styled("points,", Style::new().crossed_out()),
+                        Span::raw(" hardly renowned"),
+                    ]),
+                    Line::from("She was a black-haired beauty with big dark eyes"),
+                    Line::from("And points of her own, sittin' way up high"),
+                    Line::from("Way up firm and high"),
+                    Line::from("Out past the cornfields where the woods got heavy"),
+                    Line::from("Out in the back seat of my '60 Chevy"),
+                    Line::from("Workin' on mysteries without any clues"),
+                    Line::from("Workin' on our night moves"),
+                    Line::from("Tryin' to make some front page drive-in news"),
+                    Line::from("Workin' on our night moves"),
+                    Line::from("In the summertime"),
+                    Line::from("Umm, in the sweet summertime"),
                 ]),
         }
     }
@@ -195,18 +200,21 @@ impl Default for TextareaBeta {
                 .step(4)
                 .highlighted_str("🎵")
                 .text_rows([
-                    Span::raw("Roxanne").underlined().fg(Color::Red),
-                    Span::from("You don't have to put on the red light"),
-                    Span::from("Those days are over"),
-                    Span::from("You don't have to sell your body to the night"),
-                    Span::from("Roxanne"),
-                    Span::from("You don't have to wear that dress tonight"),
-                    Span::from("Walk the streets for money"),
-                    Span::from("You don't care if it's wrong or if it's right"),
-                    Span::from("Roxanne"),
-                    Span::from("You don't have to put on the red light"),
-                    Span::from("Roxanne"),
-                    Span::from("You don't have to put on the red light"),
+                    Line::from(Span::styled(
+                        "Roxanne",
+                        Style::new().underlined().fg(Color::Red),
+                    )),
+                    Line::from("You don't have to put on the red light"),
+                    Line::from("Those days are over"),
+                    Line::from("You don't have to sell your body to the night"),
+                    Line::from("Roxanne"),
+                    Line::from("You don't have to wear that dress tonight"),
+                    Line::from("Walk the streets for money"),
+                    Line::from("You don't care if it's wrong or if it's right"),
+                    Line::from("Roxanne"),
+                    Line::from("You don't have to put on the red light"),
+                    Line::from("Roxanne"),
+                    Line::from("You don't have to put on the red light"),
                 ]),
         }
     }

--- a/crates/tuirealm-stdlib/src/components/textarea.rs
+++ b/crates/tuirealm-stdlib/src/components/textarea.rs
@@ -1,8 +1,8 @@
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::component::Component;
 use tuirealm::props::{
-    AttrValue, Attribute, Borders, Color, LineStatic, PropPayload, PropValue, Props, QueryResult,
-    SpanStatic, Style, TextModifiers, Title,
+    AttrValue, Attribute, Borders, Color, LineStatic, Props, QueryResult, Style, TextModifiers,
+    TextStatic, Title,
 };
 use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
@@ -159,11 +159,43 @@ impl Textarea {
         self
     }
 
-    /// Set the Text content.
-    pub fn text_rows(mut self, s: impl IntoIterator<Item = SpanStatic>) -> Self {
-        let rows: Vec<PropValue> = s.into_iter().map(PropValue::TextSpan).collect();
-        self.states.set_list_len(rows.len());
-        self.attr(Attribute::Text, AttrValue::Payload(PropPayload::Vec(rows)));
+    /// Set the Text content via a array or iterator.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use tui_realm_stdlib::components::Textarea;
+    /// # use tuirealm::ratatui::text::Line;
+    /// Textarea::default()
+    ///     .text_rows([
+    ///         Line::raw("line1"),
+    ///         Line::raw("line2")
+    ///     ]);
+    /// ```
+    pub fn text_rows<T>(self, text: impl IntoIterator<Item = T>) -> Self
+    where
+        T: Into<LineStatic>,
+    {
+        let text = TextStatic::from_iter(text);
+        self.text(text)
+    }
+
+    /// Set the Text content via a single struct.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use tui_realm_stdlib::components::Textarea;
+    /// # use tuirealm::ratatui::text::{Line, Text};
+    /// Textarea::default()
+    ///     .text(Line::raw("line"));
+    /// Textarea::default()
+    ///     .text(Text::raw("another line"));
+    /// ```
+    pub fn text(mut self, text: impl Into<TextStatic>) -> Self {
+        let text = text.into();
+        self.states.set_list_len(text.lines.len());
+        self.attr(Attribute::Text, AttrValue::Text(text));
         self
     }
 }
@@ -185,14 +217,10 @@ impl Component for Textarea {
         let lines: Vec<ListItem> = self
             .props
             .get(Attribute::Text)
-            .and_then(AttrValue::as_payload)
-            .and_then(PropPayload::as_vec)
-            .map(|spans| {
-                spans
-                    .iter()
-                    // this will skip any "PropValue" that is not a "TextSpan", instead of panicing
-                    .filter_map(|x| x.as_textspan())
-                    .map(|x| crate::utils::wrap_spans(&[x], wrap_width))
+            .and_then(AttrValue::as_text)
+            .map(|text| {
+                text.iter()
+                    .map(|x| crate::utils::wrap_lines(&[x], wrap_width))
                     .map(ListItem::new)
                     .collect()
             })
@@ -231,9 +259,8 @@ impl Component for Textarea {
             self.states.set_list_len(
                 self.props
                     .get(Attribute::Text)
-                    .and_then(AttrValue::as_payload)
-                    .and_then(PropPayload::as_vec)
-                    .map_or(0, |spans| spans.len()),
+                    .and_then(AttrValue::as_text)
+                    .map_or(0, |text| text.lines.len()),
             );
             self.states.fix_list_index();
         }
@@ -291,7 +318,7 @@ mod tests {
 
     use pretty_assertions::assert_eq;
     use tuirealm::props::HorizontalAlignment;
-    use tuirealm::ratatui::text::Span;
+    use tuirealm::ratatui::text::{Line, Span, Text};
     use tuirealm::state::StateValue;
 
     use super::*;
@@ -307,17 +334,17 @@ mod tests {
             .highlighted_str("🚀")
             .step(4)
             .title(Title::from("textarea").alignment(HorizontalAlignment::Center))
-            .text_rows([Span::from("welcome to "), Span::from("tui-realm")]);
+            .text_rows([Line::from("welcome to "), Line::from("tui-realm")]);
         // Increment list index
         component.states.list_index += 1;
         assert_eq!(component.states.list_index, 1);
         // Add one row
         component.attr(
             Attribute::Text,
-            AttrValue::Payload(PropPayload::Vec(vec![
-                PropValue::TextSpan(Span::from("welcome")),
-                PropValue::TextSpan(Span::from("to")),
-                PropValue::TextSpan(Span::from("tui-realm")),
+            AttrValue::Text(TextStatic::from_iter([
+                Line::from("welcome"),
+                Line::from("to"),
+                Line::from("tui-realm"),
             ])),
         );
         // Verify states
@@ -388,5 +415,28 @@ mod tests {
         let _ = Textarea::default().text_rows(vec![Span::raw("hello")].into_boxed_slice());
         // already a iterator
         let _ = Textarea::default().text_rows(["Hello"].map(Span::raw));
+
+        // Vec
+        let _ = Textarea::default().text_rows(vec![Line::raw("hello")]);
+        // static array
+        let _ = Textarea::default().text_rows([Line::raw("hello")]);
+        // boxed array
+        let _ = Textarea::default().text_rows(vec![Line::raw("hello")].into_boxed_slice());
+        // already a iterator
+        let _ = Textarea::default().text_rows(["Hello"].map(Line::raw));
+    }
+
+    #[test]
+    fn various_text_types() {
+        // Line
+        let _ = Textarea::default().text(Text::raw("hello"));
+        // Line
+        let _ = Textarea::default().text(Line::raw("hello"));
+        // Span
+        let _ = Textarea::default().text(Span::raw("hello"));
+        // str
+        let _ = Textarea::default().text("hello");
+        // String
+        let _ = Textarea::default().text("hello".to_string());
     }
 }

--- a/crates/tuirealm-stdlib/src/utils.rs
+++ b/crates/tuirealm-stdlib/src/utils.rs
@@ -54,8 +54,143 @@ pub fn wrap_spans<'a, 'b: 'a>(spans: &[&'b Span<'a>], width: usize) -> Vec<Line<
     if !line_spans.is_empty() {
         res.push(Line::from(line_spans));
     }
-    // return res
+
     res
+}
+
+/// Make a new empty [`Line`], but with the original style applied.
+#[inline]
+fn make_new_line<'a>(orig: &Line<'a>) -> Line<'a> {
+    Line::default().style(orig.style)
+}
+
+/// Commit the current `newline` and create a new one in its place
+#[inline]
+fn commit_line<'a>(newline: &mut Line<'a>, newlines: &mut Vec<Line<'a>>, orig: &Line<'a>) {
+    let mut final_line = make_new_line(orig);
+    std::mem::swap(newline, &mut final_line);
+    newlines.push(final_line);
+}
+
+/// Wrap a single [`Span`] into multiple [`Line`]s.
+///
+/// Returns the amount of consumed width in the last line.
+fn wrap_single_span<'a>(
+    span: &'a Span<'a>,
+    newlines: &mut Vec<Line<'a>>,
+    newline: &mut Line<'a>,
+    orig_line: &Line<'a>,
+    width: usize,
+    consumed_width: &mut usize,
+) -> usize {
+    let mut remainder_width = width - *consumed_width;
+
+    // textwrap seemingly adds at least *one* character if the given width is 0
+    // so lets commit the line here so that we dont run into that case.
+    if remainder_width == 0 && newline.width() != 0 {
+        commit_line(newline, newlines, orig_line);
+        remainder_width = width;
+    }
+
+    // Use textwrap for the actual splitting.
+    // We know here that wrapping *is* necessary.
+    let words = textwrap::WordSeparator::AsciiSpace.find_words(&span.content);
+    let split_words =
+        textwrap::word_splitters::split_words(words, &textwrap::WordSplitter::HyphenSplitter);
+    let broken_words = textwrap::core::break_words(split_words, remainder_width);
+
+    let line_widths = [remainder_width, width];
+    let wrapped_words = textwrap::WrapAlgorithm::FirstFit.wrap(&broken_words, &line_widths);
+
+    // The index into "span.content" which is already consumed
+    let mut consumed_idx = 0;
+    let last_idx = wrapped_words.len().saturating_sub(1);
+    let mut final_consumed_width = 0;
+    // Each "words" loop represents a final line, except for the last iteration.
+    for (idx, words) in wrapped_words.iter().enumerate() {
+        if words.is_empty() {
+            continue;
+        }
+
+        // The following is disabled as this can (in its current form) only catch some whitespaces to trim
+        // but it would then not fully align with the fast-path in the other function.
+        // so for our purposes, it is not worth it.
+        // // only trim the last whitespace *if* we know we commit the line here
+        // // as otherwise, we dont know if something *might* follow
+        // let minus_whitespace = if idx != last_idx {
+        //     words.last().map_or(0, |word| word.whitespace.len())
+        // } else {
+        //     0
+        // };
+        let minus_whitespace = 0;
+
+        // length in bytes of the current words line
+        let len = words
+            .iter()
+            .map(|word| word.len() + word.whitespace.len())
+            .sum::<usize>()
+            - minus_whitespace;
+
+        let split_text = &span.content[consumed_idx..consumed_idx + len];
+        consumed_idx += len + minus_whitespace;
+
+        let newspan = Span::styled(split_text, span.style);
+        newline.push_span(newspan);
+
+        // unless this is the last loop, there are more lines to come
+        if idx != last_idx {
+            commit_line(newline, newlines, orig_line);
+        } else {
+            final_consumed_width = newline.width();
+        }
+    }
+
+    final_consumed_width
+}
+
+/// Wrap the given lines to fit within `width`.
+pub fn wrap_lines<'a, 'b: 'a>(lines: &[&'b Line<'a>], width: usize) -> Vec<Line<'a>> {
+    // Prepare result (capacity will be at least lines.len)
+    let mut new_lines: Vec<Line> = Vec::with_capacity(lines.len());
+
+    for line in lines {
+        // fast path for when no wrapping is necessary
+        if line.width() <= width {
+            new_lines.push(borrow_clone_line(line));
+            continue;
+        }
+
+        // Width that already has been consumed with the current line iteration
+        let mut consumed_width: usize = 0;
+        let mut newline = make_new_line(line);
+
+        for span in line.iter() {
+            // fast path for when no wrapping is necessary on a span-level
+            let span_width = span.content.width();
+            if span_width <= width - consumed_width {
+                newline.push_span(borrow_clone_span(span));
+                consumed_width += span_width;
+                continue;
+            }
+
+            let new_consumed = wrap_single_span(
+                span,
+                &mut new_lines,
+                &mut newline,
+                line,
+                width,
+                &mut consumed_width,
+            );
+            consumed_width = new_consumed;
+        }
+
+        // commit the final newline, if it is not empty
+        if !newline.spans.is_empty() {
+            new_lines.push(newline);
+        }
+    }
+
+    new_lines
 }
 
 /// Construct a [`Block`] widget from the given properties.
@@ -209,5 +344,114 @@ mod test {
         assert_eq!(calc_utf8_cursor_position(chars.as_slice()), 4);
         let chars: Vec<char> = vec!['我', '之', '😄'];
         assert_eq!(calc_utf8_cursor_position(chars.as_slice()), 6);
+    }
+
+    mod lines_wrap {
+        use pretty_assertions::assert_eq;
+        use tuirealm::props::{LineStatic, SpanStatic, Style};
+        use tuirealm::ratatui::text::Span;
+
+        use crate::utils::wrap_lines;
+
+        #[test]
+        fn should_not_do_any_wrapping() {
+            // empty
+            assert_eq!(
+                wrap_lines(&[&LineStatic::default()], 10),
+                [LineStatic::default()]
+            );
+
+            // single span, fits within width
+            assert_eq!(
+                wrap_lines(&[&LineStatic::raw("test")], 10),
+                [LineStatic::raw("test")]
+            );
+
+            // multi span, fits within width
+            assert_eq!(
+                wrap_lines(
+                    &[&LineStatic::from_iter([
+                        SpanStatic::raw("hello"),
+                        SpanStatic::raw("there")
+                    ])],
+                    10
+                ),
+                [LineStatic::from_iter([
+                    SpanStatic::raw("hello"),
+                    SpanStatic::raw("there")
+                ])]
+            );
+        }
+
+        #[test]
+        fn should_wrap_single_span() {
+            assert_eq!(
+                wrap_lines(&[&LineStatic::raw("something really long")], 10),
+                [
+                    LineStatic::raw("something "),
+                    LineStatic::raw("really "),
+                    LineStatic::raw("long")
+                ]
+            );
+
+            // should preserve styles
+            assert_eq!(
+                wrap_lines(
+                    &[&LineStatic::from(Span::styled(
+                        "something really long",
+                        Style::default().crossed_out()
+                    ))
+                    .style(Style::default().italic())],
+                    10
+                ),
+                [
+                    LineStatic::from(Span::styled("something ", Style::default().crossed_out()))
+                        .style(Style::default().italic()),
+                    LineStatic::from(Span::styled("really ", Style::default().crossed_out()))
+                        .style(Style::default().italic()),
+                    LineStatic::from(Span::styled("long", Style::default().crossed_out()))
+                        .style(Style::default().italic())
+                ]
+            );
+        }
+
+        #[test]
+        fn should_wrap_multi_span() {
+            assert_eq!(
+                wrap_lines(
+                    &[&LineStatic::from_iter([
+                        SpanStatic::raw("something "),
+                        SpanStatic::raw("really "),
+                        SpanStatic::raw("long")
+                    ])],
+                    10
+                ),
+                [
+                    LineStatic::raw("something "),
+                    LineStatic::from_iter([Span::raw("really "), Span::raw("lon")]),
+                    LineStatic::raw("g")
+                ]
+            );
+
+            // should preserve styles
+            assert_eq!(
+                wrap_lines(
+                    &[&LineStatic::from_iter([
+                        SpanStatic::styled("something ", Style::default().crossed_out()),
+                        SpanStatic::raw("really "),
+                        SpanStatic::styled("long", Style::default().italic())
+                    ])],
+                    10
+                ),
+                [
+                    LineStatic::from(Span::styled("something ", Style::default().crossed_out())),
+                    LineStatic::from_iter([
+                        Span::raw("really "),
+                        Span::styled("lon", Style::default().italic())
+                    ]),
+                    LineStatic::from(Span::styled("g", Style::default().italic()))
+                ]
+            );
+        }
     }
 }


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

Fixes #178

## Description

This PR changes the stdlib `TextArea` component to use `AttrValue::Text`, which uses ratatui's `Text` to allow multiple lines and multiple style *in the same line*.

Due to how ratatui's `Text` / `Line` / `Span` works, we need to re-implement `textwrap::wrap` function, which was arguably the hardest part of this PR.

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
