### PR TITLE
Change `Treeview` to make use of `CommonProps`

### DIFF
--- a/crates/tuirealm-treeview/src/lib.rs
+++ b/crates/tuirealm-treeview/src/lib.rs
@@ -206,7 +206,7 @@ pub mod widget;
 use std::iter;
 
 pub use orange_trees::{Node as OrangeNode, Tree as OrangeTree};
-use tui_realm_stdlib::utils::get_block;
+use tui_realm_stdlib::prop_ext::CommonProps;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::component::Component;
 use tuirealm::props::{
@@ -261,6 +261,7 @@ pub const TREE_CMD_CLOSE: &str = "c";
 ///
 /// Tree view component for tui-realm
 pub struct TreeView<V: NodeValue> {
+    common: CommonProps,
     props: Props,
     states: TreeState,
     /// The actual Tree data structure. You can access this from your Component to operate on it
@@ -271,6 +272,7 @@ pub struct TreeView<V: NodeValue> {
 impl<V: NodeValue> Default for TreeView<V> {
     fn default() -> Self {
         Self {
+            common: CommonProps::default(),
             props: Props::default(),
             states: TreeState::default(),
             tree: Tree::new(Node::new(String::new(), V::default())),
@@ -404,43 +406,10 @@ impl<V: NodeValue> TreeView<V> {
 
 impl<V: NodeValue> Component for TreeView<V> {
     fn view(&mut self, frame: &mut Frame, area: Rect) {
-        if matches!(
-            self.props.get(Attribute::Display),
-            Some(AttrValue::Flag(false))
-        ) {
+        if !self.common.display {
             return;
         }
 
-        let foreground = self
-            .props
-            .get(Attribute::Foreground)
-            .and_then(AttrValue::as_color)
-            .unwrap_or(Color::Reset);
-        let background = self
-            .props
-            .get(Attribute::Background)
-            .and_then(AttrValue::as_color)
-            .unwrap_or(Color::Reset);
-        let modifiers = self
-            .props
-            .get(Attribute::TextProps)
-            .and_then(AttrValue::as_text_modifiers)
-            .unwrap_or_default();
-        let title = self.props.get(Attribute::Title).and_then(|v| v.as_title());
-        let borders = self
-            .props
-            .get(Attribute::Borders)
-            .and_then(AttrValue::as_borders)
-            .unwrap_or_default();
-        let focus = self
-            .props
-            .get(Attribute::Focus)
-            .and_then(AttrValue::as_flag)
-            .unwrap_or_default();
-        let inactive_style = self
-            .props
-            .get(Attribute::UnfocusedBorderStyle)
-            .and_then(AttrValue::as_style);
         let indent_size = self
             .props
             .get(Attribute::Custom(TREE_INDENT_SIZE))
@@ -449,37 +418,41 @@ impl<V: NodeValue> Component for TreeView<V> {
         let hg_color = self
             .props
             .get(Attribute::HighlightedColor)
-            .and_then(AttrValue::as_color)
-            .unwrap_or(foreground);
-        let hg_style = match focus {
-            true => Style::default().bg(hg_color).fg(Color::Black),
-            false => Style::default().fg(hg_color),
-        }
-        .add_modifier(modifiers);
+            .and_then(AttrValue::as_color);
         let hg_str = self
             .props
             .get(Attribute::HighlightedStr)
-            .and_then(|x| x.as_string());
-        let div = get_block(borders, title, focus, inactive_style);
+            .and_then(AttrValue::as_string);
+        let block = self.common.get_block();
+
         // Make widget
         let mut tree = TreeWidget::new(self.tree())
-            .block(div)
-            .highlight_style(hg_style)
             .indent_size(indent_size.into())
-            .style(
-                Style::default()
-                    .fg(foreground)
-                    .bg(background)
-                    .add_modifier(modifiers),
-            );
+            .style(self.common.style);
+
+        if let Some(hg_color) = hg_color {
+            let hg_style = match self.common.is_active() {
+                true => Style::default().bg(hg_color).fg(Color::Black),
+                false => Style::default().fg(hg_color),
+            };
+            tree = tree.highlight_style(hg_style);
+        }
+        if let Some(block) = block {
+            tree = tree.block(block);
+        }
         if let Some(hg_str) = hg_str {
             tree = tree.highlight_symbol(hg_str.as_str());
         }
+
         let mut state = self.states.clone();
         frame.render_stateful_widget(tree, area, &mut state);
     }
 
     fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+        if let Some(value) = self.common.get_for_query(attr) {
+            return Some(value);
+        }
+
         self.props.get_for_query(attr)
     }
 
@@ -490,7 +463,7 @@ impl<V: NodeValue> Component for TreeView<V> {
             if let Some(node) = self.tree.root().query(&value.unwrap_string()) {
                 self.states.select(self.tree.root(), node);
             }
-        } else {
+        } else if let Some(value) = self.common.set(attr, value) {
             self.props.set(attr, value);
         }
     }

--- a/crates/tuirealm-treeview/src/lib.rs
+++ b/crates/tuirealm-treeview/src/lib.rs
@@ -281,15 +281,29 @@ impl<V: NodeValue> Default for TreeView<V> {
 }
 
 impl<V: NodeValue> TreeView<V> {
-    /// Set widget foreground
+    /// Set the main foreground color. This may get overwritten by individual text styles.
     pub fn foreground(mut self, fg: Color) -> Self {
         self.attr(Attribute::Foreground, AttrValue::Color(fg));
         self
     }
 
-    /// Set widget background
+    /// Set the main background color. This may get overwritten by individual text styles.
     pub fn background(mut self, bg: Color) -> Self {
         self.attr(Attribute::Background, AttrValue::Color(bg));
+        self
+    }
+
+    /// Set the main text modifiers. This may get overwritten by individual text styles.
+    pub fn modifiers(mut self, m: TextModifiers) -> Self {
+        self.attr(Attribute::TextProps, AttrValue::TextModifiers(m));
+        self
+    }
+
+    /// Set the main style. This may get overwritten by individual text styles.
+    ///
+    /// This option will overwrite any previous [`foreground`](Self::foreground), [`background`](Self::background) and [`modifiers`](Self::modifiers)!
+    pub fn style(mut self, style: Style) -> Self {
+        self.attr(Attribute::Style, AttrValue::Style(style));
         self
     }
 
@@ -302,12 +316,6 @@ impl<V: NodeValue> TreeView<V> {
     /// Set widget border properties
     pub fn borders(mut self, b: Borders) -> Self {
         self.attr(Attribute::Borders, AttrValue::Borders(b));
-        self
-    }
-
-    /// Set widget text modifiers
-    pub fn modifiers(mut self, m: TextModifiers) -> Self {
-        self.attr(Attribute::TextProps, AttrValue::TextModifiers(m));
         self
     }
 

--- a/crates/tuirealm/docs/en/migrating-4.0.md
+++ b/crates/tuirealm/docs/en/migrating-4.0.md
@@ -60,10 +60,6 @@ This also makes cloning explicit to the user.
 
 Due to `Props::get`(old) having been removed and to better align with STD types like `Vec::get`, `::get_ref` has been renamed to just `::get`.
 
-### Change `CommonProps::get` to return a reference
-
-To align with [`Props::get`](#rename-of-propsget_ref-to-propsget), `CommonProps::get` now also returns a reference.
-
 ### `Component::on` parameter `Event` is now a reference
 
 With 4.0, `Component::on`'s `Event` parameter is now a reference. This allowed us to remove clones in-between that had always been done


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

No issue

## Description

This PR changes `Treeview` to make use of `CommonProps`, like all the other stdlib components.

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
