### PR TITLE
Remove `Attribute::HighlightColor`; Add `Attribute::HighlightStyle`

### DIFF
--- a/crates/tuirealm-stdlib/examples/container.rs
+++ b/crates/tuirealm-stdlib/examples/container.rs
@@ -127,7 +127,7 @@ impl Default for MyContainer {
                             )
                             .scroll(true)
                             .highlight_style(Style::new().fg(Color::LightYellow))
-                            .highlighted_str("🚀")
+                            .highlight_str("🚀")
                             .rewind(true)
                             .step(4)
                             .row_height(1)
@@ -180,7 +180,7 @@ impl Default for MyContainer {
                                     .alignment(HorizontalAlignment::Center),
                             )
                             .scroll(false)
-                            .highlighted_str(">> ")
+                            .highlight_str(">> ")
                             .row_height(1)
                             .headers(["Key", "Msg", "Description"])
                             .column_spacing(3)

--- a/crates/tuirealm-stdlib/examples/container.rs
+++ b/crates/tuirealm-stdlib/examples/container.rs
@@ -9,7 +9,7 @@ use tuirealm::command::CmdResult;
 use tuirealm::component::{AppComponent, Component};
 use tuirealm::event::{Event, Key, KeyEvent, NoUserEvent};
 use tuirealm::props::{
-    BorderType, Borders, Color, HorizontalAlignment, Layout, TableBuilder, Title,
+    BorderType, Borders, Color, HorizontalAlignment, Layout, Style, TableBuilder, Title,
 };
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout as TuiLayout};
 use tuirealm::ratatui::text::Line;
@@ -126,7 +126,7 @@ impl Default for MyContainer {
                                 Title::from("Keybindings").alignment(HorizontalAlignment::Center),
                             )
                             .scroll(true)
-                            .highlighted_color(Color::LightYellow)
+                            .highlight_style(Style::new().fg(Color::LightYellow))
                             .highlighted_str("🚀")
                             .rewind(true)
                             .step(4)
@@ -180,7 +180,6 @@ impl Default for MyContainer {
                                     .alignment(HorizontalAlignment::Center),
                             )
                             .scroll(false)
-                            .highlighted_color(Color::Green)
                             .highlighted_str(">> ")
                             .row_height(1)
                             .headers(["Key", "Msg", "Description"])

--- a/crates/tuirealm-stdlib/examples/list.rs
+++ b/crates/tuirealm-stdlib/examples/list.rs
@@ -126,7 +126,7 @@ impl Default for ListAlfa {
                 .title(Title::from("Lorem ipsum (scrollable)").alignment(HorizontalAlignment::Center))
                 .scroll(true)
                 .highlight_style(Style::new().fg(Color::LightYellow))
-                .highlighted_str("🚀")
+                .highlight_str("🚀")
                 .rewind(true)
                 .step(4)
                 .rows([

--- a/crates/tuirealm-stdlib/examples/list.rs
+++ b/crates/tuirealm-stdlib/examples/list.rs
@@ -8,7 +8,7 @@ use tuirealm::application::PollStrategy;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::component::{AppComponent, Component};
 use tuirealm::event::{Event, Key, KeyEvent, NoUserEvent};
-use tuirealm::props::{BorderType, Borders, Color, HorizontalAlignment, Title};
+use tuirealm::props::{BorderType, Borders, Color, HorizontalAlignment, Style, Title};
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
 use tuirealm::ratatui::style::Stylize;
 use tuirealm::ratatui::text::Span;
@@ -125,7 +125,7 @@ impl Default for ListAlfa {
                 )
                 .title(Title::from("Lorem ipsum (scrollable)").alignment(HorizontalAlignment::Center))
                 .scroll(true)
-                .highlighted_color(Color::LightYellow)
+                .highlight_style(Style::new().fg(Color::LightYellow))
                 .highlighted_str("🚀")
                 .rewind(true)
                 .step(4)

--- a/crates/tuirealm-stdlib/examples/radio.rs
+++ b/crates/tuirealm-stdlib/examples/radio.rs
@@ -8,7 +8,9 @@ use tuirealm::application::PollStrategy;
 use tuirealm::command::{Cmd, CmdResult, Direction};
 use tuirealm::component::{AppComponent, Component};
 use tuirealm::event::{Event, Key, KeyEvent, NoUserEvent};
-use tuirealm::props::{BorderType, Borders, Color, HorizontalAlignment, Title};
+use tuirealm::props::{
+    BorderType, Borders, Color, HorizontalAlignment, Style, TextModifiers, Title,
+};
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
 use tuirealm::terminal::TerminalAdapter;
 
@@ -231,6 +233,7 @@ impl Default for RadioCeta {
                 )
                 .foreground(Color::LightYellow)
                 .title(Title::from("Choice of the day").alignment(HorizontalAlignment::Center))
+                .highlight_style(Style::new().add_modifier(TextModifiers::UNDERLINED))
                 .rewind(false)
                 .choices([
                     "hazelnuts",

--- a/crates/tuirealm-stdlib/examples/select.rs
+++ b/crates/tuirealm-stdlib/examples/select.rs
@@ -8,7 +8,9 @@ use tuirealm::application::PollStrategy;
 use tuirealm::command::{Cmd, CmdResult, Direction};
 use tuirealm::component::{AppComponent, Component};
 use tuirealm::event::{Event, Key, KeyEvent, NoUserEvent};
-use tuirealm::props::{BorderType, Borders, Color, HorizontalAlignment, Title};
+use tuirealm::props::{
+    BorderType, Borders, Color, HorizontalAlignment, Style, TextModifiers, Title,
+};
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
 use tuirealm::state::State;
 use tuirealm::terminal::TerminalAdapter;
@@ -137,7 +139,8 @@ impl Default for SelectAlfa {
                         .alignment(HorizontalAlignment::Center),
                 )
                 .rewind(true)
-                .highlighted_color(Color::LightGreen)
+                // No need to set highlight style as the default is "REVERSED"
+                // .highlight_style(Style::new().add_modifier(TextModifiers::REVERSED))
                 .highlighted_str(">> ")
                 .choices([
                     "vanilla",
@@ -192,7 +195,8 @@ impl Default for SelectBeta {
                 .foreground(Color::LightYellow)
                 .title(Title::from("Select your topping 🧁").alignment(HorizontalAlignment::Center))
                 .rewind(false)
-                .highlighted_color(Color::LightYellow)
+                // Overwrite the default "REVERSED" style to be underlined instead
+                .highlight_style(Style::new().add_modifier(TextModifiers::UNDERLINED))
                 .highlighted_str(">> ")
                 .choices([
                     "hazelnuts",

--- a/crates/tuirealm-stdlib/examples/select.rs
+++ b/crates/tuirealm-stdlib/examples/select.rs
@@ -141,7 +141,7 @@ impl Default for SelectAlfa {
                 .rewind(true)
                 // No need to set highlight style as the default is "REVERSED"
                 // .highlight_style(Style::new().add_modifier(TextModifiers::REVERSED))
-                .highlighted_str(">> ")
+                .highlight_str(">> ")
                 .choices([
                     "vanilla",
                     "chocolate",
@@ -197,7 +197,7 @@ impl Default for SelectBeta {
                 .rewind(false)
                 // Overwrite the default "REVERSED" style to be underlined instead
                 .highlight_style(Style::new().add_modifier(TextModifiers::UNDERLINED))
-                .highlighted_str(">> ")
+                .highlight_str(">> ")
                 .choices([
                     "hazelnuts",
                     "chocolate",

--- a/crates/tuirealm-stdlib/examples/table.rs
+++ b/crates/tuirealm-stdlib/examples/table.rs
@@ -129,7 +129,7 @@ impl Default for TableAlfa {
                 .title(Title::from("Keybindings").alignment(HorizontalAlignment::Center))
                 .scroll(true)
                 .highlight_style(Style::new().fg(Color::LightYellow))
-                .highlighted_str("🚀")
+                .highlight_str("🚀")
                 .rewind(true)
                 .step(4)
                 .row_height(1)
@@ -218,7 +218,7 @@ impl Default for TableBeta {
                         .alignment(HorizontalAlignment::Center),
                 )
                 .scroll(false)
-                .highlighted_str(">> ")
+                .highlight_str(">> ")
                 .row_height(1)
                 .headers(["Key", "Msg", "Description"])
                 .column_spacing(3)

--- a/crates/tuirealm-stdlib/examples/table.rs
+++ b/crates/tuirealm-stdlib/examples/table.rs
@@ -8,7 +8,9 @@ use tuirealm::application::PollStrategy;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::component::{AppComponent, Component};
 use tuirealm::event::{Event, Key, KeyEvent, NoUserEvent};
-use tuirealm::props::{BorderType, Borders, Color, HorizontalAlignment, TableBuilder, Title};
+use tuirealm::props::{
+    BorderType, Borders, Color, HorizontalAlignment, Style, TableBuilder, Title,
+};
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
 use tuirealm::ratatui::text::Line;
 use tuirealm::terminal::TerminalAdapter;
@@ -126,7 +128,7 @@ impl Default for TableAlfa {
                 .background(Color::Black)
                 .title(Title::from("Keybindings").alignment(HorizontalAlignment::Center))
                 .scroll(true)
-                .highlighted_color(Color::LightYellow)
+                .highlight_style(Style::new().fg(Color::LightYellow))
                 .highlighted_str("🚀")
                 .rewind(true)
                 .step(4)
@@ -150,7 +152,7 @@ impl Default for TableAlfa {
                         .add_row()
                         .add_col(Line::from("KeyCode::PageUp"))
                         .add_col(Line::from("OnKey"))
-                        .add_col(Line::from("ove cursor up by 8"))
+                        .add_col(Line::from("Move cursor up by 8"))
                         .add_row()
                         .add_col(Line::from("KeyCode::End"))
                         .add_col(Line::from("OnKey"))
@@ -216,7 +218,6 @@ impl Default for TableBeta {
                         .alignment(HorizontalAlignment::Center),
                 )
                 .scroll(false)
-                .highlighted_color(Color::Green)
                 .highlighted_str(">> ")
                 .row_height(1)
                 .headers(["Key", "Msg", "Description"])

--- a/crates/tuirealm-stdlib/examples/textarea.rs
+++ b/crates/tuirealm-stdlib/examples/textarea.rs
@@ -127,7 +127,7 @@ impl Default for TextareaAlfa {
                     Title::from("Night Moves (Bob Seger)").alignment(HorizontalAlignment::Center),
                 )
                 .step(4)
-                .highlighted_str("🎵")
+                .highlight_str("🎵")
                 .text_rows([
                     Line::from(Span::styled(
                         "I was a little too tall, could've used a few pounds,",
@@ -198,7 +198,7 @@ impl Default for TextareaBeta {
                 .foreground(Color::LightBlue)
                 .title(Title::from("Roxanne (The Police)").alignment(HorizontalAlignment::Center))
                 .step(4)
-                .highlighted_str("🎵")
+                .highlight_str("🎵")
                 .text_rows([
                     Line::from(Span::styled(
                         "Roxanne",

--- a/crates/tuirealm-stdlib/src/components/chart/chart.rs
+++ b/crates/tuirealm-stdlib/src/components/chart/chart.rs
@@ -204,6 +204,7 @@ impl Chart {
 
     /// Give the X axis a title
     pub fn x_title<S: Into<String>>(mut self, t: S) -> Self {
+        // TODO: we should consider using Span or Line
         self.props.set(
             Attribute::Custom(CHART_X_TITLE),
             AttrValue::String(t.into()),
@@ -213,6 +214,7 @@ impl Chart {
 
     /// Give the Y axis a title
     pub fn y_title<S: Into<String>>(mut self, t: S) -> Self {
+        // TODO: we should consider using Span or Line
         self.props.set(
             Attribute::Custom(CHART_Y_TITLE),
             AttrValue::String(t.into()),

--- a/crates/tuirealm-stdlib/src/components/checkbox.rs
+++ b/crates/tuirealm-stdlib/src/components/checkbox.rs
@@ -186,6 +186,7 @@ impl Checkbox {
 
     /// Set the choices that should be possible.
     pub fn choices<S: Into<String>>(mut self, choices: impl IntoIterator<Item = S>) -> Self {
+        // TODO: we should consider using Spans or Lines
         self.attr(
             Attribute::Content,
             AttrValue::Payload(PropPayload::Vec(

--- a/crates/tuirealm-stdlib/src/components/checkbox.rs
+++ b/crates/tuirealm-stdlib/src/components/checkbox.rs
@@ -31,11 +31,11 @@ use tuirealm::props::{
 };
 use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
-use tuirealm::ratatui::text::{Line as Spans, Span};
+use tuirealm::ratatui::text::{Line, Span};
 use tuirealm::ratatui::widgets::Tabs;
 use tuirealm::state::{State, StateValue};
 
-use crate::prop_ext::CommonProps;
+use crate::prop_ext::{CommonHighlight, CommonProps};
 
 // -- states
 
@@ -120,6 +120,7 @@ impl CheckboxStates {
 #[must_use]
 pub struct Checkbox {
     common: CommonProps,
+    common_hg: CommonHighlight,
     props: Props,
     pub states: CheckboxStates,
 }
@@ -166,6 +167,14 @@ impl Checkbox {
     /// Add a title to the component.
     pub fn title<T: Into<Title>>(mut self, title: T) -> Self {
         self.attr(Attribute::Title, AttrValue::Title(title.into()));
+        self
+    }
+
+    /// Set a custom highlight style that is patched ontop of the normal style.
+    ///
+    /// By default the highlight style is just `Style::new().add_modifier(Modifier::REVERSED)`.
+    pub fn highlight_style(mut self, s: Style) -> Self {
+        self.attr(Attribute::HighlightStyle, AttrValue::Style(s));
         self
     }
 
@@ -222,26 +231,21 @@ impl Component for Checkbox {
         }
 
         // Make choices
-        let choices: Vec<Spans> = self
+        let choices: Vec<Line> = self
             .states
             .choices
             .iter()
             .enumerate()
             .map(|(idx, x)| {
                 let checkbox: &str = if self.states.has(idx) { "☑ " } else { "☐ " };
-                // Make spans
-                Spans::from(vec![Span::raw(checkbox), Span::raw(x.to_string())])
+                // Make Lines
+                Line::from(vec![Span::raw(checkbox), Span::raw(x.to_string())])
             })
             .collect();
         let mut widget: Tabs = Tabs::new(choices)
             .select(self.states.choice)
             .style(self.common.style)
-            // TODO: highlight style
-            .highlight_style(self.common.style.add_modifier(if self.common.is_active() {
-                TextModifiers::REVERSED
-            } else {
-                TextModifiers::empty()
-            }));
+            .highlight_style(self.common_hg.get_style(self.common.style));
 
         if let Some(block) = self.common.get_block() {
             widget = widget.block(block);
@@ -251,7 +255,11 @@ impl Component for Checkbox {
     }
 
     fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
-        if let Some(value) = self.common.get_for_query(attr) {
+        if let Some(value) = self
+            .common
+            .get_for_query(attr)
+            .or_else(|| self.common_hg.get_for_query(attr))
+        {
             return Some(value);
         }
 
@@ -259,7 +267,11 @@ impl Component for Checkbox {
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {
-        if let Some(value) = self.common.set(attr, value) {
+        if let Some(value) = self
+            .common
+            .set(attr, value)
+            .and_then(|value| self.common_hg.set(attr, value))
+        {
             match attr {
                 Attribute::Content => {
                     // Reset choices

--- a/crates/tuirealm-stdlib/src/components/gauge.rs
+++ b/crates/tuirealm-stdlib/src/components/gauge.rs
@@ -74,6 +74,7 @@ impl Gauge {
 
     /// Set a label text for the Bar.
     pub fn label<S: Into<String>>(mut self, s: S) -> Self {
+        // TODO: we should consider using Span
         self.attr(Attribute::Text, AttrValue::String(s.into()));
         self
     }

--- a/crates/tuirealm-stdlib/src/components/label.rs
+++ b/crates/tuirealm-stdlib/src/components/label.rs
@@ -50,6 +50,7 @@ impl Label {
 
     /// Set the Text content.
     pub fn text<S: Into<String>>(mut self, t: S) -> Self {
+        // TODO: we should consider using Span
         self.attr(Attribute::Text, AttrValue::String(t.into()));
         self
     }

--- a/crates/tuirealm-stdlib/src/components/line_gauge.rs
+++ b/crates/tuirealm-stdlib/src/components/line_gauge.rs
@@ -75,6 +75,7 @@ impl LineGauge {
 
     /// Set a label text for the Gauge.
     pub fn label<S: Into<String>>(mut self, s: S) -> Self {
+        // TODO: we should consider using Span or Line
         self.attr(Attribute::Text, AttrValue::String(s.into()));
         self
     }

--- a/crates/tuirealm-stdlib/src/components/list.rs
+++ b/crates/tuirealm-stdlib/src/components/list.rs
@@ -11,8 +11,8 @@ use tuirealm::ratatui::layout::Rect;
 use tuirealm::ratatui::widgets::{List as TuiList, ListItem, ListState};
 use tuirealm::state::{State, StateValue};
 
-use crate::prop_ext::CommonProps;
-use crate::utils::{self, borrow_clone_line};
+use crate::prop_ext::{CommonHighlight, CommonProps};
+use crate::utils;
 
 // -- States
 
@@ -102,6 +102,7 @@ impl ListStates {
 #[must_use]
 pub struct List {
     common: CommonProps,
+    common_hg: CommonHighlight,
     props: Props,
     pub states: ListStates,
 }
@@ -175,10 +176,11 @@ impl List {
         self
     }
 
-    /// Set a custom foreground color for the currently highlighted item.
-    pub fn highlighted_color(mut self, c: Color) -> Self {
-        // TODO: shouldnt this be a highlight style instead?
-        self.attr(Attribute::HighlightedColor, AttrValue::Color(c));
+    /// Set a custom highlight style that is patched ontop of the normal style.
+    ///
+    /// By default the highlight style is just `Style::new().add_modifier(Modifier::REVERSED)`.
+    pub fn highlight_style(mut self, s: Style) -> Self {
+        self.attr(Attribute::HighlightStyle, AttrValue::Style(s));
         self
     }
 
@@ -249,37 +251,22 @@ impl Component for List {
             }
             _ => Vec::new(),
         };
-        let highlighted_color = self
-            .props
-            .get(Attribute::HighlightedColor)
-            .and_then(AttrValue::as_color);
 
-        // Make list
+        // Make the widget
         let mut widget = TuiList::new(list_items)
             .style(self.common.style)
-            .direction(tuirealm::ratatui::widgets::ListDirection::TopToBottom);
+            .direction(tuirealm::ratatui::widgets::ListDirection::TopToBottom)
+            .highlight_style(self.common_hg.get_style(self.common.style));
 
         if let Some(block) = self.common.get_block() {
             widget = widget.block(block);
         }
 
-        if let Some(highlighted_color) = highlighted_color {
-            widget = widget.highlight_style(Style::default().fg(highlighted_color).add_modifier(
-                if self.common.is_active() {
-                    TextModifiers::REVERSED
-                } else {
-                    TextModifiers::empty()
-                },
-            ));
-        }
         // Highlighted symbol
-        let hg_str = self
-            .props
-            .get(Attribute::HighlightedStr)
-            .and_then(|x| x.as_textline());
-        if let Some(hg_str) = hg_str {
-            widget = widget.highlight_symbol(borrow_clone_line(hg_str));
+        if let Some(symbol) = self.common_hg.get_symbol() {
+            widget = widget.highlight_symbol(symbol);
         }
+
         if self.scrollable() {
             let mut state: ListState = ListState::default();
             state.select(Some(self.states.list_index));
@@ -290,7 +277,11 @@ impl Component for List {
     }
 
     fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
-        if let Some(value) = self.common.get_for_query(attr) {
+        if let Some(value) = self
+            .common
+            .get_for_query(attr)
+            .or_else(|| self.common_hg.get_for_query(attr))
+        {
             return Some(value);
         }
 
@@ -298,7 +289,11 @@ impl Component for List {
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {
-        if let Some(value) = self.common.set(attr, value) {
+        if let Some(value) = self
+            .common
+            .set(attr, value)
+            .and_then(|value| self.common_hg.set(attr, value))
+        {
             self.props.set(attr, value);
             if matches!(attr, Attribute::Text) {
                 // Update list len and fix index
@@ -456,7 +451,7 @@ mod tests {
         let mut component = List::default()
             .foreground(Color::Red)
             .background(Color::Blue)
-            .highlighted_color(Color::Yellow)
+            .highlight_style(Style::new().fg(Color::Yellow))
             .highlighted_str("🚀")
             .modifiers(TextModifiers::BOLD)
             .scroll(true)
@@ -578,7 +573,7 @@ mod tests {
         let component = List::default()
             .foreground(Color::Red)
             .background(Color::Blue)
-            .highlighted_color(Color::Yellow)
+            .highlight_style(Style::new().fg(Color::Yellow))
             .highlighted_str("🚀")
             .modifiers(TextModifiers::BOLD)
             .borders(Borders::default())
@@ -601,7 +596,7 @@ mod tests {
         let mut component = List::default()
             .foreground(Color::Red)
             .background(Color::Blue)
-            .highlighted_color(Color::Yellow)
+            .highlight_style(Style::new().fg(Color::Yellow))
             .highlighted_str("🚀")
             .modifiers(TextModifiers::BOLD)
             .borders(Borders::default())

--- a/crates/tuirealm-stdlib/src/components/list.rs
+++ b/crates/tuirealm-stdlib/src/components/list.rs
@@ -171,7 +171,7 @@ impl List {
     }
 
     /// Set the Symbol and Style for the indicator of the current line.
-    pub fn highlighted_str<S: Into<LineStatic>>(mut self, s: S) -> Self {
+    pub fn highlight_str<S: Into<LineStatic>>(mut self, s: S) -> Self {
         self.attr(Attribute::HighlightedStr, AttrValue::TextLine(s.into()));
         self
     }
@@ -452,7 +452,7 @@ mod tests {
             .foreground(Color::Red)
             .background(Color::Blue)
             .highlight_style(Style::new().fg(Color::Yellow))
-            .highlighted_str("🚀")
+            .highlight_str("🚀")
             .modifiers(TextModifiers::BOLD)
             .scroll(true)
             .step(4)
@@ -574,7 +574,7 @@ mod tests {
             .foreground(Color::Red)
             .background(Color::Blue)
             .highlight_style(Style::new().fg(Color::Yellow))
-            .highlighted_str("🚀")
+            .highlight_str("🚀")
             .modifiers(TextModifiers::BOLD)
             .borders(Borders::default())
             .title(Title::from("events").alignment(HorizontalAlignment::Center))
@@ -597,7 +597,7 @@ mod tests {
             .foreground(Color::Red)
             .background(Color::Blue)
             .highlight_style(Style::new().fg(Color::Yellow))
-            .highlighted_str("🚀")
+            .highlight_str("🚀")
             .modifiers(TextModifiers::BOLD)
             .borders(Borders::default())
             .title(Title::from("events").alignment(HorizontalAlignment::Center))

--- a/crates/tuirealm-stdlib/src/components/radio.rs
+++ b/crates/tuirealm-stdlib/src/components/radio.rs
@@ -31,11 +31,11 @@ use tuirealm::props::{
 };
 use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
-use tuirealm::ratatui::text::Line as Spans;
+use tuirealm::ratatui::text::Line;
 use tuirealm::ratatui::widgets::Tabs;
 use tuirealm::state::{State, StateValue};
 
-use crate::prop_ext::CommonProps;
+use crate::prop_ext::{CommonHighlight, CommonProps};
 
 // -- states
 
@@ -99,6 +99,7 @@ impl RadioStates {
 #[must_use]
 pub struct Radio {
     common: CommonProps,
+    common_hg: CommonHighlight,
     props: Props,
     pub states: RadioStates,
 }
@@ -145,6 +146,14 @@ impl Radio {
     /// Add a title to the component.
     pub fn title<T: Into<Title>>(mut self, title: T) -> Self {
         self.attr(Attribute::Title, AttrValue::Title(title.into()));
+        self
+    }
+
+    /// Set a custom highlight style that is patched ontop of the normal style.
+    ///
+    /// By default the highlight style is just `Style::new().add_modifier(Modifier::REVERSED)`.
+    pub fn highlight_style(mut self, s: Style) -> Self {
+        self.attr(Attribute::HighlightStyle, AttrValue::Style(s));
         self
     }
 
@@ -199,21 +208,17 @@ impl Component for Radio {
         }
 
         // Make choices
-        let choices: Vec<Spans> = self
+        let choices: Vec<Line> = self
             .states
             .choices
             .iter()
-            .map(|x| Spans::from(x.as_str()))
+            .map(|x| Line::from(x.as_str()))
             .collect();
 
         let mut widget = Tabs::new(choices)
             .select(self.states.choice)
             .style(self.common.style)
-            .highlight_style(Style::default().add_modifier(if self.common.is_active() {
-                TextModifiers::REVERSED
-            } else {
-                TextModifiers::empty()
-            }));
+            .highlight_style(self.common_hg.get_style(self.common.style));
 
         if let Some(block) = self.common.get_block() {
             widget = widget.block(block);
@@ -223,7 +228,11 @@ impl Component for Radio {
     }
 
     fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
-        if let Some(value) = self.common.get_for_query(attr) {
+        if let Some(value) = self
+            .common
+            .get_for_query(attr)
+            .or_else(|| self.common_hg.get_for_query(attr))
+        {
             return Some(value);
         }
 
@@ -231,7 +240,11 @@ impl Component for Radio {
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {
-        if let Some(value) = self.common.set(attr, value) {
+        if let Some(value) = self
+            .common
+            .set(attr, value)
+            .and_then(|value| self.common_hg.set(attr, value))
+        {
             match attr {
                 Attribute::Content => {
                     // Reset choices

--- a/crates/tuirealm-stdlib/src/components/radio.rs
+++ b/crates/tuirealm-stdlib/src/components/radio.rs
@@ -165,6 +165,7 @@ impl Radio {
 
     /// Set the choices that should be possible.
     pub fn choices<S: Into<String>>(mut self, choices: impl IntoIterator<Item = S>) -> Self {
+        // TODO: we should consider using Spans or Lines
         self.attr(
             Attribute::Content,
             AttrValue::Payload(PropPayload::Vec(

--- a/crates/tuirealm-stdlib/src/components/select.rs
+++ b/crates/tuirealm-stdlib/src/components/select.rs
@@ -180,6 +180,7 @@ impl Select {
 
     /// Set the choices that should be possible.
     pub fn choices<S: Into<String>>(mut self, choices: impl IntoIterator<Item = S>) -> Self {
+        // TODO: we should consider using Spans or Lines
         self.attr(
             Attribute::Content,
             AttrValue::Payload(PropPayload::Vec(

--- a/crates/tuirealm-stdlib/src/components/select.rs
+++ b/crates/tuirealm-stdlib/src/components/select.rs
@@ -165,7 +165,7 @@ impl Select {
     }
 
     /// Set the Symbol and Style for the indicator of the current line.
-    pub fn highlighted_str<S: Into<LineStatic>>(mut self, s: S) -> Self {
+    pub fn highlight_str<S: Into<LineStatic>>(mut self, s: S) -> Self {
         self.attr(Attribute::HighlightedStr, AttrValue::TextLine(s.into()));
         self
     }
@@ -483,7 +483,7 @@ mod test {
                     .fg(Color::Red)
                     .add_modifier(TextModifiers::REVERSED),
             )
-            .highlighted_str(">>")
+            .highlight_str(">>")
             .title(
                 Title::from("C'est oui ou bien c'est non?").alignment(HorizontalAlignment::Center),
             )

--- a/crates/tuirealm-stdlib/src/components/select.rs
+++ b/crates/tuirealm-stdlib/src/components/select.rs
@@ -13,8 +13,7 @@ use tuirealm::ratatui::text::Line as Spans;
 use tuirealm::ratatui::widgets::{List, ListItem, ListState, Paragraph};
 use tuirealm::state::{State, StateValue};
 
-use crate::prop_ext::CommonProps;
-use crate::utils::borrow_clone_line;
+use crate::prop_ext::{CommonHighlight, CommonProps};
 
 // -- states
 
@@ -109,6 +108,7 @@ impl SelectStates {
 #[must_use]
 pub struct Select {
     common: CommonProps,
+    common_hg: CommonHighlight,
     props: Props,
     pub states: SelectStates,
 }
@@ -170,10 +170,11 @@ impl Select {
         self
     }
 
-    /// Set a custom foreground color for the currently highlighted item.
-    pub fn highlighted_color(mut self, c: Color) -> Self {
-        // TODO: shouldnt this be a highlight style instead?
-        self.attr(Attribute::HighlightedColor, AttrValue::Color(c));
+    /// Set a custom highlight style that is patched ontop of the normal style.
+    ///
+    /// By default the highlight style is just `Style::new().add_modifier(Modifier::REVERSED)`.
+    pub fn highlight_style(mut self, s: Style) -> Self {
+        self.attr(Attribute::HighlightStyle, AttrValue::Style(s));
         self
     }
 
@@ -213,11 +214,6 @@ impl Select {
             .map(|x| ListItem::new(Spans::from(x.as_str())))
             .collect();
 
-        let hg = self
-            .props
-            .get(Attribute::HighlightedColor)
-            .and_then(AttrValue::as_color);
-
         if let Some(block) = self.common.get_block() {
             let inner = block.inner(area);
             render.render_widget(block, area);
@@ -239,31 +235,21 @@ impl Select {
         let para = Paragraph::new(selected_text).style(self.common.style);
         render.render_widget(para, para_area);
 
-        let hg_style = if let Some(color) = hg {
-            Style::new().fg(color)
-        } else {
-            Style::new()
-        }
-        .add_modifier(TextModifiers::REVERSED);
-
         // Render the list of elements in chunks [1]
         // Make list
-        let mut list = List::new(choices)
+        let mut widget = List::new(choices)
             .direction(tuirealm::ratatui::widgets::ListDirection::TopToBottom)
             .style(self.common.style)
-            .highlight_style(hg_style);
-        // Highlighted symbol
-        let hg_str = self
-            .props
-            .get(Attribute::HighlightedStr)
-            .and_then(|x| x.as_textline());
-        if let Some(hg_str) = hg_str {
-            list = list.highlight_symbol(borrow_clone_line(hg_str));
+            .highlight_style(self.common_hg.get_style(self.common.style));
+
+        if let Some(symbol) = self.common_hg.get_symbol() {
+            widget = widget.highlight_symbol(symbol);
         }
+
         let mut state: ListState = ListState::default();
         state.select(Some(self.states.selected));
 
-        render.render_stateful_widget(list, list_area, &mut state);
+        render.render_stateful_widget(widget, list_area, &mut state);
     }
 
     /// ### render_closed_tab
@@ -305,7 +291,11 @@ impl Component for Select {
     }
 
     fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
-        if let Some(value) = self.common.get_for_query(attr) {
+        if let Some(value) = self
+            .common
+            .get_for_query(attr)
+            .or_else(|| self.common_hg.get_for_query(attr))
+        {
             return Some(value);
         }
 
@@ -313,7 +303,11 @@ impl Component for Select {
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {
-        if let Some(value) = self.common.set(attr, value) {
+        if let Some(value) = self
+            .common
+            .set(attr, value)
+            .and_then(|value| self.common_hg.set(attr, value))
+        {
             match attr {
                 Attribute::Content => {
                     // Reset choices
@@ -484,7 +478,11 @@ mod test {
             .foreground(Color::Red)
             .background(Color::Black)
             .borders(Borders::default())
-            .highlighted_color(Color::Red)
+            .highlight_style(
+                Style::new()
+                    .fg(Color::Red)
+                    .add_modifier(TextModifiers::REVERSED),
+            )
             .highlighted_str(">>")
             .title(
                 Title::from("C'est oui ou bien c'est non?").alignment(HorizontalAlignment::Center),

--- a/crates/tuirealm-stdlib/src/components/spinner.rs
+++ b/crates/tuirealm-stdlib/src/components/spinner.rs
@@ -159,7 +159,7 @@ impl Component for Spinner {
 mod tests {
 
     use pretty_assertions::assert_eq;
-    use tuirealm::ratatui::{self};
+    use tuirealm::ratatui;
 
     use super::*;
 

--- a/crates/tuirealm-stdlib/src/components/table.rs
+++ b/crates/tuirealm-stdlib/src/components/table.rs
@@ -210,6 +210,7 @@ impl Table {
 
     /// Set headers for columns.
     pub fn headers<S: Into<String>>(mut self, headers: impl IntoIterator<Item = S>) -> Self {
+        // TODO: we should consider using Spans or Lines
         self.attr(
             Attribute::Text,
             AttrValue::Payload(PropPayload::Vec(
@@ -370,8 +371,8 @@ impl Component for Table {
         let headers: Vec<&str> = self
             .props
             .get(Attribute::Text)
-            .and_then(|v| v.as_payload())
-            .and_then(|v| v.as_vec())
+            .and_then(AttrValue::as_payload)
+            .and_then(PropPayload::as_vec)
             .map(|v| {
                 v.iter()
                     .filter_map(|v| v.as_str().map(|v| v.as_str()))

--- a/crates/tuirealm-stdlib/src/components/table.rs
+++ b/crates/tuirealm-stdlib/src/components/table.rs
@@ -15,8 +15,8 @@ use tuirealm::ratatui::widgets::{Cell, Row, Table as TuiTable, TableState};
 use tuirealm::state::{State, StateValue};
 
 use super::props::TABLE_COLUMN_SPACING;
-use crate::prop_ext::CommonProps;
-use crate::utils::{self, borrow_clone_line};
+use crate::prop_ext::{CommonHighlight, CommonProps};
+use crate::utils;
 
 // -- States
 
@@ -106,6 +106,7 @@ impl TableStates {
 #[must_use]
 pub struct Table {
     common: CommonProps,
+    common_hg: CommonHighlight,
     props: Props,
     pub states: TableStates,
 }
@@ -173,10 +174,11 @@ impl Table {
         self
     }
 
-    /// Set a custom foreground color for the currently highlighted item.
-    pub fn highlighted_color(mut self, c: Color) -> Self {
-        // TODO: shouldnt this be a highlight style instead?
-        self.attr(Attribute::HighlightedColor, AttrValue::Color(c));
+    /// Set a custom highlight style that is patched ontop of the normal style.
+    ///
+    /// By default the highlight style is just `Style::new().add_modifier(Modifier::REVERSED)`.
+    pub fn highlight_style(mut self, s: Style) -> Self {
+        self.attr(Attribute::HighlightStyle, AttrValue::Style(s));
         self
     }
 
@@ -343,35 +345,19 @@ impl Component for Table {
         let rows: Vec<Row> = self.make_rows(row_height);
         let widths: Vec<Constraint> = self.layout();
 
-        let mut widget = TuiTable::new(rows, &widths).style(self.common.style);
+        let mut widget = TuiTable::new(rows, &widths)
+            .style(self.common.style)
+            .row_highlight_style(self.common_hg.get_style(self.common.style));
 
         if let Some(block) = self.common.get_block() {
             widget = widget.block(block);
         }
 
-        let highlighted_color = self
-            .props
-            .get(Attribute::HighlightedColor)
-            .and_then(AttrValue::as_color);
-
-        if let Some(highlighted_color) = highlighted_color {
-            widget =
-                widget.row_highlight_style(Style::default().fg(highlighted_color).add_modifier(
-                    if self.common.is_active() {
-                        TextModifiers::REVERSED
-                    } else {
-                        TextModifiers::empty()
-                    },
-                ));
-        }
         // Highlighted symbol
-        let hg_str = self
-            .props
-            .get(Attribute::HighlightedStr)
-            .and_then(|x| x.as_textline());
-        if let Some(hg_str) = hg_str {
-            widget = widget.highlight_symbol(borrow_clone_line(hg_str));
+        if let Some(symbol) = self.common_hg.get_symbol() {
+            widget = widget.highlight_symbol(symbol);
         }
+
         // Col spacing
         if let Some(spacing) = self
             .props
@@ -409,7 +395,11 @@ impl Component for Table {
     }
 
     fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
-        if let Some(value) = self.common.get_for_query(attr) {
+        if let Some(value) = self
+            .common
+            .get_for_query(attr)
+            .or_else(|| self.common_hg.get_for_query(attr))
+        {
             return Some(value);
         }
 
@@ -417,7 +407,11 @@ impl Component for Table {
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {
-        if let Some(value) = self.common.set(attr, value) {
+        if let Some(value) = self
+            .common
+            .set(attr, value)
+            .and_then(|value| self.common_hg.set(attr, value))
+        {
             self.props.set(attr, value);
             if matches!(attr, Attribute::Content) {
                 // Update list len and fix index
@@ -571,7 +565,7 @@ mod tests {
         let mut component = Table::default()
             .foreground(Color::Red)
             .background(Color::Blue)
-            .highlighted_color(Color::Yellow)
+            .highlight_style(Style::new().fg(Color::Yellow))
             .highlighted_str("🚀")
             .modifiers(TextModifiers::BOLD)
             .scroll(true)
@@ -706,7 +700,7 @@ mod tests {
         let component = Table::default()
             .foreground(Color::Red)
             .background(Color::Blue)
-            .highlighted_color(Color::Yellow)
+            .highlight_style(Style::new().fg(Color::Yellow))
             .highlighted_str("🚀")
             .modifiers(TextModifiers::BOLD)
             .borders(Borders::default())
@@ -755,7 +749,7 @@ mod tests {
         let mut component = Table::default()
             .foreground(Color::Red)
             .background(Color::Blue)
-            .highlighted_color(Color::Yellow)
+            .highlight_style(Style::new().fg(Color::Yellow))
             .highlighted_str("🚀")
             .modifiers(TextModifiers::BOLD)
             .borders(Borders::default())

--- a/crates/tuirealm-stdlib/src/components/table.rs
+++ b/crates/tuirealm-stdlib/src/components/table.rs
@@ -169,7 +169,7 @@ impl Table {
     }
 
     /// Set the Symbol and Style for the indicator of the current line.
-    pub fn highlighted_str<S: Into<LineStatic>>(mut self, s: S) -> Self {
+    pub fn highlight_str<S: Into<LineStatic>>(mut self, s: S) -> Self {
         self.attr(Attribute::HighlightedStr, AttrValue::TextLine(s.into()));
         self
     }
@@ -566,7 +566,7 @@ mod tests {
             .foreground(Color::Red)
             .background(Color::Blue)
             .highlight_style(Style::new().fg(Color::Yellow))
-            .highlighted_str("🚀")
+            .highlight_str("🚀")
             .modifiers(TextModifiers::BOLD)
             .scroll(true)
             .step(4)
@@ -701,7 +701,7 @@ mod tests {
             .foreground(Color::Red)
             .background(Color::Blue)
             .highlight_style(Style::new().fg(Color::Yellow))
-            .highlighted_str("🚀")
+            .highlight_str("🚀")
             .modifiers(TextModifiers::BOLD)
             .borders(Borders::default())
             .title(Title::from("events").alignment(HorizontalAlignment::Center))
@@ -750,7 +750,7 @@ mod tests {
             .foreground(Color::Red)
             .background(Color::Blue)
             .highlight_style(Style::new().fg(Color::Yellow))
-            .highlighted_str("🚀")
+            .highlight_str("🚀")
             .modifiers(TextModifiers::BOLD)
             .borders(Borders::default())
             .title(Title::from("events").alignment(HorizontalAlignment::Center))

--- a/crates/tuirealm-stdlib/src/components/textarea.rs
+++ b/crates/tuirealm-stdlib/src/components/textarea.rs
@@ -213,7 +213,6 @@ impl Component for Textarea {
             .and_then(|x| x.as_textline());
         // NOTE: wrap width is width of area minus 2 (block) minus width of highlighting string
         let wrap_width = (area.width as usize) - hg_str.as_ref().map_or(0, |x| x.width()) - 2;
-        // TODO: refactor to use "Text"?
         let lines: Vec<ListItem> = self
             .props
             .get(Attribute::Text)

--- a/crates/tuirealm-stdlib/src/components/textarea.rs
+++ b/crates/tuirealm-stdlib/src/components/textarea.rs
@@ -154,7 +154,7 @@ impl Textarea {
     }
 
     /// Set the Symbol and Style for the indicator of the current line.
-    pub fn highlighted_str<S: Into<LineStatic>>(mut self, s: S) -> Self {
+    pub fn highlight_str<S: Into<LineStatic>>(mut self, s: S) -> Self {
         self.attr(Attribute::HighlightedStr, AttrValue::TextLine(s.into()));
         self
     }
@@ -331,7 +331,7 @@ mod tests {
             .background(Color::Blue)
             .modifiers(TextModifiers::BOLD)
             .borders(Borders::default())
-            .highlighted_str("🚀")
+            .highlight_str("🚀")
             .step(4)
             .title(Title::from("textarea").alignment(HorizontalAlignment::Center))
             .text_rows([Line::from("welcome to "), Line::from("tui-realm")]);

--- a/crates/tuirealm-stdlib/src/prop_ext.rs
+++ b/crates/tuirealm-stdlib/src/prop_ext.rs
@@ -1,14 +1,20 @@
 //! Extra extensions to handle Properties.
 
-use tuirealm::props::{AttrValue, AttrValueRef, Attribute, Borders, QueryResult, Style, Title};
+use tuirealm::props::{
+    AttrValue, AttrValueRef, Attribute, Borders, LineStatic, QueryResult, Style, TextModifiers,
+    Title,
+};
+use tuirealm::ratatui::text::Line;
 use tuirealm::ratatui::widgets::Block;
+
+use crate::utils::borrow_clone_line;
 
 /// Prop Store for very common props.
 ///
 /// This structure helps to have a common way to handle the "very common" properties, reducing boilerplate
 /// and potential mis-matches.
 ///
-/// Additionally, using this over [`Props`](tuirealm::Props), saves on indirection and heap-size.
+/// Additionally, using this over [`Props`](tuirealm::props::Props), saves on indirection and heap-size.
 /// On usage (usually on `view`), it also saves on `unwraps` or "defaulting".
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -132,6 +138,76 @@ impl CommonProps {
     }
 }
 
+/// Prop Store for very common highlight props.
+///
+/// This structure helps to have a common way to handle the "very common" highlight properties, reducing boilerplate
+/// and potential mis-matches.
+///
+/// Additionally, using this over [`Props`](tuirealm::props::Props), saves on indirection and heap-size.
+/// On usage (usually on `view`), it also saves on `unwraps` or "defaulting"
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct CommonHighlight {
+    /// The main style to patch [`CommonProps::style`] with for the currently active element.
+    pub style: Style,
+    /// The symbol to use to indicate the currently selected element.
+    pub symbol: LineStatic,
+}
+
+impl Default for CommonHighlight {
+    fn default() -> Self {
+        Self {
+            style: Style::default().add_modifier(TextModifiers::REVERSED),
+            symbol: LineStatic::default(),
+        }
+    }
+}
+
+impl CommonHighlight {
+    /// Try to set a given [`Attribute`]. Returns `Some` if the value is unhandled. `None` if handled.
+    pub fn set(&mut self, attr: Attribute, value: AttrValue) -> Option<AttrValue> {
+        match (attr, value) {
+            (Attribute::HighlightStyle, AttrValue::Style(val)) => self.style = val,
+            (Attribute::HighlightedStr, AttrValue::TextLine(val)) => self.symbol = val,
+
+            // other
+            (_, value) => return Some(value),
+        }
+
+        None
+    }
+
+    /// Try to get a given [`Attribute`].
+    pub fn get<'a>(&'a self, attr: Attribute) -> Option<AttrValueRef<'a>> {
+        match attr {
+            Attribute::HighlightStyle => Some(AttrValueRef::Style(self.style)),
+            Attribute::HighlightedStr => Some(AttrValueRef::TextLine(&self.symbol)),
+
+            // other
+            _ => None,
+        }
+    }
+
+    /// Try to get a given [`Attribute`] as a type compatible with [`Component::query`](tuirealm::component::Component::query).
+    #[inline]
+    pub fn get_for_query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+        self.get(attr).map(QueryResult::Borrowed)
+    }
+
+    pub fn get_symbol(&self) -> Option<Line<'_>> {
+        if self.symbol.spans.is_empty() {
+            None
+        } else {
+            Some(borrow_clone_line(&self.symbol))
+        }
+    }
+
+    #[inline]
+    pub fn get_style(&self, normal_style: Style) -> Style {
+        normal_style.patch(self.style)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use pretty_assertions::assert_eq;
@@ -141,7 +217,7 @@ mod tests {
     };
     use tuirealm::ratatui::widgets::{Block, TitlePosition};
 
-    use crate::prop_ext::CommonProps;
+    use crate::prop_ext::{CommonHighlight, CommonProps};
 
     #[test]
     fn common_should_have_expected_defaults() {
@@ -392,6 +468,60 @@ mod tests {
                 .title_bottom(LineStatic::from("Hello").centered())
                 .borders(BorderSides::TOP)
                 .border_type(BorderType::Double)
+        );
+    }
+
+    #[test]
+    fn common_highlight_should_have_expected_defaults() {
+        let props = CommonHighlight::default();
+
+        // test defaults
+        assert_eq!(
+            props.get(Attribute::HighlightStyle).unwrap().unwrap_style(),
+            Style::new().add_modifier(TextModifiers::REVERSED)
+        );
+        assert_eq!(
+            props
+                .get(Attribute::HighlightedStr)
+                .unwrap()
+                .unwrap_textline(),
+            &LineStatic::default()
+        );
+    }
+
+    #[test]
+    fn common_highlight_should_get_set() {
+        let mut props = CommonHighlight::default();
+
+        // style via highlight style attribute
+        props.set(
+            Attribute::HighlightStyle,
+            AttrValue::Style(
+                Style::new()
+                    .fg(Color::Blue)
+                    .add_modifier(TextModifiers::DIM),
+            ),
+        );
+
+        assert_eq!(
+            props.get(Attribute::HighlightStyle).unwrap().unwrap_style(),
+            Style::new()
+                .fg(Color::Blue)
+                .add_modifier(TextModifiers::DIM)
+        );
+
+        // symbol via highlight symbol attribute
+        props.set(
+            Attribute::HighlightedStr,
+            AttrValue::TextLine(LineStatic::raw(">>")),
+        );
+
+        assert_eq!(
+            props
+                .get(Attribute::HighlightedStr)
+                .unwrap()
+                .unwrap_textline(),
+            &LineStatic::raw(">>")
         );
     }
 }

--- a/crates/tuirealm-stdlib/tests/component_list.rs
+++ b/crates/tuirealm-stdlib/tests/component_list.rs
@@ -4,7 +4,7 @@ use pretty_assertions::assert_eq;
 use tui_realm_stdlib::components::List;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::component::Component;
-use tuirealm::props::{Borders, Color, Title};
+use tuirealm::props::{Borders, Color, Style, Title};
 use tuirealm::ratatui::text::Line;
 use tuirealm::state::{State, StateValue};
 
@@ -111,7 +111,7 @@ fn test_list_snapshot_default() {
         .title(Title::from("Items"))
         .foreground(Color::White)
         .scroll(true)
-        .highlighted_color(Color::Yellow)
+        .highlight_style(Style::new().fg(Color::Yellow))
         .rows(vec![
             Line::from("First item"),
             Line::from("Second item"),

--- a/crates/tuirealm-stdlib/tests/component_table.rs
+++ b/crates/tuirealm-stdlib/tests/component_table.rs
@@ -4,7 +4,7 @@ use pretty_assertions::assert_eq;
 use tui_realm_stdlib::components::Table;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::component::Component;
-use tuirealm::props::{Borders, Color, TableBuilder, Title};
+use tuirealm::props::{Borders, Color, Style, TableBuilder, Title};
 use tuirealm::ratatui::text::Line;
 use tuirealm::state::{State, StateValue};
 
@@ -107,7 +107,7 @@ fn test_table_snapshot_default() {
         .title(Title::from("Users"))
         .foreground(Color::White)
         .scroll(true)
-        .highlighted_color(Color::Yellow)
+        .highlight_style(Style::new().fg(Color::Yellow))
         .headers(["Name", "Age"])
         .widths(&[20, 10])
         .table(make_table_data());

--- a/crates/tuirealm-stdlib/tests/component_textarea.rs
+++ b/crates/tuirealm-stdlib/tests/component_textarea.rs
@@ -95,7 +95,7 @@ fn test_textarea_snapshot_default() {
         .borders(Borders::default())
         .title(Title::from("Log"))
         .foreground(Color::White)
-        .highlighted_str(">> ")
+        .highlight_str(">> ")
         .text_rows([
             Span::from("First line of text"),
             Span::from("Second line of text"),

--- a/crates/tuirealm-treeview/README.md
+++ b/crates/tuirealm-treeview/README.md
@@ -173,7 +173,7 @@ impl FsTree {
                 .indent_size(3)
                 .scroll_step(6)
                 .title(tree.root().id(), Alignment::Left)
-                .highlighted_color(Color::LightYellow)
+                .highlight_color(Color::LightYellow)
                 .highlight_symbol("🦄")
                 .with_tree(tree)
                 .initial_node(initial_node),

--- a/crates/tuirealm-treeview/examples/filesystem.rs
+++ b/crates/tuirealm-treeview/examples/filesystem.rs
@@ -9,7 +9,8 @@ use tuirealm::component::{AppComponent, Component};
 use tuirealm::event::{Event, Key, KeyEvent, KeyModifiers, NoUserEvent};
 use tuirealm::listener::EventListenerCfg;
 use tuirealm::props::{
-    AttrValue, Attribute, BorderType, Borders, Color, HorizontalAlignment, InputType, Style, Title,
+    AttrValue, Attribute, BorderType, Borders, Color, HorizontalAlignment, InputType, Style,
+    TextModifiers, Title,
 };
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
 use tuirealm::state::{State, StateValue};
@@ -261,8 +262,12 @@ impl FsTree {
                 .title(
                     Title::from(tree.root().id().to_string()).alignment(HorizontalAlignment::Left),
                 )
-                .highlighted_color(Color::LightYellow)
-                .highlight_symbol("🦄")
+                .highlight_style(
+                    Style::new()
+                        .fg(Color::LightYellow)
+                        .add_modifier(TextModifiers::REVERSED),
+                )
+                .highlight_str("🦄")
                 .with_tree(tree)
                 .initial_node(initial_node),
         }

--- a/crates/tuirealm-treeview/src/lib.rs
+++ b/crates/tuirealm-treeview/src/lib.rs
@@ -118,8 +118,8 @@
 //!                 .indent_size(3)
 //!                 .scroll_step(6)
 //!                 .title(Title::from(tree.root().id().to_string()).alignment(HorizontalAlignment::Left))
-//!                 .highlighted_color(Color::LightYellow)
-//!                 .highlight_symbol("🦄")
+//!                 .highlight_style(Style::new().fg(Color::LightYellow))
+//!                 .highlight_str("🦄")
 //!                 .with_tree(tree)
 //!                 .initial_node(initial_node),
 //!         }
@@ -206,12 +206,12 @@ pub mod widget;
 use std::iter;
 
 pub use orange_trees::{Node as OrangeNode, Tree as OrangeTree};
-use tui_realm_stdlib::prop_ext::CommonProps;
+use tui_realm_stdlib::prop_ext::{CommonHighlight, CommonProps};
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::component::Component;
 use tuirealm::props::{
-    AttrValue, Attribute, Borders, Color, Props, QueryResult, SpanStatic, Style, TextModifiers,
-    Title,
+    AttrValue, Attribute, Borders, Color, LineStatic, Props, QueryResult, SpanStatic, Style,
+    TextModifiers, Title,
 };
 use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
@@ -262,6 +262,7 @@ pub const TREE_CMD_CLOSE: &str = "c";
 /// Tree view component for tui-realm
 pub struct TreeView<V: NodeValue> {
     common: CommonProps,
+    common_hg: CommonHighlight,
     props: Props,
     states: TreeState,
     /// The actual Tree data structure. You can access this from your Component to operate on it
@@ -273,6 +274,7 @@ impl<V: NodeValue> Default for TreeView<V> {
     fn default() -> Self {
         Self {
             common: CommonProps::default(),
+            common_hg: CommonHighlight::default(),
             props: Props::default(),
             states: TreeState::default(),
             tree: Tree::new(Node::new(String::new(), V::default())),
@@ -325,15 +327,17 @@ impl<V: NodeValue> TreeView<V> {
         self
     }
 
-    /// Set symbol to prepend to highlighted node
-    pub fn highlight_symbol<S: Into<String>>(mut self, symbol: S) -> Self {
-        self.attr(Attribute::HighlightedStr, AttrValue::String(symbol.into()));
+    /// Set the Symbol and Style for the indicator of the current line.
+    pub fn highlight_str<S: Into<LineStatic>>(mut self, s: S) -> Self {
+        self.attr(Attribute::HighlightedStr, AttrValue::TextLine(s.into()));
         self
     }
 
-    /// Set color to apply to highlighted item
-    pub fn highlighted_color(mut self, color: Color) -> Self {
-        self.attr(Attribute::HighlightedColor, AttrValue::Color(color));
+    /// Set a custom highlight style that is patched ontop of the normal style.
+    ///
+    /// By default the highlight style is just `Style::new().add_modifier(Modifier::REVERSED)`.
+    pub fn highlight_style(mut self, s: Style) -> Self {
+        self.attr(Attribute::HighlightStyle, AttrValue::Style(s));
         self
     }
 
@@ -423,33 +427,20 @@ impl<V: NodeValue> Component for TreeView<V> {
             .get(Attribute::Custom(TREE_INDENT_SIZE))
             .and_then(AttrValue::as_size)
             .unwrap_or(4);
-        let hg_color = self
-            .props
-            .get(Attribute::HighlightedColor)
-            .and_then(AttrValue::as_color);
-        let hg_str = self
-            .props
-            .get(Attribute::HighlightedStr)
-            .and_then(AttrValue::as_string);
+
         let block = self.common.get_block();
 
         // Make widget
         let mut tree = TreeWidget::new(self.tree())
             .indent_size(indent_size.into())
-            .style(self.common.style);
+            .style(self.common.style)
+            .highlight_style(self.common_hg.get_style(self.common.style));
 
-        if let Some(hg_color) = hg_color {
-            let hg_style = match self.common.is_active() {
-                true => Style::default().bg(hg_color).fg(Color::Black),
-                false => Style::default().fg(hg_color),
-            };
-            tree = tree.highlight_style(hg_style);
-        }
         if let Some(block) = block {
             tree = tree.block(block);
         }
-        if let Some(hg_str) = hg_str {
-            tree = tree.highlight_symbol(hg_str.as_str());
+        if let Some(symbol) = self.common_hg.get_symbol() {
+            tree = tree.highlight_str(symbol);
         }
 
         let mut state = self.states.clone();
@@ -457,7 +448,11 @@ impl<V: NodeValue> Component for TreeView<V> {
     }
 
     fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
-        if let Some(value) = self.common.get_for_query(attr) {
+        if let Some(value) = self
+            .common
+            .get_for_query(attr)
+            .or_else(|| self.common_hg.get_for_query(attr))
+        {
             return Some(value);
         }
 
@@ -471,7 +466,11 @@ impl<V: NodeValue> Component for TreeView<V> {
             if let Some(node) = self.tree.root().query(&value.unwrap_string()) {
                 self.states.select(self.tree.root(), node);
             }
-        } else if let Some(value) = self.common.set(attr, value) {
+        } else if let Some(value) = self
+            .common
+            .set(attr, value)
+            .and_then(|value| self.common_hg.set(attr, value))
+        {
             self.props.set(attr, value);
         }
     }

--- a/crates/tuirealm-treeview/src/widget.rs
+++ b/crates/tuirealm-treeview/src/widget.rs
@@ -5,8 +5,8 @@
 use tuirealm::ratatui::buffer::Buffer;
 use tuirealm::ratatui::layout::Rect;
 use tuirealm::ratatui::style::Style;
+use tuirealm::ratatui::text::Line;
 use tuirealm::ratatui::widgets::{Block, StatefulWidget, Widget};
-use unicode_width::UnicodeWidthStr;
 
 use super::{Node, NodeValue, Tree, TreeState};
 
@@ -19,7 +19,7 @@ pub struct TreeWidget<'a, V: NodeValue> {
     /// Highlight style
     highlight_style: Style,
     /// Symbol to display on the side of the current highlighted
-    highlight_symbol: Option<&'a str>,
+    highlight_symbol: Option<Line<'a>>,
     /// Spaces to use for indentation
     indent_size: usize,
     /// [`Tree`] to render
@@ -58,8 +58,8 @@ impl<'a, V: NodeValue> TreeWidget<'a, V> {
     }
 
     /// Set symbol to prepend to highlighted entry
-    pub fn highlight_symbol(mut self, s: &'a str) -> Self {
-        self.highlight_symbol = Some(s);
+    pub fn highlight_str<S: Into<Line<'a>>>(mut self, s: S) -> Self {
+        self.highlight_symbol = Some(s.into());
         self
     }
 
@@ -151,7 +151,7 @@ impl<V: NodeValue> TreeWidget<'_, V> {
             return area;
         }
         let highlight_symbol = match state.is_selected(node) {
-            true => Some(self.highlight_symbol.unwrap_or_default()),
+            true => self.highlight_symbol.as_ref(),
             false => None,
         };
         // Get area for current node
@@ -187,7 +187,14 @@ impl<V: NodeValue> TreeWidget<'_, V> {
         );
         // Write highlight symbol
         let (start_x, start_y) = highlight_symbol
-            .map(|x| buf.set_stringn(start_x, start_y, x, width - start_x as usize, style))
+            .map(|x| {
+                buf.set_line(
+                    start_x,
+                    start_y,
+                    x,
+                    u16::try_from(width - start_x as usize).unwrap_or(u16::MAX),
+                )
+            })
             .map(|(x, y)| buf.set_stringn(x, y, " ", width - start_x as usize, style))
             .unwrap_or((start_x, start_y));
 
@@ -296,13 +303,13 @@ mod test {
         let widget = TreeWidget::new(&tree)
             .block(Block::default())
             .highlight_style(Style::default().fg(Color::Red))
-            .highlight_symbol(">")
+            .highlight_str(">")
             .indent_size(8)
             .style(Style::default().fg(Color::LightRed));
         assert!(widget.block.is_some());
         assert_eq!(widget.highlight_style.fg.unwrap(), Color::Red);
         assert_eq!(widget.indent_size, 8);
-        assert_eq!(widget.highlight_symbol.unwrap(), ">");
+        assert_eq!(widget.highlight_symbol.unwrap(), Line::raw(">"));
         assert_eq!(widget.style.fg.unwrap(), Color::LightRed);
     }
 

--- a/crates/tuirealm-treeview/tests/component_treeview.rs
+++ b/crates/tuirealm-treeview/tests/component_treeview.rs
@@ -5,7 +5,7 @@ use tui_realm_treeview::mock::mock_tree;
 use tui_realm_treeview::{TREE_CMD_CLOSE, TREE_CMD_OPEN, TreeView};
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::component::Component;
-use tuirealm::props::{Borders, Color, Title};
+use tuirealm::props::{Borders, Color, Style, Title};
 use tuirealm::state::{State, StateValue};
 
 #[test]
@@ -111,7 +111,7 @@ fn test_treeview_snapshot_default() {
         .borders(Borders::default())
         .title(Title::from("Files"))
         .foreground(Color::White)
-        .highlighted_color(Color::Yellow)
+        .highlight_style(Style::new().fg(Color::Yellow))
         .indent_size(3)
         .with_tree(mock_tree())
         .initial_node("/");

--- a/crates/tuirealm/docs/en/migrating-4.0.md
+++ b/crates/tuirealm/docs/en/migrating-4.0.md
@@ -192,3 +192,7 @@ This allowed the consumer to decide when a clone is actually necessary, for prac
 
 `Attribute` variant `HighlightColor` has been removed and instead variant `HighlightStyle` has been added to fully configure the style (including modifiers)
 instead of just the color.
+
+### Rename `::highlighted_*` functions to `::highlight_*`
+
+To have consistent naming and alight with function names in `ratatui`, all `highlighted_*` function (ex. `::highlighted_str`) to be `highlight_*` (ex. `::highlight_str`).

--- a/crates/tuirealm/docs/en/migrating-4.0.md
+++ b/crates/tuirealm/docs/en/migrating-4.0.md
@@ -187,3 +187,8 @@ This allowed the consumer to decide when a clone is actually necessary, for prac
 ### Rename `Attribute::FocusStyle` to `Attribute::UnfocusedBorderStyle`
 
 `Attribute` variant `FocusStyle` has been renamed to `UnfocusedBorderStyle` as that better represents what this attribute is doing on a glance.
+
+### Rename `Attribute::HighlightColor` to `Attribute::HighlightStyle`
+
+`Attribute` variant `HighlightColor` has been removed and instead variant `HighlightStyle` has been added to fully configure the style (including modifiers)
+instead of just the color.

--- a/crates/tuirealm/src/core/props/mod.rs
+++ b/crates/tuirealm/src/core/props/mod.rs
@@ -78,8 +78,8 @@ pub enum Attribute {
     Height,
     /// String to prepend to highlighted items in list or other
     HighlightedStr,
-    /// Color to apply to highlighted items
-    HighlightedColor,
+    /// Style to patch [`Style`](Self::Style) with to apply on the highlighted element.
+    HighlightStyle,
     /// Maximum input length for input fields
     InputLength,
     /// Input type for input fields


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

Re #208
Depends on #210

## Description

This PR mainly focuses on changing `Attribute::HighlightColor` to `Attribute::HighlightStyle` to be able to configure more than the style.
To do this, i added a new Common interface, `CommonHighlight`, which can be used pretty much the same as `CommonProps`.
Additionally, i took the liberty of having consistent `highlight_*` function naming (no more `highlighted_*`) and changing `_symbol` to `_str` to be consistent across crates.

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
