### PR TITLE
Add `Attribute::AlwaysActive`

### DIFF
--- a/crates/tuirealm-stdlib/examples/radio.rs
+++ b/crates/tuirealm-stdlib/examples/radio.rs
@@ -28,6 +28,7 @@ pub enum Msg {
 pub enum Id {
     RadioAlfa,
     RadioBeta,
+    RadioCeta,
 }
 
 impl Model<Id, Msg> {
@@ -43,6 +44,7 @@ impl Model<Id, Msg> {
                         [
                             Constraint::Length(3),
                             Constraint::Length(3),
+                            Constraint::Length(3),
                             Constraint::Length(1),
                         ]
                         .as_ref(),
@@ -50,6 +52,7 @@ impl Model<Id, Msg> {
                     .split(f.area());
                 self.app.view(&Id::RadioAlfa, f, chunks[0]);
                 self.app.view(&Id::RadioBeta, f, chunks[1]);
+                self.app.view(&Id::RadioCeta, f, chunks[2]);
             })
             .expect("Drawing to the terminal failed");
     }
@@ -67,6 +70,7 @@ impl Model<Id, Msg> {
             Msg::RadioBetaBlur => {
                 assert!(self.app.active(&Id::RadioAlfa).is_ok());
             }
+            // Ceta is not focusable
             Msg::Redraw => (),
         }
     }
@@ -77,6 +81,8 @@ impl Model<Id, Msg> {
             .mount(Id::RadioAlfa, Box::new(RadioAlfa::default()), vec![])?;
         self.app
             .mount(Id::RadioBeta, Box::new(RadioBeta::default()), vec![])?;
+        self.app
+            .mount(Id::RadioCeta, Box::new(RadioCeta::default()), vec![])?;
         // We need to give focus to input then
         self.app.active(&Id::RadioAlfa)?;
 
@@ -206,5 +212,41 @@ impl AppComponent<Msg, NoUserEvent> for RadioBeta {
             _ => CmdResult::None,
         };
         Some(Msg::Redraw)
+    }
+}
+
+#[derive(Component)]
+struct RadioCeta {
+    component: Radio,
+}
+
+impl Default for RadioCeta {
+    fn default() -> Self {
+        Self {
+            component: Radio::default()
+                .borders(
+                    Borders::default()
+                        .modifiers(BorderType::Rounded)
+                        .color(Color::LightYellow),
+                )
+                .foreground(Color::LightYellow)
+                .title(Title::from("Choice of the day").alignment(HorizontalAlignment::Center))
+                .rewind(false)
+                .choices([
+                    "hazelnuts",
+                    "chocolate",
+                    "maple cyrup",
+                    "smarties",
+                    "raspberries",
+                ])
+                .value(3)
+                .always_active(),
+        }
+    }
+}
+
+impl AppComponent<Msg, NoUserEvent> for RadioCeta {
+    fn on(&mut self, _ev: &Event<NoUserEvent>) -> Option<Msg> {
+        None
     }
 }

--- a/crates/tuirealm-stdlib/src/components/checkbox.rs
+++ b/crates/tuirealm-stdlib/src/components/checkbox.rs
@@ -201,6 +201,12 @@ impl Checkbox {
         self
     }
 
+    /// Set the current component to be always active (show highligh even if unfocused)
+    pub fn always_active(mut self) -> Self {
+        self.attr(Attribute::AlwaysActive, AttrValue::Flag(true));
+        self
+    }
+
     fn rewindable(&self) -> bool {
         self.props
             .get(Attribute::Rewind)
@@ -231,7 +237,7 @@ impl Component for Checkbox {
             .select(self.states.choice)
             .style(self.common.style)
             // TODO: highlight style
-            .highlight_style(self.common.style.add_modifier(if self.common.focused {
+            .highlight_style(self.common.style.add_modifier(if self.common.is_active() {
                 TextModifiers::REVERSED
             } else {
                 TextModifiers::empty()

--- a/crates/tuirealm-stdlib/src/components/input.rs
+++ b/crates/tuirealm-stdlib/src/components/input.rs
@@ -306,7 +306,7 @@ impl Component for Input {
         let mut block = self.common.get_block();
         // Apply invalid style
         // TODO: invalid style should likely still be applied even if unfocused
-        if self.common.focused
+        if self.common.is_active()
             && !self.is_valid()
             && let Some(invalid_style) = self
                 .props
@@ -353,7 +353,7 @@ impl Component for Input {
             &text_to_display
         };
         // Choose paragraph style based on whether is valid or not and if has focus and if should show placeholder
-        let paragraph_style = if self.common.focused {
+        let paragraph_style = if self.common.is_active() {
             normal_style
         } else {
             // TODO: this should likely be a different property
@@ -377,6 +377,7 @@ impl Component for Input {
         render.render_widget(widget, area);
 
         // Set cursor, if focus
+        // not using "common.is_active" here as cursor position should *only* be set for the actually focused component (as there can only be one cursor position)
         if self.common.focused && !area_for_bounds.is_empty() {
             let x: u16 = area_for_bounds.x
                 + calc_utf8_cursor_position(

--- a/crates/tuirealm-stdlib/src/components/list.rs
+++ b/crates/tuirealm-stdlib/src/components/list.rs
@@ -208,6 +208,12 @@ impl List {
         self
     }
 
+    /// Set the current component to be always active (show highligh even if unfocused)
+    pub fn always_active(mut self) -> Self {
+        self.attr(Attribute::AlwaysActive, AttrValue::Flag(true));
+        self
+    }
+
     fn scrollable(&self) -> bool {
         self.props
             .get(Attribute::Scroll)
@@ -259,7 +265,7 @@ impl Component for List {
 
         if let Some(highlighted_color) = highlighted_color {
             widget = widget.highlight_style(Style::default().fg(highlighted_color).add_modifier(
-                if self.common.focused {
+                if self.common.is_active() {
                     TextModifiers::REVERSED
                 } else {
                     TextModifiers::empty()

--- a/crates/tuirealm-stdlib/src/components/radio.rs
+++ b/crates/tuirealm-stdlib/src/components/radio.rs
@@ -178,6 +178,12 @@ impl Radio {
         self
     }
 
+    /// Set the current component to be always active (show highligh even if unfocused)
+    pub fn always_active(mut self) -> Self {
+        self.attr(Attribute::AlwaysActive, AttrValue::Flag(true));
+        self
+    }
+
     fn is_rewind(&self) -> bool {
         self.props
             .get(Attribute::Rewind)
@@ -203,7 +209,7 @@ impl Component for Radio {
         let mut widget = Tabs::new(choices)
             .select(self.states.choice)
             .style(self.common.style)
-            .highlight_style(Style::default().add_modifier(if self.common.focused {
+            .highlight_style(Style::default().add_modifier(if self.common.is_active() {
                 TextModifiers::REVERSED
             } else {
                 TextModifiers::empty()

--- a/crates/tuirealm-stdlib/src/components/table.rs
+++ b/crates/tuirealm-stdlib/src/components/table.rs
@@ -241,6 +241,12 @@ impl Table {
         self
     }
 
+    /// Set the current component to be always active (show highligh even if unfocused)
+    pub fn always_active(mut self) -> Self {
+        self.attr(Attribute::AlwaysActive, AttrValue::Flag(true));
+        self
+    }
+
     /// ### scrollable
     ///
     /// returns the value of the scrollable flag; by default is false
@@ -351,7 +357,7 @@ impl Component for Table {
         if let Some(highlighted_color) = highlighted_color {
             widget =
                 widget.row_highlight_style(Style::default().fg(highlighted_color).add_modifier(
-                    if self.common.focused {
+                    if self.common.is_active() {
                         TextModifiers::REVERSED
                     } else {
                         TextModifiers::empty()

--- a/crates/tuirealm-stdlib/src/prop_ext.rs
+++ b/crates/tuirealm-stdlib/src/prop_ext.rs
@@ -27,6 +27,9 @@ pub struct CommonProps {
     pub display: bool,
     /// Determines if the current component is focused or not.
     pub focused: bool,
+
+    /// Determines if the current component should always use the "active" style, regardless if it is focused or not.
+    pub always_active: bool,
 }
 
 impl Default for CommonProps {
@@ -38,6 +41,7 @@ impl Default for CommonProps {
             title: Option::default(),
             display: true,
             focused: false,
+            always_active: false,
         }
     }
 }
@@ -58,6 +62,7 @@ impl CommonProps {
             // handle flags
             (Attribute::Display, AttrValue::Flag(val)) => self.display = val,
             (Attribute::Focus, AttrValue::Flag(val)) => self.focused = val,
+            (Attribute::AlwaysActive, AttrValue::Flag(val)) => self.always_active = val,
 
             // handle borders & titles
             (Attribute::Borders, AttrValue::Borders(val)) => self.border = Some(val),
@@ -83,6 +88,7 @@ impl CommonProps {
             // handle flags
             Attribute::Display => Some(AttrValue::Flag(self.display)),
             Attribute::Focus => Some(AttrValue::Flag(self.focused)),
+            Attribute::AlwaysActive => Some(AttrValue::Flag(self.always_active)),
 
             // handle borders & titles
             Attribute::Borders => self.border.map(AttrValue::Borders),
@@ -106,6 +112,7 @@ impl CommonProps {
             // handle flags
             Attribute::Display => Some(AttrValueRef::Flag(self.display)),
             Attribute::Focus => Some(AttrValueRef::Flag(self.focused)),
+            Attribute::AlwaysActive => Some(AttrValueRef::Flag(self.always_active)),
 
             // handle borders & titles
             Attribute::Borders => self.border.map(AttrValueRef::Borders),
@@ -127,11 +134,16 @@ impl CommonProps {
         let block = crate::utils::get_block(
             borders,
             title,
-            self.focused,
+            self.always_active || self.focused,
             Some(self.border_unfocused_style),
         );
 
         Some(block)
+    }
+
+    /// Get if the current component is determined to be "active", either by having "Always active" active or being focused.
+    pub fn is_active(&self) -> bool {
+        self.always_active || self.focused
     }
 }
 
@@ -171,6 +183,7 @@ mod tests {
 
         assert!(props.get(Attribute::Display).unwrap().unwrap_flag());
         assert!(!props.get(Attribute::Focus).unwrap().unwrap_flag());
+        assert!(!props.get(Attribute::AlwaysActive).unwrap().unwrap_flag());
 
         assert!(props.get(Attribute::Borders).is_none());
         assert!(props.get(Attribute::Title).is_none());
@@ -260,9 +273,11 @@ mod tests {
 
         props.set(Attribute::Display, AttrValue::Flag(false));
         props.set(Attribute::Focus, AttrValue::Flag(true));
+        props.set(Attribute::AlwaysActive, AttrValue::Flag(true));
 
         assert!(!props.get(Attribute::Display).unwrap().unwrap_flag());
         assert!(props.get(Attribute::Focus).unwrap().unwrap_flag());
+        assert!(props.get(Attribute::AlwaysActive).unwrap().unwrap_flag());
 
         // border & title
 
@@ -326,11 +341,60 @@ mod tests {
             ),
         );
 
+        // unfocused, no set inactive style
+        let block = props.get_block().unwrap();
+        assert_eq!(
+            block,
+            Block::new()
+                .title_bottom(LineStatic::from("Hello").centered())
+                .borders(BorderSides::TOP)
+                .border_type(BorderType::Double)
+        );
+
+        // focused, no set inactive style
+        props.set(Attribute::Focus, AttrValue::Flag(true));
+
+        let block = props.get_block().unwrap();
+        assert_eq!(
+            block,
+            Block::new()
+                .border_style(Style::new().black())
+                .title_bottom(LineStatic::from("Hello").centered())
+                .borders(BorderSides::TOP)
+                .border_type(BorderType::Double)
+        );
+    }
+
+    #[test]
+    fn block_should_be_active_with_alwaysactive() {
+        let mut props = CommonProps::default();
+        props.set(
+            Attribute::Borders,
+            AttrValue::Borders(
+                Borders::default()
+                    .color(Color::Black)
+                    .modifiers(BorderType::Double)
+                    .sides(BorderSides::TOP),
+            ),
+        );
+        props.set(
+            Attribute::Title,
+            AttrValue::Title(
+                Title::default()
+                    .content("Hello".into())
+                    .alignment(HorizontalAlignment::Center)
+                    .position(TitlePosition::Bottom),
+            ),
+        );
+        props.set(Attribute::FocusStyle, AttrValue::Style(Style::new().gray()));
+        props.set(Attribute::AlwaysActive, AttrValue::Flag(true));
+
         let block = props.get_block().unwrap();
 
         assert_eq!(
             block,
             Block::new()
+                .border_style(Style::new().black())
                 .title_bottom(LineStatic::from("Hello").centered())
                 .borders(BorderSides::TOP)
                 .border_type(BorderType::Double)

--- a/crates/tuirealm/src/core/props/mod.rs
+++ b/crates/tuirealm/src/core/props/mod.rs
@@ -45,6 +45,8 @@ pub enum Attribute {
     AlignmentHorizontal,
     /// Vertical Layout Alignment
     AlignmentVertical,
+    /// Should be used to indicate if a component should always be regarded as "active" (for styling), regardless of if it has [`Focus`](Self::Focus) or not.
+    AlwaysActive,
     /// Background color or style
     Background,
     /// Borders styles


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

Fixes #177

## Description

This PR adds a the new `Attribute::AlwaysActive`, which is implemented for `CommonProps` and all places that previously used `common.focused` for `highlight style` or `get_block` will, if active, behave as if focused previously.

One exception is `Input`'s `cursor_position` setting, which should only be done for the actually focused component as there can only be one set cursor position.

A new example component is added to showcase this feature. The new component cannot be focused and is meant to be "static" (not directly user controlled).

A possible downside is due to it always displaying as if "active", if the component can *actually* be focused, with the current styling options, it might not be obvious which is focused (just see the newly added example).

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
