### PR TITLE
Rename `CmdResult::None` and `Attribute::FocusStyle`

### DIFF
--- a/crates/tuirealm-stdlib/examples/bar_chart.rs
+++ b/crates/tuirealm-stdlib/examples/bar_chart.rs
@@ -158,7 +158,7 @@ impl AppComponent<Msg, NoUserEvent> for ChartAlfa {
             KeyEvent { code: Key::End, .. } => self.perform(Cmd::GoTo(Position::End)),
             KeyEvent { code: Key::Tab, .. } => return Some(Msg::ChartAlfaBlur),
             KeyEvent { code: Key::Esc, .. } => return Some(Msg::AppClose),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }
@@ -221,7 +221,7 @@ impl AppComponent<Msg, NoUserEvent> for ChartBeta {
             KeyEvent { code: Key::End, .. } => self.perform(Cmd::GoTo(Position::End)),
             KeyEvent { code: Key::Tab, .. } => return Some(Msg::ChartBetaBlur),
             KeyEvent { code: Key::Esc, .. } => return Some(Msg::AppClose),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }

--- a/crates/tuirealm-stdlib/examples/chart.rs
+++ b/crates/tuirealm-stdlib/examples/chart.rs
@@ -173,9 +173,9 @@ impl AppComponent<Msg, UserEvent> for ChartAlfa {
                     Attribute::Dataset,
                     AttrValue::Payload(PropPayload::Any(Box::new(vec![dataset]))),
                 );
-                CmdResult::None
+                CmdResult::NoChange
             }
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }

--- a/crates/tuirealm-stdlib/examples/checkbox.rs
+++ b/crates/tuirealm-stdlib/examples/checkbox.rs
@@ -160,7 +160,7 @@ impl AppComponent<Msg, NoUserEvent> for CheckboxAlfa {
             } => self.perform(Cmd::Toggle),
             KeyEvent { code: Key::Tab, .. } => return Some(Msg::CheckboxAlfaBlur),
             KeyEvent { code: Key::Esc, .. } => return Some(Msg::AppClose),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }
@@ -215,7 +215,7 @@ impl AppComponent<Msg, NoUserEvent> for CheckboxBeta {
             } => self.perform(Cmd::Toggle),
             KeyEvent { code: Key::Tab, .. } => return Some(Msg::CheckboxBetaBlur),
             KeyEvent { code: Key::Esc, .. } => return Some(Msg::AppClose),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }

--- a/crates/tuirealm-stdlib/examples/container.rs
+++ b/crates/tuirealm-stdlib/examples/container.rs
@@ -227,7 +227,7 @@ impl AppComponent<Msg, NoUserEvent> for MyContainer {
     fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         match ev {
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }

--- a/crates/tuirealm-stdlib/examples/gauge.rs
+++ b/crates/tuirealm-stdlib/examples/gauge.rs
@@ -190,11 +190,11 @@ impl AppComponent<Msg, UserEvent> for GaugeAlfa {
                     AttrValue::Payload(PropPayload::Single(PropValue::F64(*prog))),
                 );
                 self.attr(Attribute::Text, AttrValue::String(label));
-                CmdResult::None
+                CmdResult::NoChange
             }
             Event::Keyboard(KeyEvent { code: Key::Tab, .. }) => return Some(Msg::GaugeAlfaBlur),
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }
@@ -243,11 +243,11 @@ impl AppComponent<Msg, UserEvent> for GaugeBeta {
                     AttrValue::Payload(PropPayload::Single(PropValue::F64(prog))),
                 );
                 self.attr(Attribute::Text, AttrValue::String(label));
-                CmdResult::None
+                CmdResult::NoChange
             }
             Event::Keyboard(KeyEvent { code: Key::Tab, .. }) => return Some(Msg::GaugeBetaBlur),
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }

--- a/crates/tuirealm-stdlib/examples/input.rs
+++ b/crates/tuirealm-stdlib/examples/input.rs
@@ -197,7 +197,7 @@ impl AppComponent<Msg, NoUserEvent> for InputText {
             } => self.perform(Cmd::Type(*ch)),
             KeyEvent { code: Key::Tab, .. } => return Some(Msg::TextBlur),
             KeyEvent { code: Key::Esc, .. } => return Some(Msg::AppClose),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }
@@ -255,7 +255,7 @@ impl AppComponent<Msg, NoUserEvent> for InputEmail {
             } => self.perform(Cmd::Type(*ch)),
             KeyEvent { code: Key::Tab, .. } => return Some(Msg::EmailBlur),
             KeyEvent { code: Key::Esc, .. } => return Some(Msg::AppClose),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }
@@ -310,7 +310,7 @@ impl AppComponent<Msg, NoUserEvent> for InputNumber {
             } => self.perform(Cmd::Type(*ch)),
             KeyEvent { code: Key::Tab, .. } => return Some(Msg::NumberBlur),
             KeyEvent { code: Key::Esc, .. } => return Some(Msg::AppClose),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }
@@ -364,7 +364,7 @@ impl AppComponent<Msg, NoUserEvent> for InputPassword {
             } => self.perform(Cmd::Type(*ch)),
             KeyEvent { code: Key::Tab, .. } => return Some(Msg::PasswordBlur),
             KeyEvent { code: Key::Esc, .. } => return Some(Msg::AppClose),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }
@@ -423,7 +423,7 @@ impl AppComponent<Msg, NoUserEvent> for InputPhone {
             } => self.perform(Cmd::Type(*ch)),
             KeyEvent { code: Key::Tab, .. } => return Some(Msg::PhoneBlur),
             KeyEvent { code: Key::Esc, .. } => return Some(Msg::AppClose),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }
@@ -491,11 +491,11 @@ impl AppComponent<Msg, NoUserEvent> for InputColor {
                         ),
                     );
                 }
-                CmdResult::None
+                CmdResult::NoChange
             }
             KeyEvent { code: Key::Tab, .. } => return Some(Msg::ColorBlur),
             KeyEvent { code: Key::Esc, .. } => return Some(Msg::AppClose),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }

--- a/crates/tuirealm-stdlib/examples/label.rs
+++ b/crates/tuirealm-stdlib/examples/label.rs
@@ -120,7 +120,7 @@ impl AppComponent<Msg, NoUserEvent> for LabelAlfa {
     fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         match ev {
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }
@@ -148,7 +148,7 @@ impl AppComponent<Msg, NoUserEvent> for LabelBeta {
     fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         match ev {
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }

--- a/crates/tuirealm-stdlib/examples/line_gauge.rs
+++ b/crates/tuirealm-stdlib/examples/line_gauge.rs
@@ -168,11 +168,11 @@ impl AppComponent<Msg, UserEvent> for GaugeAlfa {
                     AttrValue::Payload(PropPayload::Single(PropValue::F64(*prog))),
                 );
                 self.attr(Attribute::Text, AttrValue::String(label));
-                CmdResult::None
+                CmdResult::NoChange
             }
             Event::Keyboard(KeyEvent { code: Key::Tab, .. }) => return Some(Msg::GaugeAlfaBlur),
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }
@@ -215,11 +215,11 @@ impl AppComponent<Msg, UserEvent> for GaugeBeta {
                     AttrValue::Payload(PropPayload::Single(PropValue::F64(*prog))),
                 );
                 self.attr(Attribute::Text, AttrValue::String(label));
-                CmdResult::None
+                CmdResult::NoChange
             }
             Event::Keyboard(KeyEvent { code: Key::Tab, .. }) => return Some(Msg::GaugeBetaBlur),
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }

--- a/crates/tuirealm-stdlib/examples/list.rs
+++ b/crates/tuirealm-stdlib/examples/list.rs
@@ -221,7 +221,7 @@ impl AppComponent<Msg, NoUserEvent> for ListAlfa {
             KeyEvent { code: Key::End, .. } => self.perform(Cmd::GoTo(Position::End)),
             KeyEvent { code: Key::Tab, .. } => return Some(Msg::ListAlfaBlur),
             KeyEvent { code: Key::Esc, .. } => return Some(Msg::AppClose),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }
@@ -320,7 +320,7 @@ impl AppComponent<Msg, NoUserEvent> for ListBeta {
         match ev.as_keyboard()? {
             KeyEvent { code: Key::Tab, .. } => return Some(Msg::ListBetaBlur),
             KeyEvent { code: Key::Esc, .. } => return Some(Msg::AppClose),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }

--- a/crates/tuirealm-stdlib/examples/paragraph.rs
+++ b/crates/tuirealm-stdlib/examples/paragraph.rs
@@ -138,7 +138,7 @@ impl AppComponent<Msg, NoUserEvent> for ParagraphAlfa {
     fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         match ev {
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }
@@ -175,7 +175,7 @@ impl AppComponent<Msg, NoUserEvent> for ParagraphBeta {
     fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         match ev {
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }

--- a/crates/tuirealm-stdlib/examples/radio.rs
+++ b/crates/tuirealm-stdlib/examples/radio.rs
@@ -161,7 +161,7 @@ impl AppComponent<Msg, NoUserEvent> for RadioAlfa {
             } => self.perform(Cmd::Submit),
             KeyEvent { code: Key::Tab, .. } => return Some(Msg::RadioAlfaBlur),
             KeyEvent { code: Key::Esc, .. } => return Some(Msg::AppClose),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }
@@ -209,7 +209,7 @@ impl AppComponent<Msg, NoUserEvent> for RadioBeta {
             } => self.perform(Cmd::Submit),
             KeyEvent { code: Key::Tab, .. } => return Some(Msg::RadioBetaBlur),
             KeyEvent { code: Key::Esc, .. } => return Some(Msg::AppClose),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }

--- a/crates/tuirealm-stdlib/examples/select.rs
+++ b/crates/tuirealm-stdlib/examples/select.rs
@@ -169,7 +169,7 @@ impl AppComponent<Msg, NoUserEvent> for SelectAlfa {
             } => self.perform(Cmd::Cancel),
             KeyEvent { code: Key::Tab, .. } => return Some(Msg::SelectAlfaBlur),
             KeyEvent { code: Key::Esc, .. } => return Some(Msg::AppClose),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }
@@ -221,7 +221,7 @@ impl AppComponent<Msg, NoUserEvent> for SelectBeta {
             } => self.perform(Cmd::Cancel),
             KeyEvent { code: Key::Tab, .. } => return Some(Msg::SelectBetaBlur),
             KeyEvent { code: Key::Esc, .. } => return Some(Msg::AppClose),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }

--- a/crates/tuirealm-stdlib/examples/span.rs
+++ b/crates/tuirealm-stdlib/examples/span.rs
@@ -123,7 +123,7 @@ impl AppComponent<Msg, NoUserEvent> for SpanAlfa {
     fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         match ev {
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }
@@ -154,7 +154,7 @@ impl AppComponent<Msg, NoUserEvent> for SpanBeta {
     fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         match ev {
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }

--- a/crates/tuirealm-stdlib/examples/sparkline.rs
+++ b/crates/tuirealm-stdlib/examples/sparkline.rs
@@ -149,9 +149,9 @@ impl AppComponent<Msg, UserEvent> for SparklineAlfa {
                     Attribute::Dataset,
                     AttrValue::Payload(PropPayload::Vec(data)),
                 );
-                CmdResult::None
+                CmdResult::NoChange
             }
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }

--- a/crates/tuirealm-stdlib/examples/spinner.rs
+++ b/crates/tuirealm-stdlib/examples/spinner.rs
@@ -143,7 +143,7 @@ impl AppComponent<Msg, NoUserEvent> for SpanAlfa {
     fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         match ev {
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }
@@ -179,7 +179,7 @@ impl AppComponent<Msg, NoUserEvent> for SpanBeta {
     fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         match ev {
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }

--- a/crates/tuirealm-stdlib/examples/table.rs
+++ b/crates/tuirealm-stdlib/examples/table.rs
@@ -189,7 +189,7 @@ impl AppComponent<Msg, NoUserEvent> for TableAlfa {
             KeyEvent { code: Key::End, .. } => self.perform(Cmd::GoTo(Position::End)),
             KeyEvent { code: Key::Tab, .. } => return Some(Msg::TableAlfaBlur),
             KeyEvent { code: Key::Esc, .. } => return Some(Msg::AppClose),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }
@@ -262,7 +262,7 @@ impl AppComponent<Msg, NoUserEvent> for TableBeta {
         match ev.as_keyboard()? {
             KeyEvent { code: Key::Tab, .. } => return Some(Msg::TableBetaBlur),
             KeyEvent { code: Key::Esc, .. } => return Some(Msg::AppClose),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }

--- a/crates/tuirealm-stdlib/examples/textarea.rs
+++ b/crates/tuirealm-stdlib/examples/textarea.rs
@@ -175,7 +175,7 @@ impl AppComponent<Msg, NoUserEvent> for TextareaAlfa {
             KeyEvent { code: Key::End, .. } => self.perform(Cmd::GoTo(Position::End)),
             KeyEvent { code: Key::Tab, .. } => return Some(Msg::TextareaAlfaBlur),
             KeyEvent { code: Key::Esc, .. } => return Some(Msg::AppClose),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }
@@ -240,7 +240,7 @@ impl AppComponent<Msg, NoUserEvent> for TextareaBeta {
             KeyEvent { code: Key::End, .. } => self.perform(Cmd::GoTo(Position::End)),
             KeyEvent { code: Key::Tab, .. } => return Some(Msg::TextareaBetaBlur),
             KeyEvent { code: Key::Esc, .. } => return Some(Msg::AppClose),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }

--- a/crates/tuirealm-stdlib/src/components/bar_chart.rs
+++ b/crates/tuirealm-stdlib/src/components/bar_chart.rs
@@ -338,7 +338,7 @@ impl Component for BarChart {
             }
             return CmdResult::Visual;
         }
-        CmdResult::None
+        CmdResult::NoChange
     }
 
     fn state(&self) -> State {

--- a/crates/tuirealm-stdlib/src/components/bar_chart.rs
+++ b/crates/tuirealm-stdlib/src/components/bar_chart.rs
@@ -124,9 +124,9 @@ impl BarChart {
         self
     }
 
-    /// Set the inactive style for the whole component
+    /// Set a custom style for the border when the component is unfocused.
     pub fn inactive(mut self, s: Style) -> Self {
-        self.attr(Attribute::FocusStyle, AttrValue::Style(s));
+        self.attr(Attribute::UnfocusedBorderStyle, AttrValue::Style(s));
         self
     }
 

--- a/crates/tuirealm-stdlib/src/components/canvas.rs
+++ b/crates/tuirealm-stdlib/src/components/canvas.rs
@@ -63,7 +63,7 @@ impl Canvas {
 
     /// Set a custom style for the border when the component is unfocused.
     pub fn inactive(mut self, s: Style) -> Self {
-        self.attr(Attribute::FocusStyle, AttrValue::Style(s));
+        self.attr(Attribute::UnfocusedBorderStyle, AttrValue::Style(s));
         self
     }
 

--- a/crates/tuirealm-stdlib/src/components/chart/chart.rs
+++ b/crates/tuirealm-stdlib/src/components/chart/chart.rs
@@ -125,9 +125,10 @@ impl Chart {
         self
     }
 
-    /// Set the inactive style for the whole component
+    /// Set a custom style for the border when the component is unfocused.
     pub fn inactive(mut self, s: Style) -> Self {
-        self.props.set(Attribute::FocusStyle, AttrValue::Style(s));
+        self.props
+            .set(Attribute::UnfocusedBorderStyle, AttrValue::Style(s));
         self
     }
 

--- a/crates/tuirealm-stdlib/src/components/chart/chart.rs
+++ b/crates/tuirealm-stdlib/src/components/chart/chart.rs
@@ -409,7 +409,7 @@ impl Component for Chart {
             }
             return CmdResult::Visual;
         }
-        CmdResult::None
+        CmdResult::NoChange
     }
 
     fn state(&self) -> State {

--- a/crates/tuirealm-stdlib/src/components/checkbox.rs
+++ b/crates/tuirealm-stdlib/src/components/checkbox.rs
@@ -153,7 +153,7 @@ impl Checkbox {
 
     /// Set a custom style for the border when the component is unfocused.
     pub fn inactive(mut self, s: Style) -> Self {
-        self.attr(Attribute::FocusStyle, AttrValue::Style(s));
+        self.attr(Attribute::UnfocusedBorderStyle, AttrValue::Style(s));
         self
     }
 

--- a/crates/tuirealm-stdlib/src/components/container.rs
+++ b/crates/tuirealm-stdlib/src/components/container.rs
@@ -69,7 +69,7 @@ impl Container {
 
     /// Set a custom style for the border when the component is unfocused.
     pub fn inactive(mut self, s: Style) -> Self {
-        self.attr(Attribute::FocusStyle, AttrValue::Style(s));
+        self.attr(Attribute::UnfocusedBorderStyle, AttrValue::Style(s));
         self
     }
 

--- a/crates/tuirealm-stdlib/src/components/gauge.rs
+++ b/crates/tuirealm-stdlib/src/components/gauge.rs
@@ -56,7 +56,7 @@ impl Gauge {
 
     /// Set a custom style for the border when the component is unfocused.
     pub fn inactive(mut self, s: Style) -> Self {
-        self.attr(Attribute::FocusStyle, AttrValue::Style(s));
+        self.attr(Attribute::UnfocusedBorderStyle, AttrValue::Style(s));
         self
     }
 

--- a/crates/tuirealm-stdlib/src/components/input.rs
+++ b/crates/tuirealm-stdlib/src/components/input.rs
@@ -221,7 +221,7 @@ impl Input {
 
     /// Set a custom style for the border when the component is unfocused.
     pub fn inactive(mut self, s: Style) -> Self {
-        self.attr(Attribute::FocusStyle, AttrValue::Style(s));
+        self.attr(Attribute::UnfocusedBorderStyle, AttrValue::Style(s));
         self
     }
 

--- a/crates/tuirealm-stdlib/src/components/input.rs
+++ b/crates/tuirealm-stdlib/src/components/input.rs
@@ -444,7 +444,7 @@ impl Component for Input {
                 let prev_input = self.states.input.clone();
                 self.states.backspace();
                 if prev_input == self.states.input {
-                    CmdResult::None
+                    CmdResult::NoChange
                 } else {
                     CmdResult::Changed(self.state())
                 }
@@ -454,7 +454,7 @@ impl Component for Input {
                 let prev_input = self.states.input.clone();
                 self.states.delete();
                 if prev_input == self.states.input {
-                    CmdResult::None
+                    CmdResult::NoChange
                 } else {
                     CmdResult::Changed(self.state())
                 }
@@ -483,7 +483,7 @@ impl Component for Input {
                     .append(ch, &self.get_input_type().clone(), self.get_input_len());
                 // Message on change
                 if prev_input == self.states.input {
-                    CmdResult::None
+                    CmdResult::NoChange
                 } else {
                     CmdResult::Changed(self.state())
                 }
@@ -571,7 +571,7 @@ mod tests {
         );
         assert_eq!(component.states.cursor, 5);
         // Verify max length (shouldn't push any character)
-        assert_eq!(component.perform(Cmd::Type('a')), CmdResult::None);
+        assert_eq!(component.perform(Cmd::Type('a')), CmdResult::NoChange);
         assert_eq!(
             component.state(),
             State::Single(StateValue::String(String::from("home/")))
@@ -605,14 +605,14 @@ mod tests {
         );
         assert_eq!(component.states.cursor, 0);
         // Another one...
-        assert_eq!(component.perform(Cmd::Delete), CmdResult::None);
+        assert_eq!(component.perform(Cmd::Delete), CmdResult::NoChange);
         assert_eq!(
             component.state(),
             State::Single(StateValue::String(String::new()))
         );
         assert_eq!(component.states.cursor, 0);
         // See del behaviour here
-        assert_eq!(component.perform(Cmd::Cancel), CmdResult::None);
+        assert_eq!(component.perform(Cmd::Cancel), CmdResult::NoChange);
         assert_eq!(
             component.state(),
             State::Single(StateValue::String(String::new()))
@@ -631,7 +631,7 @@ mod tests {
         );
         assert_eq!(component.states.cursor, 1);
         // Another one (should do nothing)
-        assert_eq!(component.perform(Cmd::Cancel), CmdResult::None);
+        assert_eq!(component.perform(Cmd::Cancel), CmdResult::NoChange);
         assert_eq!(
             component.state(),
             State::Single(StateValue::String(String::from("h")))

--- a/crates/tuirealm-stdlib/src/components/line_gauge.rs
+++ b/crates/tuirealm-stdlib/src/components/line_gauge.rs
@@ -57,7 +57,7 @@ impl LineGauge {
 
     /// Set a custom style for the border when the component is unfocused.
     pub fn inactive(mut self, s: Style) -> Self {
-        self.attr(Attribute::FocusStyle, AttrValue::Style(s));
+        self.attr(Attribute::UnfocusedBorderStyle, AttrValue::Style(s));
         self
     }
 

--- a/crates/tuirealm-stdlib/src/components/list.rs
+++ b/crates/tuirealm-stdlib/src/components/list.rs
@@ -135,7 +135,7 @@ impl List {
 
     /// Set a custom style for the border when the component is unfocused.
     pub fn inactive(mut self, s: Style) -> Self {
-        self.attr(Attribute::FocusStyle, AttrValue::Style(s));
+        self.attr(Attribute::UnfocusedBorderStyle, AttrValue::Style(s));
         self
     }
 

--- a/crates/tuirealm-stdlib/src/components/list.rs
+++ b/crates/tuirealm-stdlib/src/components/list.rs
@@ -341,7 +341,7 @@ impl Component for List {
                 let prev = self.states.list_index;
                 self.states.incr_list_index(self.rewindable());
                 if prev == self.states.list_index {
-                    CmdResult::None
+                    CmdResult::NoChange
                 } else {
                     CmdResult::Changed(self.state())
                 }
@@ -350,7 +350,7 @@ impl Component for List {
                 let prev = self.states.list_index;
                 self.states.decr_list_index(self.rewindable());
                 if prev == self.states.list_index {
-                    CmdResult::None
+                    CmdResult::NoChange
                 } else {
                     CmdResult::Changed(self.state())
                 }
@@ -365,7 +365,7 @@ impl Component for List {
                 let step: usize = self.states.calc_max_step_ahead(step);
                 (0..step).for_each(|_| self.states.incr_list_index(false));
                 if prev == self.states.list_index {
-                    CmdResult::None
+                    CmdResult::NoChange
                 } else {
                     CmdResult::Changed(self.state())
                 }
@@ -380,7 +380,7 @@ impl Component for List {
                 let step: usize = self.states.calc_max_step_behind(step);
                 (0..step).for_each(|_| self.states.decr_list_index(false));
                 if prev == self.states.list_index {
-                    CmdResult::None
+                    CmdResult::NoChange
                 } else {
                     CmdResult::Changed(self.state())
                 }
@@ -389,7 +389,7 @@ impl Component for List {
                 let prev = self.states.list_index;
                 self.states.list_index_at_first();
                 if prev == self.states.list_index {
-                    CmdResult::None
+                    CmdResult::NoChange
                 } else {
                     CmdResult::Changed(self.state())
                 }
@@ -398,7 +398,7 @@ impl Component for List {
                 let prev = self.states.list_index;
                 self.states.list_index_at_last();
                 if prev == self.states.list_index {
-                    CmdResult::None
+                    CmdResult::NoChange
                 } else {
                     CmdResult::Changed(self.state())
                 }

--- a/crates/tuirealm-stdlib/src/components/radio.rs
+++ b/crates/tuirealm-stdlib/src/components/radio.rs
@@ -132,7 +132,7 @@ impl Radio {
 
     /// Set a custom style for the border when the component is unfocused.
     pub fn inactive(mut self, s: Style) -> Self {
-        self.attr(Attribute::FocusStyle, AttrValue::Style(s));
+        self.attr(Attribute::UnfocusedBorderStyle, AttrValue::Style(s));
         self
     }
 

--- a/crates/tuirealm-stdlib/src/components/select.rs
+++ b/crates/tuirealm-stdlib/src/components/select.rs
@@ -359,7 +359,7 @@ impl Component for Select {
                 if self.states.is_tab_open() {
                     CmdResult::Changed(State::Single(StateValue::Usize(self.states.selected)))
                 } else {
-                    CmdResult::None
+                    CmdResult::NoChange
                 }
             }
             Cmd::Move(Direction::Up) => {
@@ -369,7 +369,7 @@ impl Component for Select {
                 if self.states.is_tab_open() {
                     CmdResult::Changed(State::Single(StateValue::Usize(self.states.selected)))
                 } else {
-                    CmdResult::None
+                    CmdResult::NoChange
                 }
             }
             Cmd::Cancel => {
@@ -553,9 +553,12 @@ mod test {
         assert_eq!(component.states.is_tab_open(), false);
         assert_eq!(
             component.perform(Cmd::Move(Direction::Down)),
-            CmdResult::None
+            CmdResult::NoChange
         );
-        assert_eq!(component.perform(Cmd::Move(Direction::Up)), CmdResult::None);
+        assert_eq!(
+            component.perform(Cmd::Move(Direction::Up)),
+            CmdResult::NoChange
+        );
     }
 
     #[test]

--- a/crates/tuirealm-stdlib/src/components/select.rs
+++ b/crates/tuirealm-stdlib/src/components/select.rs
@@ -142,7 +142,7 @@ impl Select {
 
     /// Set a custom style for the border when the component is unfocused.
     pub fn inactive(mut self, s: Style) -> Self {
-        self.attr(Attribute::FocusStyle, AttrValue::Style(s));
+        self.attr(Attribute::UnfocusedBorderStyle, AttrValue::Style(s));
         self
     }
 

--- a/crates/tuirealm-stdlib/src/components/sparkline.rs
+++ b/crates/tuirealm-stdlib/src/components/sparkline.rs
@@ -49,7 +49,7 @@ impl Sparkline {
 
     /// Set a custom style for the border when the component is unfocused.
     pub fn inactive(mut self, s: Style) -> Self {
-        self.attr(Attribute::FocusStyle, AttrValue::Style(s));
+        self.attr(Attribute::UnfocusedBorderStyle, AttrValue::Style(s));
         self
     }
 

--- a/crates/tuirealm-stdlib/src/components/table.rs
+++ b/crates/tuirealm-stdlib/src/components/table.rs
@@ -139,7 +139,7 @@ impl Table {
 
     /// Set a custom style for the border when the component is unfocused.
     pub fn inactive(mut self, s: Style) -> Self {
-        self.attr(Attribute::FocusStyle, AttrValue::Style(s));
+        self.attr(Attribute::UnfocusedBorderStyle, AttrValue::Style(s));
         self
     }
 

--- a/crates/tuirealm-stdlib/src/components/table.rs
+++ b/crates/tuirealm-stdlib/src/components/table.rs
@@ -456,7 +456,7 @@ impl Component for Table {
                 let prev = self.states.list_index;
                 self.states.incr_list_index(self.rewindable());
                 if prev == self.states.list_index {
-                    CmdResult::None
+                    CmdResult::NoChange
                 } else {
                     CmdResult::Changed(self.state())
                 }
@@ -465,7 +465,7 @@ impl Component for Table {
                 let prev = self.states.list_index;
                 self.states.decr_list_index(self.rewindable());
                 if prev == self.states.list_index {
-                    CmdResult::None
+                    CmdResult::NoChange
                 } else {
                     CmdResult::Changed(self.state())
                 }
@@ -480,7 +480,7 @@ impl Component for Table {
                 let step: usize = self.states.calc_max_step_ahead(step);
                 (0..step).for_each(|_| self.states.incr_list_index(false));
                 if prev == self.states.list_index {
-                    CmdResult::None
+                    CmdResult::NoChange
                 } else {
                     CmdResult::Changed(self.state())
                 }
@@ -495,7 +495,7 @@ impl Component for Table {
                 let step: usize = self.states.calc_max_step_behind(step);
                 (0..step).for_each(|_| self.states.decr_list_index(false));
                 if prev == self.states.list_index {
-                    CmdResult::None
+                    CmdResult::NoChange
                 } else {
                     CmdResult::Changed(self.state())
                 }
@@ -504,7 +504,7 @@ impl Component for Table {
                 let prev = self.states.list_index;
                 self.states.list_index_at_first();
                 if prev == self.states.list_index {
-                    CmdResult::None
+                    CmdResult::NoChange
                 } else {
                     CmdResult::Changed(self.state())
                 }
@@ -513,7 +513,7 @@ impl Component for Table {
                 let prev = self.states.list_index;
                 self.states.list_index_at_last();
                 if prev == self.states.list_index {
-                    CmdResult::None
+                    CmdResult::NoChange
                 } else {
                     CmdResult::Changed(self.state())
                 }

--- a/crates/tuirealm-stdlib/src/components/textarea.rs
+++ b/crates/tuirealm-stdlib/src/components/textarea.rs
@@ -308,7 +308,7 @@ impl Component for Textarea {
         if prev != self.states.list_index {
             CmdResult::Changed(self.state())
         } else {
-            CmdResult::None
+            CmdResult::NoChange
         }
     }
 }
@@ -396,7 +396,7 @@ mod tests {
         // No-op when already at beginning
         assert_eq!(
             component.perform(Cmd::GoTo(Position::Begin)),
-            CmdResult::None
+            CmdResult::NoChange
         );
         // Unhandled command
         assert_eq!(

--- a/crates/tuirealm-stdlib/src/components/textarea.rs
+++ b/crates/tuirealm-stdlib/src/components/textarea.rs
@@ -131,7 +131,7 @@ impl Textarea {
 
     /// Set a custom style for the border when the component is unfocused.
     pub fn inactive(mut self, s: Style) -> Self {
-        self.attr(Attribute::FocusStyle, AttrValue::Style(s));
+        self.attr(Attribute::UnfocusedBorderStyle, AttrValue::Style(s));
         self
     }
 

--- a/crates/tuirealm-stdlib/src/prop_ext.rs
+++ b/crates/tuirealm-stdlib/src/prop_ext.rs
@@ -54,7 +54,9 @@ impl CommonProps {
             (Attribute::Style, AttrValue::Style(val)) => self.style = val,
             (Attribute::Foreground, AttrValue::Color(val)) => self.style = self.style.fg(val),
             (Attribute::Background, AttrValue::Color(val)) => self.style = self.style.bg(val),
-            (Attribute::FocusStyle, AttrValue::Style(val)) => self.border_unfocused_style = val,
+            (Attribute::UnfocusedBorderStyle, AttrValue::Style(val)) => {
+                self.border_unfocused_style = val
+            }
             (Attribute::TextProps, AttrValue::TextModifiers(val)) => {
                 self.style = self.style.add_modifier(val)
             }
@@ -82,7 +84,7 @@ impl CommonProps {
             Attribute::Style => Some(AttrValue::Style(self.style)),
             Attribute::Foreground => self.style.fg.map(AttrValue::Color),
             Attribute::Background => self.style.bg.map(AttrValue::Color),
-            Attribute::FocusStyle => Some(AttrValue::Style(self.border_unfocused_style)),
+            Attribute::UnfocusedBorderStyle => Some(AttrValue::Style(self.border_unfocused_style)),
             Attribute::TextProps => Some(AttrValue::TextModifiers(self.style.add_modifier)),
 
             // handle flags
@@ -106,7 +108,9 @@ impl CommonProps {
             Attribute::Style => Some(AttrValueRef::Style(self.style)),
             Attribute::Foreground => self.style.fg.map(AttrValueRef::Color),
             Attribute::Background => self.style.bg.map(AttrValueRef::Color),
-            Attribute::FocusStyle => Some(AttrValueRef::Style(self.border_unfocused_style)),
+            Attribute::UnfocusedBorderStyle => {
+                Some(AttrValueRef::Style(self.border_unfocused_style))
+            }
             Attribute::TextProps => Some(AttrValueRef::TextModifiers(self.style.add_modifier)),
 
             // handle flags
@@ -168,7 +172,10 @@ mod tests {
             Style::new()
         );
         assert_eq!(
-            props.get(Attribute::FocusStyle).unwrap().unwrap_style(),
+            props
+                .get(Attribute::UnfocusedBorderStyle)
+                .unwrap()
+                .unwrap_style(),
             Style::new()
         );
         assert!(props.get(Attribute::Foreground).is_none());
@@ -260,12 +267,15 @@ mod tests {
 
         // focus style
         props.set(
-            Attribute::FocusStyle,
+            Attribute::UnfocusedBorderStyle,
             AttrValue::Style(Style::new().add_modifier(TextModifiers::REVERSED)),
         );
 
         assert_eq!(
-            props.get(Attribute::FocusStyle).unwrap().unwrap_style(),
+            props
+                .get(Attribute::UnfocusedBorderStyle)
+                .unwrap()
+                .unwrap_style(),
             Style::new().add_modifier(TextModifiers::REVERSED)
         );
 
@@ -386,7 +396,10 @@ mod tests {
                     .position(TitlePosition::Bottom),
             ),
         );
-        props.set(Attribute::FocusStyle, AttrValue::Style(Style::new().gray()));
+        props.set(
+            Attribute::UnfocusedBorderStyle,
+            AttrValue::Style(Style::new().gray()),
+        );
         props.set(Attribute::AlwaysActive, AttrValue::Flag(true));
 
         let block = props.get_block().unwrap();

--- a/crates/tuirealm-stdlib/src/prop_ext.rs
+++ b/crates/tuirealm-stdlib/src/prop_ext.rs
@@ -78,31 +78,7 @@ impl CommonProps {
     }
 
     /// Try to get a given [`Attribute`].
-    pub fn get(&self, attr: Attribute) -> Option<AttrValue> {
-        match attr {
-            // handle style attributes
-            Attribute::Style => Some(AttrValue::Style(self.style)),
-            Attribute::Foreground => self.style.fg.map(AttrValue::Color),
-            Attribute::Background => self.style.bg.map(AttrValue::Color),
-            Attribute::UnfocusedBorderStyle => Some(AttrValue::Style(self.border_unfocused_style)),
-            Attribute::TextProps => Some(AttrValue::TextModifiers(self.style.add_modifier)),
-
-            // handle flags
-            Attribute::Display => Some(AttrValue::Flag(self.display)),
-            Attribute::Focus => Some(AttrValue::Flag(self.focused)),
-            Attribute::AlwaysActive => Some(AttrValue::Flag(self.always_active)),
-
-            // handle borders & titles
-            Attribute::Borders => self.border.map(AttrValue::Borders),
-            Attribute::Title => self.title.clone().map(AttrValue::Title),
-
-            // other
-            _ => None,
-        }
-    }
-
-    /// Try to get a given [`Attribute`] as a type compatible with [`Component::query`](tuirealm::component::Component::query).
-    pub fn get_for_query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+    pub fn get<'a>(&'a self, attr: Attribute) -> Option<AttrValueRef<'a>> {
         match attr {
             // handle style attributes
             Attribute::Style => Some(AttrValueRef::Style(self.style)),
@@ -125,7 +101,12 @@ impl CommonProps {
             // other
             _ => None,
         }
-        .map(QueryResult::Borrowed)
+    }
+
+    /// Try to get a given [`Attribute`] as a type compatible with [`Component::query`](tuirealm::component::Component::query).
+    #[inline]
+    pub fn get_for_query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+        self.get(attr).map(QueryResult::Borrowed)
     }
 
     /// Get a [`Block`] with the configuration from the common props, if `borders` are defined.
@@ -319,7 +300,7 @@ mod tests {
         );
         assert_eq!(
             props.get(Attribute::Title).unwrap().unwrap_title(),
-            Title::default()
+            &Title::default()
                 .content("Hello".into())
                 .alignment(HorizontalAlignment::Center)
                 .position(TitlePosition::Bottom)

--- a/crates/tuirealm-stdlib/tests/component_bar_chart.rs
+++ b/crates/tuirealm-stdlib/tests/component_bar_chart.rs
@@ -46,7 +46,7 @@ fn test_bar_chart_disabled() {
         .data(&[("Q1", 100), ("Q2", 200)]);
     assert_eq!(
         component.perform(Cmd::Move(Direction::Right)),
-        CmdResult::None
+        CmdResult::NoChange
     );
 }
 

--- a/crates/tuirealm-stdlib/tests/component_chart.rs
+++ b/crates/tuirealm-stdlib/tests/component_chart.rs
@@ -51,7 +51,7 @@ fn test_chart_disabled() {
     let mut component = Chart::default().disabled(true).data([make_dataset()]);
     assert_eq!(
         component.perform(Cmd::Move(Direction::Right)),
-        CmdResult::None
+        CmdResult::NoChange
     );
 }
 

--- a/crates/tuirealm-stdlib/tests/component_input.rs
+++ b/crates/tuirealm-stdlib/tests/component_input.rs
@@ -57,7 +57,7 @@ fn test_input_delete_backspace() {
 fn test_input_delete_on_empty() {
     let mut component = Input::default().input_type(InputType::Text);
     let result = component.perform(Cmd::Delete);
-    assert_eq!(result, CmdResult::None);
+    assert_eq!(result, CmdResult::NoChange);
 }
 
 #[test]
@@ -112,7 +112,7 @@ fn test_input_with_max_length() {
         .value("ab");
     component.perform(Cmd::Type('c'));
     let result = component.perform(Cmd::Type('d'));
-    assert_eq!(result, CmdResult::None);
+    assert_eq!(result, CmdResult::NoChange);
     assert_eq!(
         component.state(),
         State::Single(StateValue::String("abc".to_string()))

--- a/crates/tuirealm-stdlib/tests/component_list.rs
+++ b/crates/tuirealm-stdlib/tests/component_list.rs
@@ -43,7 +43,7 @@ fn test_list_move_up_at_top() {
         .rewind(false)
         .rows(vec![Line::from("A"), Line::from("B")]);
     let result = component.perform(Cmd::Move(Direction::Up));
-    assert_eq!(result, CmdResult::None);
+    assert_eq!(result, CmdResult::NoChange);
 }
 
 #[test]
@@ -54,7 +54,7 @@ fn test_list_move_down_at_bottom_no_rewind() {
         .rows(vec![Line::from("A"), Line::from("B")])
         .selected_line(1);
     let result = component.perform(Cmd::Move(Direction::Down));
-    assert_eq!(result, CmdResult::None);
+    assert_eq!(result, CmdResult::NoChange);
 }
 
 #[test]

--- a/crates/tuirealm-stdlib/tests/component_table.rs
+++ b/crates/tuirealm-stdlib/tests/component_table.rs
@@ -54,7 +54,7 @@ fn test_table_move_up_at_top() {
         .widths(&[20, 10])
         .table(make_table_data());
     let result = component.perform(Cmd::Move(Direction::Up));
-    assert_eq!(result, CmdResult::None);
+    assert_eq!(result, CmdResult::NoChange);
 }
 
 #[test]

--- a/crates/tuirealm-stdlib/tests/component_textarea.rs
+++ b/crates/tuirealm-stdlib/tests/component_textarea.rs
@@ -33,7 +33,7 @@ fn test_textarea_move_down() {
 fn test_textarea_move_up_at_top() {
     let mut component = Textarea::default().text_rows([Span::from("A"), Span::from("B")]);
     let result = component.perform(Cmd::Move(Direction::Up));
-    assert_eq!(result, CmdResult::None);
+    assert_eq!(result, CmdResult::NoChange);
 }
 
 #[test]
@@ -41,7 +41,7 @@ fn test_textarea_move_down_at_bottom() {
     let mut component = Textarea::default().text_rows([Span::from("A"), Span::from("B")]);
     component.perform(Cmd::Move(Direction::Down));
     let result = component.perform(Cmd::Move(Direction::Down));
-    assert_eq!(result, CmdResult::None);
+    assert_eq!(result, CmdResult::NoChange);
 }
 
 #[test]

--- a/crates/tuirealm-textarea/examples/editor.rs
+++ b/crates/tuirealm-textarea/examples/editor.rs
@@ -390,7 +390,7 @@ impl AppComponent<Msg, NoUserEvent> for Editor {
             _ => return None,
         };
 
-        if matches!(result, CmdResult::None | CmdResult::Invalid(_)) {
+        if matches!(result, CmdResult::NoChange | CmdResult::Invalid(_)) {
             None
         } else {
             Some(Msg::Redraw)
@@ -471,13 +471,13 @@ impl AppComponent<Msg, NoUserEvent> for Search {
                 {
                     return Some(Msg::Search(pattern));
                 }
-                CmdResult::None
+                CmdResult::NoChange
             }
             KeyEvent { code: Key::Tab, .. } => {
                 return Some(Msg::ChangeFocus(Id::Editor));
             }
             KeyEvent { code: Key::Esc, .. } => return Some(Msg::AppClose),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         };
         Some(Msg::Redraw)
     }

--- a/crates/tuirealm-textarea/examples/single_line.rs
+++ b/crates/tuirealm-textarea/examples/single_line.rs
@@ -279,7 +279,7 @@ impl AppComponent<Msg, NoUserEvent> for Input {
             _ => return None,
         };
 
-        if matches!(result, CmdResult::None | CmdResult::Invalid(_)) {
+        if matches!(result, CmdResult::NoChange | CmdResult::Invalid(_)) {
             None
         } else {
             Some(Msg::Redraw)

--- a/crates/tuirealm-textarea/src/lib.rs
+++ b/crates/tuirealm-textarea/src/lib.rs
@@ -414,7 +414,7 @@ impl<'a> TextArea<'a> {
         let prev = self.widget.cursor();
         self.widget.move_cursor(to);
         if prev == self.widget.cursor() {
-            CmdResult::None
+            CmdResult::NoChange
         } else {
             CmdResult::Visual
         }
@@ -653,9 +653,9 @@ impl Component for TextArea<'_> {
                         .get(Attribute::ScrollStep)
                         .and_then(AttrValue::as_length)
                         .unwrap_or(8);
-                    let mut res = CmdResult::None;
+                    let mut res = CmdResult::NoChange;
                     (0..step).for_each(|_| match self.move_cursor(CursorMove::Down) {
-                        CmdResult::None => (),
+                        CmdResult::NoChange => (),
                         v => res = v,
                     });
                     return res;
@@ -668,9 +668,9 @@ impl Component for TextArea<'_> {
                         .get(Attribute::ScrollStep)
                         .and_then(AttrValue::as_length)
                         .unwrap_or(8);
-                    let mut res = CmdResult::None;
+                    let mut res = CmdResult::NoChange;
                     (0..step).for_each(|_| match self.move_cursor(CursorMove::Up) {
-                        CmdResult::None => (),
+                        CmdResult::NoChange => (),
                         v => res = v,
                     });
                     return res;
@@ -693,7 +693,7 @@ impl Component for TextArea<'_> {
         if prev_lines != self.widget.lines() {
             CmdResult::Changed(self.state())
         } else {
-            CmdResult::None
+            CmdResult::NoChange
         }
     }
 }
@@ -735,7 +735,7 @@ mod tests {
         let mut textarea = make_textarea();
         let result = textarea.perform(Cmd::Delete);
         assert!(
-            matches!(result, CmdResult::None),
+            matches!(result, CmdResult::NoChange),
             "deleting from an empty textarea should return None"
         );
     }
@@ -756,7 +756,7 @@ mod tests {
         let mut textarea = make_textarea();
         let result = textarea.perform(Cmd::Cancel);
         assert!(
-            matches!(result, CmdResult::None),
+            matches!(result, CmdResult::NoChange),
             "cancel (delete-next) on empty textarea should return None"
         );
     }

--- a/crates/tuirealm-textarea/src/lib.rs
+++ b/crates/tuirealm-textarea/src/lib.rs
@@ -225,9 +225,9 @@ impl<'a> TextArea<'a> {
         }
     }
 
-    /// Set another style from default to use when component is inactive
+    /// Set a custom style for the border when the component is unfocused.
     pub fn inactive(mut self, s: Style) -> Self {
-        self.attr(Attribute::FocusStyle, AttrValue::Style(s));
+        self.attr(Attribute::UnfocusedBorderStyle, AttrValue::Style(s));
         self
     }
 
@@ -384,7 +384,7 @@ impl<'a> TextArea<'a> {
         ) = self.query(Attribute::Borders)
         {
             let inactive_style = self
-                .query(Attribute::FocusStyle)
+                .query(Attribute::UnfocusedBorderStyle)
                 .as_ref()
                 .map(QueryResult::as_ref)
                 .and_then(AttrValueRef::as_style)

--- a/crates/tuirealm-treeview/src/lib.rs
+++ b/crates/tuirealm-treeview/src/lib.rs
@@ -291,9 +291,9 @@ impl<V: NodeValue> TreeView<V> {
         self
     }
 
-    /// Set another style from default to use when component is inactive
+    /// Set a custom style for the border when the component is unfocused.
     pub fn inactive(mut self, s: Style) -> Self {
-        self.attr(Attribute::FocusStyle, AttrValue::Style(s));
+        self.attr(Attribute::UnfocusedBorderStyle, AttrValue::Style(s));
         self
     }
 
@@ -439,7 +439,7 @@ impl<V: NodeValue> Component for TreeView<V> {
             .unwrap_or_default();
         let inactive_style = self
             .props
-            .get(Attribute::FocusStyle)
+            .get(Attribute::UnfocusedBorderStyle)
             .and_then(AttrValue::as_style);
         let indent_size = self
             .props

--- a/crates/tuirealm-treeview/src/lib.rs
+++ b/crates/tuirealm-treeview/src/lib.rs
@@ -395,9 +395,9 @@ impl<V: NodeValue> TreeView<V> {
     /// Returns whether selectd node has changed
     fn changed(&self, prev: Option<&str>) -> CmdResult {
         match self.states.selected() {
-            None => CmdResult::None,
+            None => CmdResult::NoChange,
             id if id != prev => CmdResult::Changed(self.state()),
-            _ => CmdResult::None,
+            _ => CmdResult::NoChange,
         }
     }
 }
@@ -624,7 +624,7 @@ mod test {
         // GoTo begin (unchanged)
         assert_eq!(
             component.perform(Cmd::GoTo(Position::Begin)),
-            CmdResult::None
+            CmdResult::NoChange
         );
     }
 
@@ -639,7 +639,10 @@ mod test {
             CmdResult::Changed(State::Single(StateValue::String(String::from("bB5"))))
         );
         // GoTo end (unchanged)
-        assert_eq!(component.perform(Cmd::GoTo(Position::End)), CmdResult::None);
+        assert_eq!(
+            component.perform(Cmd::GoTo(Position::End)),
+            CmdResult::NoChange
+        );
     }
 
     #[test]
@@ -655,7 +658,7 @@ mod test {
         // Move down (unchanged)
         assert_eq!(
             component.perform(Cmd::Move(Direction::Down)),
-            CmdResult::None
+            CmdResult::NoChange
         );
     }
 
@@ -668,7 +671,10 @@ mod test {
             CmdResult::Changed(State::Single(StateValue::String(String::from("/"))))
         );
         // Move up (unchanged)
-        assert_eq!(component.perform(Cmd::Move(Direction::Up)), CmdResult::None);
+        assert_eq!(
+            component.perform(Cmd::Move(Direction::Up)),
+            CmdResult::NoChange
+        );
     }
 
     #[test]
@@ -685,7 +691,7 @@ mod test {
         // Scroll down (unchanged)
         assert_eq!(
             component.perform(Cmd::Scroll(Direction::Down)),
-            CmdResult::None
+            CmdResult::NoChange
         );
     }
 
@@ -703,7 +709,7 @@ mod test {
         // Scroll Up (unchanged)
         assert_eq!(
             component.perform(Cmd::Scroll(Direction::Up)),
-            CmdResult::None
+            CmdResult::NoChange
         );
     }
 

--- a/crates/tuirealm-treeview/tests/component_treeview.rs
+++ b/crates/tuirealm-treeview/tests/component_treeview.rs
@@ -37,7 +37,7 @@ fn test_treeview_move_up_at_root() {
         .with_tree(mock_tree())
         .initial_node("/");
     let result = component.perform(Cmd::Move(Direction::Up));
-    assert_eq!(result, CmdResult::None);
+    assert_eq!(result, CmdResult::NoChange);
 }
 
 #[test]

--- a/crates/tuirealm/docs/en/migrating-4.0.md
+++ b/crates/tuirealm/docs/en/migrating-4.0.md
@@ -60,6 +60,10 @@ This also makes cloning explicit to the user.
 
 Due to `Props::get`(old) having been removed and to better align with STD types like `Vec::get`, `::get_ref` has been renamed to just `::get`.
 
+### Change `CommonProps::get` to return a reference
+
+To align with [`Props::get`](#rename-of-propsget_ref-to-propsget), `CommonProps::get` now also returns a reference.
+
 ### `Component::on` parameter `Event` is now a reference
 
 With 4.0, `Component::on`'s `Event` parameter is now a reference. This allowed us to remove clones in-between that had always been done

--- a/crates/tuirealm/docs/en/migrating-4.0.md
+++ b/crates/tuirealm/docs/en/migrating-4.0.md
@@ -183,3 +183,7 @@ This allowed the consumer to decide when a clone is actually necessary, for prac
 ### Rename `CmdResult::None` to `CmdResult::NoChange`
 
 `CmdResult` variant `None` has been renamed to `NoChange` to better represent what this variant does on a glance.
+
+### Rename `Attribute::FocusStyle` to `Attribute::UnfocusedBorderStyle`
+
+`Attribute` variant `FocusStyle` has been renamed to `UnfocusedBorderStyle` as that better represents what this attribute is doing on a glance.

--- a/crates/tuirealm/docs/en/migrating-4.0.md
+++ b/crates/tuirealm/docs/en/migrating-4.0.md
@@ -179,3 +179,7 @@ impl AppComponent<Msg, UserEvent> for MyWidget {
 
 `Component::query` has been changed to allow for and prefer borrowed content, but still allow owned content to be returned.
 This allowed the consumer to decide when a clone is actually necessary, for practically anything other than `PropPayload::Any`.
+
+### Rename `CmdResult::None` to `CmdResult::NoChange`
+
+`CmdResult` variant `None` has been renamed to `NoChange` to better represent what this variant does on a glance.

--- a/crates/tuirealm/src/core/command.rs
+++ b/crates/tuirealm/src/core/command.rs
@@ -73,7 +73,7 @@ pub enum CmdResult {
     Submit(State),
     /// The command issues is unsupported for this component.
     ///
-    /// This should basically be treated the same as [`None`](CmdResult::None), but may be useful for debugging.
+    /// This should basically be treated the same as [`NoChange`](CmdResult::NoChange), but may be useful for debugging.
     Invalid(Cmd),
     /// Custom result with a name and a state attached.
     Custom(&'static str, State),
@@ -84,5 +84,5 @@ pub enum CmdResult {
     /// If state *did* change, always use [`Changed`](CmdResult::Changed) instead.
     Visual,
     /// Nothing changed, nothing needs to be done.
-    None,
+    NoChange,
 }

--- a/crates/tuirealm/src/core/props/mod.rs
+++ b/crates/tuirealm/src/core/props/mod.rs
@@ -70,8 +70,8 @@ pub enum Attribute {
     /// view/application. When implementing a component, its value should be read-only.
     /// The value is always `AttrValue::Flag`
     Focus,
-    /// Should be used to use a different style from default when component is not enabled.
-    FocusStyle,
+    /// Recommended to be used as a style patch on top of [`Style`](Self::Style) to apply when the component is unfocused.
+    UnfocusedBorderStyle,
     /// Foreground color or style
     Foreground,
     /// Height size. Useful when building layouts or containers


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

Re #208

## Description

This PR renames:
- `CmdResult::None` to `CmdResult::NoChange`
- `Attribute::FocusStyle` to `Attribute::UnfocusedBorderStyle`

Additionally, while i noticed it again, i have changed `CommonProps::get` to return a reference and de-duplicate the getting code.

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
