### PR TITLE
Extra `Input` test and improve `testing`

### DIFF
--- a/crates/tuirealm-stdlib/tests/common.rs
+++ b/crates/tuirealm-stdlib/tests/common.rs
@@ -1,1 +1,0 @@
-pub use tuirealm::testing::render_to_string;

--- a/crates/tuirealm-stdlib/tests/component_bar_chart.rs
+++ b/crates/tuirealm-stdlib/tests/component_bar_chart.rs
@@ -1,11 +1,10 @@
-mod common;
-
 use pretty_assertions::assert_eq;
 use tui_realm_stdlib::components::BarChart;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::component::Component;
 use tuirealm::props::{Borders, Color, Title};
 use tuirealm::state::State;
+use tuirealm::testing::render_to_string;
 
 #[test]
 fn test_bar_chart_state_is_none() {
@@ -70,6 +69,6 @@ fn test_bar_chart_snapshot_default() {
         .title(Title::from("Sales"))
         .foreground(Color::Green)
         .data(&[("Q1", 100), ("Q2", 150), ("Q3", 200), ("Q4", 175)]);
-    let rendered = common::render_to_string(&mut component, 50, 12);
+    let rendered = render_to_string(&mut component, 50, 12);
     insta::assert_snapshot!("bar_chart_default", rendered);
 }

--- a/crates/tuirealm-stdlib/tests/component_bar_chart.rs
+++ b/crates/tuirealm-stdlib/tests/component_bar_chart.rs
@@ -3,6 +3,7 @@ use tui_realm_stdlib::components::BarChart;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::component::Component;
 use tuirealm::props::{Borders, Color, Title};
+use tuirealm::ratatui::layout::Size;
 use tuirealm::state::State;
 use tuirealm::testing::render_to_string;
 
@@ -69,6 +70,6 @@ fn test_bar_chart_snapshot_default() {
         .title(Title::from("Sales"))
         .foreground(Color::Green)
         .data(&[("Q1", 100), ("Q2", 150), ("Q3", 200), ("Q4", 175)]);
-    let rendered = render_to_string(&mut component, 50, 12);
+    let rendered = render_to_string(&mut component, Size::new(50, 12));
     insta::assert_snapshot!("bar_chart_default", rendered);
 }

--- a/crates/tuirealm-stdlib/tests/component_canvas.rs
+++ b/crates/tuirealm-stdlib/tests/component_canvas.rs
@@ -1,5 +1,3 @@
-mod common;
-
 use pretty_assertions::assert_eq;
 use tui_realm_stdlib::components::Canvas;
 use tuirealm::command::{Cmd, CmdResult};
@@ -7,6 +5,7 @@ use tuirealm::component::Component;
 use tuirealm::props::{Borders, Color, Shape, Title};
 use tuirealm::ratatui::widgets::canvas::Line as CanvasLine;
 use tuirealm::state::State;
+use tuirealm::testing::render_to_string;
 
 #[test]
 fn test_canvas_state_is_none() {
@@ -38,6 +37,6 @@ fn test_canvas_snapshot_default() {
             y2: 100.0,
             color: Color::White,
         })]);
-    let rendered = common::render_to_string(&mut component, 40, 15);
+    let rendered = render_to_string(&mut component, 40, 15);
     insta::assert_snapshot!("canvas_default", rendered);
 }

--- a/crates/tuirealm-stdlib/tests/component_canvas.rs
+++ b/crates/tuirealm-stdlib/tests/component_canvas.rs
@@ -3,6 +3,7 @@ use tui_realm_stdlib::components::Canvas;
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::component::Component;
 use tuirealm::props::{Borders, Color, Shape, Title};
+use tuirealm::ratatui::layout::Size;
 use tuirealm::ratatui::widgets::canvas::Line as CanvasLine;
 use tuirealm::state::State;
 use tuirealm::testing::render_to_string;
@@ -37,6 +38,6 @@ fn test_canvas_snapshot_default() {
             y2: 100.0,
             color: Color::White,
         })]);
-    let rendered = render_to_string(&mut component, 40, 15);
+    let rendered = render_to_string(&mut component, Size::new(40, 15));
     insta::assert_snapshot!("canvas_default", rendered);
 }

--- a/crates/tuirealm-stdlib/tests/component_chart.rs
+++ b/crates/tuirealm-stdlib/tests/component_chart.rs
@@ -3,6 +3,7 @@ use tui_realm_stdlib::components::{Chart, ChartDataset};
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::component::Component;
 use tuirealm::props::{Borders, Color, Style, Title};
+use tuirealm::ratatui::layout::Size;
 use tuirealm::state::State;
 use tuirealm::testing::render_to_string;
 
@@ -73,6 +74,6 @@ fn test_chart_snapshot_default() {
         .x_labels(&["0", "5", "10"])
         .y_labels(&["0", "5", "10"])
         .data([make_dataset()]);
-    let rendered = render_to_string(&mut component, 60, 15);
+    let rendered = render_to_string(&mut component, Size::new(60, 15));
     insta::assert_snapshot!("chart_default", rendered);
 }

--- a/crates/tuirealm-stdlib/tests/component_chart.rs
+++ b/crates/tuirealm-stdlib/tests/component_chart.rs
@@ -1,11 +1,10 @@
-mod common;
-
 use pretty_assertions::assert_eq;
 use tui_realm_stdlib::components::{Chart, ChartDataset};
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::component::Component;
 use tuirealm::props::{Borders, Color, Style, Title};
 use tuirealm::state::State;
+use tuirealm::testing::render_to_string;
 
 fn make_dataset() -> ChartDataset {
     ChartDataset::default()
@@ -74,6 +73,6 @@ fn test_chart_snapshot_default() {
         .x_labels(&["0", "5", "10"])
         .y_labels(&["0", "5", "10"])
         .data([make_dataset()]);
-    let rendered = common::render_to_string(&mut component, 60, 15);
+    let rendered = render_to_string(&mut component, 60, 15);
     insta::assert_snapshot!("chart_default", rendered);
 }

--- a/crates/tuirealm-stdlib/tests/component_checkbox.rs
+++ b/crates/tuirealm-stdlib/tests/component_checkbox.rs
@@ -1,11 +1,10 @@
-mod common;
-
 use pretty_assertions::assert_eq;
 use tui_realm_stdlib::components::Checkbox;
 use tuirealm::command::{Cmd, CmdResult, Direction};
 use tuirealm::component::Component;
 use tuirealm::props::{Borders, Color, HorizontalAlignment, Title};
 use tuirealm::state::{State, StateValue};
+use tuirealm::testing::render_to_string;
 
 #[test]
 fn test_checkbox_initial_state_empty() {
@@ -73,6 +72,6 @@ fn test_checkbox_snapshot_default() {
         .foreground(Color::Yellow)
         .choices(["Alpha", "Beta", "Gamma"])
         .values(&[1]);
-    let rendered = common::render_to_string(&mut component, 50, 3);
+    let rendered = render_to_string(&mut component, 50, 3);
     insta::assert_snapshot!("checkbox_default", rendered);
 }

--- a/crates/tuirealm-stdlib/tests/component_checkbox.rs
+++ b/crates/tuirealm-stdlib/tests/component_checkbox.rs
@@ -3,6 +3,7 @@ use tui_realm_stdlib::components::Checkbox;
 use tuirealm::command::{Cmd, CmdResult, Direction};
 use tuirealm::component::Component;
 use tuirealm::props::{Borders, Color, HorizontalAlignment, Title};
+use tuirealm::ratatui::layout::Size;
 use tuirealm::state::{State, StateValue};
 use tuirealm::testing::render_to_string;
 
@@ -72,6 +73,6 @@ fn test_checkbox_snapshot_default() {
         .foreground(Color::Yellow)
         .choices(["Alpha", "Beta", "Gamma"])
         .values(&[1]);
-    let rendered = render_to_string(&mut component, 50, 3);
+    let rendered = render_to_string(&mut component, Size::new(50, 3));
     insta::assert_snapshot!("checkbox_default", rendered);
 }

--- a/crates/tuirealm-stdlib/tests/component_container.rs
+++ b/crates/tuirealm-stdlib/tests/component_container.rs
@@ -3,7 +3,7 @@ use tui_realm_stdlib::components::{Container, Label};
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::component::Component;
 use tuirealm::props::{Borders, Layout, Title};
-use tuirealm::ratatui::layout::{Constraint, Direction};
+use tuirealm::ratatui::layout::{Constraint, Direction, Size};
 use tuirealm::state::State;
 use tuirealm::testing::render_to_string;
 
@@ -35,6 +35,6 @@ fn test_container_snapshot_with_children() {
                 .constraints(&[Constraint::Percentage(50), Constraint::Percentage(50)]),
         )
         .children(vec![Box::new(child1), Box::new(child2)]);
-    let rendered = render_to_string(&mut component, 40, 8);
+    let rendered = render_to_string(&mut component, Size::new(40, 8));
     insta::assert_snapshot!("container_with_children", rendered);
 }

--- a/crates/tuirealm-stdlib/tests/component_container.rs
+++ b/crates/tuirealm-stdlib/tests/component_container.rs
@@ -1,5 +1,3 @@
-mod common;
-
 use pretty_assertions::assert_eq;
 use tui_realm_stdlib::components::{Container, Label};
 use tuirealm::command::{Cmd, CmdResult};
@@ -7,6 +5,7 @@ use tuirealm::component::Component;
 use tuirealm::props::{Borders, Layout, Title};
 use tuirealm::ratatui::layout::{Constraint, Direction};
 use tuirealm::state::State;
+use tuirealm::testing::render_to_string;
 
 #[test]
 fn test_container_state_is_none() {
@@ -36,6 +35,6 @@ fn test_container_snapshot_with_children() {
                 .constraints(&[Constraint::Percentage(50), Constraint::Percentage(50)]),
         )
         .children(vec![Box::new(child1), Box::new(child2)]);
-    let rendered = common::render_to_string(&mut component, 40, 8);
+    let rendered = render_to_string(&mut component, 40, 8);
     insta::assert_snapshot!("container_with_children", rendered);
 }

--- a/crates/tuirealm-stdlib/tests/component_gauge.rs
+++ b/crates/tuirealm-stdlib/tests/component_gauge.rs
@@ -1,11 +1,10 @@
-mod common;
-
 use pretty_assertions::assert_eq;
 use tui_realm_stdlib::components::Gauge;
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::component::Component;
 use tuirealm::props::{Borders, Color, Title};
 use tuirealm::state::State;
+use tuirealm::testing::render_to_string;
 
 #[test]
 fn test_gauge_state_is_none() {
@@ -30,20 +29,20 @@ fn test_gauge_snapshot_default() {
         .foreground(Color::Green)
         .label("50%")
         .progress(0.5);
-    let rendered = common::render_to_string(&mut component, 40, 3);
+    let rendered = render_to_string(&mut component, 40, 3);
     insta::assert_snapshot!("gauge_default", rendered);
 }
 
 #[test]
 fn test_gauge_snapshot_empty() {
     let mut component = Gauge::default().borders(Borders::default()).progress(0.0);
-    let rendered = common::render_to_string(&mut component, 40, 3);
+    let rendered = render_to_string(&mut component, 40, 3);
     insta::assert_snapshot!("gauge_empty", rendered);
 }
 
 #[test]
 fn test_gauge_snapshot_full() {
     let mut component = Gauge::default().borders(Borders::default()).progress(1.0);
-    let rendered = common::render_to_string(&mut component, 40, 3);
+    let rendered = render_to_string(&mut component, 40, 3);
     insta::assert_snapshot!("gauge_full", rendered);
 }

--- a/crates/tuirealm-stdlib/tests/component_gauge.rs
+++ b/crates/tuirealm-stdlib/tests/component_gauge.rs
@@ -3,6 +3,7 @@ use tui_realm_stdlib::components::Gauge;
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::component::Component;
 use tuirealm::props::{Borders, Color, Title};
+use tuirealm::ratatui::layout::Size;
 use tuirealm::state::State;
 use tuirealm::testing::render_to_string;
 
@@ -29,20 +30,20 @@ fn test_gauge_snapshot_default() {
         .foreground(Color::Green)
         .label("50%")
         .progress(0.5);
-    let rendered = render_to_string(&mut component, 40, 3);
+    let rendered = render_to_string(&mut component, Size::new(40, 3));
     insta::assert_snapshot!("gauge_default", rendered);
 }
 
 #[test]
 fn test_gauge_snapshot_empty() {
     let mut component = Gauge::default().borders(Borders::default()).progress(0.0);
-    let rendered = render_to_string(&mut component, 40, 3);
+    let rendered = render_to_string(&mut component, Size::new(40, 3));
     insta::assert_snapshot!("gauge_empty", rendered);
 }
 
 #[test]
 fn test_gauge_snapshot_full() {
     let mut component = Gauge::default().borders(Borders::default()).progress(1.0);
-    let rendered = render_to_string(&mut component, 40, 3);
+    let rendered = render_to_string(&mut component, Size::new(40, 3));
     insta::assert_snapshot!("gauge_full", rendered);
 }

--- a/crates/tuirealm-stdlib/tests/component_input.rs
+++ b/crates/tuirealm-stdlib/tests/component_input.rs
@@ -3,6 +3,7 @@ use tui_realm_stdlib::components::Input;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::component::Component;
 use tuirealm::props::{Borders, Color, InputType, Title};
+use tuirealm::ratatui::layout::Size;
 use tuirealm::state::{State, StateValue};
 use tuirealm::testing::render_to_string;
 
@@ -139,7 +140,7 @@ fn test_input_snapshot_default() {
         .foreground(Color::Cyan)
         .input_type(InputType::Text)
         .value("john_doe");
-    let rendered = render_to_string(&mut component, 40, 3);
+    let rendered = render_to_string(&mut component, Size::new(40, 3));
     insta::assert_snapshot!("input_default", rendered);
 }
 
@@ -149,7 +150,7 @@ fn test_input_snapshot_empty() {
         .borders(Borders::default())
         .title(Title::from("Input"))
         .input_type(InputType::Text);
-    let rendered = render_to_string(&mut component, 40, 3);
+    let rendered = render_to_string(&mut component, Size::new(40, 3));
     insta::assert_snapshot!("input_empty", rendered);
 }
 
@@ -158,7 +159,7 @@ fn test_input_snapshot_noborder() {
     let mut component = Input::default()
         .input_type(InputType::Text)
         .value("Test Text");
-    let rendered = render_to_string(&mut component, 40, 3);
+    let rendered = render_to_string(&mut component, Size::new(40, 3));
     insta::assert_snapshot!("input_no_borders", rendered);
 }
 
@@ -169,6 +170,6 @@ fn test_input_snapshot_password() {
         .title(Title::from("Password"))
         .input_type(InputType::Password('*'))
         .value("secret");
-    let rendered = render_to_string(&mut component, 40, 3);
+    let rendered = render_to_string(&mut component, Size::new(40, 3));
     insta::assert_snapshot!("input_password", rendered);
 }

--- a/crates/tuirealm-stdlib/tests/component_input.rs
+++ b/crates/tuirealm-stdlib/tests/component_input.rs
@@ -155,6 +155,15 @@ fn test_input_snapshot_empty() {
 }
 
 #[test]
+fn test_input_snapshot_noborder() {
+    let mut component = Input::default()
+        .input_type(InputType::Text)
+        .value("Test Text");
+    let rendered = common::render_to_string(&mut component, 40, 3);
+    insta::assert_snapshot!("input_no_borders", rendered);
+}
+
+#[test]
 fn test_input_snapshot_password() {
     let mut component = Input::default()
         .borders(Borders::default())

--- a/crates/tuirealm-stdlib/tests/component_input.rs
+++ b/crates/tuirealm-stdlib/tests/component_input.rs
@@ -1,11 +1,10 @@
-mod common;
-
 use pretty_assertions::assert_eq;
 use tui_realm_stdlib::components::Input;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::component::Component;
 use tuirealm::props::{Borders, Color, InputType, Title};
 use tuirealm::state::{State, StateValue};
+use tuirealm::testing::render_to_string;
 
 #[test]
 fn test_input_initial_state() {
@@ -140,7 +139,7 @@ fn test_input_snapshot_default() {
         .foreground(Color::Cyan)
         .input_type(InputType::Text)
         .value("john_doe");
-    let rendered = common::render_to_string(&mut component, 40, 3);
+    let rendered = render_to_string(&mut component, 40, 3);
     insta::assert_snapshot!("input_default", rendered);
 }
 
@@ -150,7 +149,7 @@ fn test_input_snapshot_empty() {
         .borders(Borders::default())
         .title(Title::from("Input"))
         .input_type(InputType::Text);
-    let rendered = common::render_to_string(&mut component, 40, 3);
+    let rendered = render_to_string(&mut component, 40, 3);
     insta::assert_snapshot!("input_empty", rendered);
 }
 
@@ -159,7 +158,7 @@ fn test_input_snapshot_noborder() {
     let mut component = Input::default()
         .input_type(InputType::Text)
         .value("Test Text");
-    let rendered = common::render_to_string(&mut component, 40, 3);
+    let rendered = render_to_string(&mut component, 40, 3);
     insta::assert_snapshot!("input_no_borders", rendered);
 }
 
@@ -170,6 +169,6 @@ fn test_input_snapshot_password() {
         .title(Title::from("Password"))
         .input_type(InputType::Password('*'))
         .value("secret");
-    let rendered = common::render_to_string(&mut component, 40, 3);
+    let rendered = render_to_string(&mut component, 40, 3);
     insta::assert_snapshot!("input_password", rendered);
 }

--- a/crates/tuirealm-stdlib/tests/component_label.rs
+++ b/crates/tuirealm-stdlib/tests/component_label.rs
@@ -3,6 +3,7 @@ use tui_realm_stdlib::components::Label;
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::component::Component;
 use tuirealm::props::{Color, HorizontalAlignment};
+use tuirealm::ratatui::layout::Size;
 use tuirealm::state::State;
 use tuirealm::testing::render_to_string;
 
@@ -34,7 +35,7 @@ fn test_label_snapshot_default() {
     let mut component = Label::default()
         .foreground(Color::Yellow)
         .text("Hello, World!");
-    let rendered = render_to_string(&mut component, 40, 3);
+    let rendered = render_to_string(&mut component, Size::new(40, 3));
     insta::assert_snapshot!("label_default", rendered);
 }
 
@@ -43,6 +44,6 @@ fn test_label_snapshot_centered() {
     let mut component = Label::default()
         .text("Centered Text")
         .alignment_horizontal(HorizontalAlignment::Center);
-    let rendered = render_to_string(&mut component, 40, 3);
+    let rendered = render_to_string(&mut component, Size::new(40, 3));
     insta::assert_snapshot!("label_centered", rendered);
 }

--- a/crates/tuirealm-stdlib/tests/component_label.rs
+++ b/crates/tuirealm-stdlib/tests/component_label.rs
@@ -1,11 +1,10 @@
-mod common;
-
 use pretty_assertions::assert_eq;
 use tui_realm_stdlib::components::Label;
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::component::Component;
 use tuirealm::props::{Color, HorizontalAlignment};
 use tuirealm::state::State;
+use tuirealm::testing::render_to_string;
 
 #[test]
 fn test_label_state_is_none() {
@@ -35,7 +34,7 @@ fn test_label_snapshot_default() {
     let mut component = Label::default()
         .foreground(Color::Yellow)
         .text("Hello, World!");
-    let rendered = common::render_to_string(&mut component, 40, 3);
+    let rendered = render_to_string(&mut component, 40, 3);
     insta::assert_snapshot!("label_default", rendered);
 }
 
@@ -44,6 +43,6 @@ fn test_label_snapshot_centered() {
     let mut component = Label::default()
         .text("Centered Text")
         .alignment_horizontal(HorizontalAlignment::Center);
-    let rendered = common::render_to_string(&mut component, 40, 3);
+    let rendered = render_to_string(&mut component, 40, 3);
     insta::assert_snapshot!("label_centered", rendered);
 }

--- a/crates/tuirealm-stdlib/tests/component_line_gauge.rs
+++ b/crates/tuirealm-stdlib/tests/component_line_gauge.rs
@@ -3,6 +3,7 @@ use tui_realm_stdlib::components::LineGauge;
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::component::Component;
 use tuirealm::props::{Borders, Color, Title};
+use tuirealm::ratatui::layout::Size;
 use tuirealm::state::State;
 use tuirealm::testing::render_to_string;
 
@@ -29,7 +30,7 @@ fn test_line_gauge_snapshot_default() {
         .foreground(Color::Cyan)
         .label("75%")
         .progress(0.75);
-    let rendered = render_to_string(&mut component, 40, 3);
+    let rendered = render_to_string(&mut component, Size::new(40, 3));
     insta::assert_snapshot!("line_gauge_default", rendered);
 }
 
@@ -38,6 +39,6 @@ fn test_line_gauge_snapshot_empty() {
     let mut component = LineGauge::default()
         .borders(Borders::default())
         .progress(0.0);
-    let rendered = render_to_string(&mut component, 40, 3);
+    let rendered = render_to_string(&mut component, Size::new(40, 3));
     insta::assert_snapshot!("line_gauge_empty", rendered);
 }

--- a/crates/tuirealm-stdlib/tests/component_line_gauge.rs
+++ b/crates/tuirealm-stdlib/tests/component_line_gauge.rs
@@ -1,11 +1,10 @@
-mod common;
-
 use pretty_assertions::assert_eq;
 use tui_realm_stdlib::components::LineGauge;
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::component::Component;
 use tuirealm::props::{Borders, Color, Title};
 use tuirealm::state::State;
+use tuirealm::testing::render_to_string;
 
 #[test]
 fn test_line_gauge_state_is_none() {
@@ -30,7 +29,7 @@ fn test_line_gauge_snapshot_default() {
         .foreground(Color::Cyan)
         .label("75%")
         .progress(0.75);
-    let rendered = common::render_to_string(&mut component, 40, 3);
+    let rendered = render_to_string(&mut component, 40, 3);
     insta::assert_snapshot!("line_gauge_default", rendered);
 }
 
@@ -39,6 +38,6 @@ fn test_line_gauge_snapshot_empty() {
     let mut component = LineGauge::default()
         .borders(Borders::default())
         .progress(0.0);
-    let rendered = common::render_to_string(&mut component, 40, 3);
+    let rendered = render_to_string(&mut component, 40, 3);
     insta::assert_snapshot!("line_gauge_empty", rendered);
 }

--- a/crates/tuirealm-stdlib/tests/component_list.rs
+++ b/crates/tuirealm-stdlib/tests/component_list.rs
@@ -1,5 +1,3 @@
-mod common;
-
 use pretty_assertions::assert_eq;
 use tui_realm_stdlib::components::List;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
@@ -7,6 +5,7 @@ use tuirealm::component::Component;
 use tuirealm::props::{Borders, Color, Style, Title};
 use tuirealm::ratatui::text::Line;
 use tuirealm::state::{State, StateValue};
+use tuirealm::testing::render_to_string;
 
 #[test]
 fn test_list_initial_state_scrollable() {
@@ -117,7 +116,7 @@ fn test_list_snapshot_default() {
             Line::from("Second item"),
             Line::from("Third item"),
         ]);
-    let rendered = common::render_to_string(&mut component, 40, 7);
+    let rendered = render_to_string(&mut component, 40, 7);
     insta::assert_snapshot!("list_default", rendered);
 }
 
@@ -128,6 +127,6 @@ fn test_list_snapshot_empty() {
         .title(Title::from("Empty List"))
         .scroll(true)
         .rows(Vec::<Line>::new());
-    let rendered = common::render_to_string(&mut component, 40, 5);
+    let rendered = render_to_string(&mut component, 40, 5);
     insta::assert_snapshot!("list_empty", rendered);
 }

--- a/crates/tuirealm-stdlib/tests/component_list.rs
+++ b/crates/tuirealm-stdlib/tests/component_list.rs
@@ -3,6 +3,7 @@ use tui_realm_stdlib::components::List;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::component::Component;
 use tuirealm::props::{Borders, Color, Style, Title};
+use tuirealm::ratatui::layout::Size;
 use tuirealm::ratatui::text::Line;
 use tuirealm::state::{State, StateValue};
 use tuirealm::testing::render_to_string;
@@ -116,7 +117,7 @@ fn test_list_snapshot_default() {
             Line::from("Second item"),
             Line::from("Third item"),
         ]);
-    let rendered = render_to_string(&mut component, 40, 7);
+    let rendered = render_to_string(&mut component, Size::new(40, 7));
     insta::assert_snapshot!("list_default", rendered);
 }
 
@@ -127,6 +128,6 @@ fn test_list_snapshot_empty() {
         .title(Title::from("Empty List"))
         .scroll(true)
         .rows(Vec::<Line>::new());
-    let rendered = render_to_string(&mut component, 40, 5);
+    let rendered = render_to_string(&mut component, Size::new(40, 5));
     insta::assert_snapshot!("list_empty", rendered);
 }

--- a/crates/tuirealm-stdlib/tests/component_paragraph.rs
+++ b/crates/tuirealm-stdlib/tests/component_paragraph.rs
@@ -3,6 +3,7 @@ use tui_realm_stdlib::components::Paragraph;
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::component::Component;
 use tuirealm::props::{Borders, HorizontalAlignment, Title};
+use tuirealm::ratatui::layout::Size;
 use tuirealm::ratatui::text::Line;
 use tuirealm::state::State;
 use tuirealm::testing::render_to_string;
@@ -28,7 +29,7 @@ fn test_paragraph_snapshot_default() {
         .borders(Borders::default())
         .title(Title::from("Info"))
         .text(vec![Line::from("Line one"), Line::from("Line two")]);
-    let rendered = render_to_string(&mut component, 40, 6);
+    let rendered = render_to_string(&mut component, Size::new(40, 6));
     insta::assert_snapshot!("paragraph_default", rendered);
 }
 
@@ -37,6 +38,6 @@ fn test_paragraph_snapshot_centered() {
     let mut component = Paragraph::default()
         .alignment_horizontal(HorizontalAlignment::Center)
         .text(vec![Line::from("Centered")]);
-    let rendered = render_to_string(&mut component, 40, 3);
+    let rendered = render_to_string(&mut component, Size::new(40, 3));
     insta::assert_snapshot!("paragraph_centered", rendered);
 }

--- a/crates/tuirealm-stdlib/tests/component_paragraph.rs
+++ b/crates/tuirealm-stdlib/tests/component_paragraph.rs
@@ -1,5 +1,3 @@
-mod common;
-
 use pretty_assertions::assert_eq;
 use tui_realm_stdlib::components::Paragraph;
 use tuirealm::command::{Cmd, CmdResult};
@@ -7,6 +5,7 @@ use tuirealm::component::Component;
 use tuirealm::props::{Borders, HorizontalAlignment, Title};
 use tuirealm::ratatui::text::Line;
 use tuirealm::state::State;
+use tuirealm::testing::render_to_string;
 
 #[test]
 fn test_paragraph_state_is_none() {
@@ -29,7 +28,7 @@ fn test_paragraph_snapshot_default() {
         .borders(Borders::default())
         .title(Title::from("Info"))
         .text(vec![Line::from("Line one"), Line::from("Line two")]);
-    let rendered = common::render_to_string(&mut component, 40, 6);
+    let rendered = render_to_string(&mut component, 40, 6);
     insta::assert_snapshot!("paragraph_default", rendered);
 }
 
@@ -38,6 +37,6 @@ fn test_paragraph_snapshot_centered() {
     let mut component = Paragraph::default()
         .alignment_horizontal(HorizontalAlignment::Center)
         .text(vec![Line::from("Centered")]);
-    let rendered = common::render_to_string(&mut component, 40, 3);
+    let rendered = render_to_string(&mut component, 40, 3);
     insta::assert_snapshot!("paragraph_centered", rendered);
 }

--- a/crates/tuirealm-stdlib/tests/component_phantom.rs
+++ b/crates/tuirealm-stdlib/tests/component_phantom.rs
@@ -1,8 +1,7 @@
-mod common;
-
 use tui_realm_stdlib::components::Phantom;
 use tuirealm::component::Component;
 use tuirealm::state::State;
+use tuirealm::testing::render_to_string;
 
 #[test]
 fn test_phantom_state_is_none() {
@@ -13,7 +12,7 @@ fn test_phantom_state_is_none() {
 #[test]
 fn test_phantom_snapshot_default() {
     let mut component = Phantom::default();
-    let rendered = common::render_to_string(&mut component, 40, 5);
+    let rendered = render_to_string(&mut component, 40, 5);
     insta::assert_snapshot!(rendered, @r"
 
 

--- a/crates/tuirealm-stdlib/tests/component_phantom.rs
+++ b/crates/tuirealm-stdlib/tests/component_phantom.rs
@@ -1,5 +1,6 @@
 use tui_realm_stdlib::components::Phantom;
 use tuirealm::component::Component;
+use tuirealm::ratatui::layout::Size;
 use tuirealm::state::State;
 use tuirealm::testing::render_to_string;
 
@@ -12,7 +13,7 @@ fn test_phantom_state_is_none() {
 #[test]
 fn test_phantom_snapshot_default() {
     let mut component = Phantom::default();
-    let rendered = render_to_string(&mut component, 40, 5);
+    let rendered = render_to_string(&mut component, Size::new(40, 5));
     insta::assert_snapshot!(rendered, @r"
 
 

--- a/crates/tuirealm-stdlib/tests/component_radio.rs
+++ b/crates/tuirealm-stdlib/tests/component_radio.rs
@@ -1,11 +1,10 @@
-mod common;
-
 use pretty_assertions::assert_eq;
 use tui_realm_stdlib::components::Radio;
 use tuirealm::command::{Cmd, CmdResult, Direction};
 use tuirealm::component::Component;
 use tuirealm::props::{Borders, Color, HorizontalAlignment, Title};
 use tuirealm::state::{State, StateValue};
+use tuirealm::testing::render_to_string;
 
 #[test]
 fn test_radio_initial_state() {
@@ -90,6 +89,6 @@ fn test_radio_snapshot_default() {
         .foreground(Color::Cyan)
         .choices(["Option A", "Option B", "Option C"])
         .value(0);
-    let rendered = common::render_to_string(&mut component, 40, 3);
+    let rendered = render_to_string(&mut component, 40, 3);
     insta::assert_snapshot!("radio_default", rendered);
 }

--- a/crates/tuirealm-stdlib/tests/component_radio.rs
+++ b/crates/tuirealm-stdlib/tests/component_radio.rs
@@ -3,6 +3,7 @@ use tui_realm_stdlib::components::Radio;
 use tuirealm::command::{Cmd, CmdResult, Direction};
 use tuirealm::component::Component;
 use tuirealm::props::{Borders, Color, HorizontalAlignment, Title};
+use tuirealm::ratatui::layout::Size;
 use tuirealm::state::{State, StateValue};
 use tuirealm::testing::render_to_string;
 
@@ -89,6 +90,6 @@ fn test_radio_snapshot_default() {
         .foreground(Color::Cyan)
         .choices(["Option A", "Option B", "Option C"])
         .value(0);
-    let rendered = render_to_string(&mut component, 40, 3);
+    let rendered = render_to_string(&mut component, Size::new(40, 3));
     insta::assert_snapshot!("radio_default", rendered);
 }

--- a/crates/tuirealm-stdlib/tests/component_select.rs
+++ b/crates/tuirealm-stdlib/tests/component_select.rs
@@ -1,11 +1,10 @@
-mod common;
-
 use pretty_assertions::assert_eq;
 use tui_realm_stdlib::components::Select;
 use tuirealm::command::{Cmd, CmdResult, Direction};
 use tuirealm::component::Component;
 use tuirealm::props::{Borders, Color, Title};
 use tuirealm::state::{State, StateValue};
+use tuirealm::testing::render_to_string;
 
 #[test]
 fn test_select_initial_state() {
@@ -64,7 +63,7 @@ fn test_select_snapshot_closed() {
         .foreground(Color::Cyan)
         .choices(["Option A", "Option B", "Option C"])
         .value(0);
-    let rendered = common::render_to_string(&mut component, 40, 3);
+    let rendered = render_to_string(&mut component, 40, 3);
     insta::assert_snapshot!("select_closed", rendered);
 }
 
@@ -77,6 +76,6 @@ fn test_select_snapshot_open() {
         .choices(["Option A", "Option B", "Option C"])
         .value(0);
     component.perform(Cmd::Submit); // Open tab
-    let rendered = common::render_to_string(&mut component, 40, 8);
+    let rendered = render_to_string(&mut component, 40, 8);
     insta::assert_snapshot!("select_open", rendered);
 }

--- a/crates/tuirealm-stdlib/tests/component_select.rs
+++ b/crates/tuirealm-stdlib/tests/component_select.rs
@@ -3,6 +3,7 @@ use tui_realm_stdlib::components::Select;
 use tuirealm::command::{Cmd, CmdResult, Direction};
 use tuirealm::component::Component;
 use tuirealm::props::{Borders, Color, Title};
+use tuirealm::ratatui::layout::Size;
 use tuirealm::state::{State, StateValue};
 use tuirealm::testing::render_to_string;
 
@@ -63,7 +64,7 @@ fn test_select_snapshot_closed() {
         .foreground(Color::Cyan)
         .choices(["Option A", "Option B", "Option C"])
         .value(0);
-    let rendered = render_to_string(&mut component, 40, 3);
+    let rendered = render_to_string(&mut component, Size::new(40, 3));
     insta::assert_snapshot!("select_closed", rendered);
 }
 
@@ -76,6 +77,6 @@ fn test_select_snapshot_open() {
         .choices(["Option A", "Option B", "Option C"])
         .value(0);
     component.perform(Cmd::Submit); // Open tab
-    let rendered = render_to_string(&mut component, 40, 8);
+    let rendered = render_to_string(&mut component, Size::new(40, 8));
     insta::assert_snapshot!("select_open", rendered);
 }

--- a/crates/tuirealm-stdlib/tests/component_span.rs
+++ b/crates/tuirealm-stdlib/tests/component_span.rs
@@ -3,6 +3,7 @@ use tui_realm_stdlib::components::Span;
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::component::Component;
 use tuirealm::props::HorizontalAlignment;
+use tuirealm::ratatui::layout::Size;
 use tuirealm::ratatui::text::Span as RatatuiSpan;
 use tuirealm::state::State;
 use tuirealm::testing::render_to_string;
@@ -26,7 +27,7 @@ fn test_span_unhandled_cmd() {
 fn test_span_snapshot_default() {
     let mut component =
         Span::default().spans([RatatuiSpan::raw("Hello "), RatatuiSpan::raw("World")]);
-    let rendered = render_to_string(&mut component, 40, 3);
+    let rendered = render_to_string(&mut component, Size::new(40, 3));
     insta::assert_snapshot!("span_default", rendered);
 }
 
@@ -35,6 +36,6 @@ fn test_span_snapshot_centered() {
     let mut component = Span::default()
         .alignment_horizontal(HorizontalAlignment::Center)
         .spans([RatatuiSpan::raw("Centered")]);
-    let rendered = render_to_string(&mut component, 40, 3);
+    let rendered = render_to_string(&mut component, Size::new(40, 3));
     insta::assert_snapshot!("span_centered", rendered);
 }

--- a/crates/tuirealm-stdlib/tests/component_span.rs
+++ b/crates/tuirealm-stdlib/tests/component_span.rs
@@ -1,5 +1,3 @@
-mod common;
-
 use pretty_assertions::assert_eq;
 use tui_realm_stdlib::components::Span;
 use tuirealm::command::{Cmd, CmdResult};
@@ -7,6 +5,7 @@ use tuirealm::component::Component;
 use tuirealm::props::HorizontalAlignment;
 use tuirealm::ratatui::text::Span as RatatuiSpan;
 use tuirealm::state::State;
+use tuirealm::testing::render_to_string;
 
 #[test]
 fn test_span_state_is_none() {
@@ -27,7 +26,7 @@ fn test_span_unhandled_cmd() {
 fn test_span_snapshot_default() {
     let mut component =
         Span::default().spans([RatatuiSpan::raw("Hello "), RatatuiSpan::raw("World")]);
-    let rendered = common::render_to_string(&mut component, 40, 3);
+    let rendered = render_to_string(&mut component, 40, 3);
     insta::assert_snapshot!("span_default", rendered);
 }
 
@@ -36,6 +35,6 @@ fn test_span_snapshot_centered() {
     let mut component = Span::default()
         .alignment_horizontal(HorizontalAlignment::Center)
         .spans([RatatuiSpan::raw("Centered")]);
-    let rendered = common::render_to_string(&mut component, 40, 3);
+    let rendered = render_to_string(&mut component, 40, 3);
     insta::assert_snapshot!("span_centered", rendered);
 }

--- a/crates/tuirealm-stdlib/tests/component_sparkline.rs
+++ b/crates/tuirealm-stdlib/tests/component_sparkline.rs
@@ -1,11 +1,10 @@
-mod common;
-
 use pretty_assertions::assert_eq;
 use tui_realm_stdlib::components::Sparkline;
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::component::Component;
 use tuirealm::props::{Borders, Color, Title};
 use tuirealm::state::State;
+use tuirealm::testing::render_to_string;
 
 #[test]
 fn test_sparkline_state_is_none() {
@@ -29,13 +28,13 @@ fn test_sparkline_snapshot_default() {
         .title(Title::from("Metrics"))
         .foreground(Color::Green)
         .data(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-    let rendered = common::render_to_string(&mut component, 40, 5);
+    let rendered = render_to_string(&mut component, 40, 5);
     insta::assert_snapshot!("sparkline_default", rendered);
 }
 
 #[test]
 fn test_sparkline_snapshot_empty() {
     let mut component = Sparkline::default().borders(Borders::default()).data(&[]);
-    let rendered = common::render_to_string(&mut component, 40, 5);
+    let rendered = render_to_string(&mut component, 40, 5);
     insta::assert_snapshot!("sparkline_empty", rendered);
 }

--- a/crates/tuirealm-stdlib/tests/component_sparkline.rs
+++ b/crates/tuirealm-stdlib/tests/component_sparkline.rs
@@ -3,6 +3,7 @@ use tui_realm_stdlib::components::Sparkline;
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::component::Component;
 use tuirealm::props::{Borders, Color, Title};
+use tuirealm::ratatui::layout::Size;
 use tuirealm::state::State;
 use tuirealm::testing::render_to_string;
 
@@ -28,13 +29,13 @@ fn test_sparkline_snapshot_default() {
         .title(Title::from("Metrics"))
         .foreground(Color::Green)
         .data(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-    let rendered = render_to_string(&mut component, 40, 5);
+    let rendered = render_to_string(&mut component, Size::new(40, 5));
     insta::assert_snapshot!("sparkline_default", rendered);
 }
 
 #[test]
 fn test_sparkline_snapshot_empty() {
     let mut component = Sparkline::default().borders(Borders::default()).data(&[]);
-    let rendered = render_to_string(&mut component, 40, 5);
+    let rendered = render_to_string(&mut component, Size::new(40, 5));
     insta::assert_snapshot!("sparkline_empty", rendered);
 }

--- a/crates/tuirealm-stdlib/tests/component_spinner.rs
+++ b/crates/tuirealm-stdlib/tests/component_spinner.rs
@@ -1,11 +1,10 @@
-mod common;
-
 use pretty_assertions::assert_eq;
 use tui_realm_stdlib::components::Spinner;
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::component::Component;
 use tuirealm::props::Color;
 use tuirealm::state::State;
+use tuirealm::testing::render_to_string;
 
 #[test]
 fn test_spinner_state_is_none() {
@@ -31,6 +30,6 @@ fn test_spinner_snapshot_default() {
     let mut component = Spinner::default()
         .foreground(Color::Cyan)
         .sequence("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏");
-    let rendered = common::render_to_string(&mut component, 10, 1);
+    let rendered = render_to_string(&mut component, 10, 1);
     insta::assert_snapshot!(rendered, @"⠋");
 }

--- a/crates/tuirealm-stdlib/tests/component_spinner.rs
+++ b/crates/tuirealm-stdlib/tests/component_spinner.rs
@@ -3,6 +3,7 @@ use tui_realm_stdlib::components::Spinner;
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::component::Component;
 use tuirealm::props::Color;
+use tuirealm::ratatui::layout::Size;
 use tuirealm::state::State;
 use tuirealm::testing::render_to_string;
 
@@ -30,6 +31,6 @@ fn test_spinner_snapshot_default() {
     let mut component = Spinner::default()
         .foreground(Color::Cyan)
         .sequence("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏");
-    let rendered = render_to_string(&mut component, 10, 1);
+    let rendered = render_to_string(&mut component, Size::new(10, 1));
     insta::assert_snapshot!(rendered, @"⠋");
 }

--- a/crates/tuirealm-stdlib/tests/component_table.rs
+++ b/crates/tuirealm-stdlib/tests/component_table.rs
@@ -3,6 +3,7 @@ use tui_realm_stdlib::components::Table;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::component::Component;
 use tuirealm::props::{Borders, Color, Style, TableBuilder, Title};
+use tuirealm::ratatui::layout::Size;
 use tuirealm::ratatui::text::Line;
 use tuirealm::state::{State, StateValue};
 use tuirealm::testing::render_to_string;
@@ -110,6 +111,6 @@ fn test_table_snapshot_default() {
         .headers(["Name", "Age"])
         .widths(&[20, 10])
         .table(make_table_data());
-    let rendered = render_to_string(&mut component, 50, 8);
+    let rendered = render_to_string(&mut component, Size::new(50, 8));
     insta::assert_snapshot!("table_default", rendered);
 }

--- a/crates/tuirealm-stdlib/tests/component_table.rs
+++ b/crates/tuirealm-stdlib/tests/component_table.rs
@@ -1,5 +1,3 @@
-mod common;
-
 use pretty_assertions::assert_eq;
 use tui_realm_stdlib::components::Table;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
@@ -7,6 +5,7 @@ use tuirealm::component::Component;
 use tuirealm::props::{Borders, Color, Style, TableBuilder, Title};
 use tuirealm::ratatui::text::Line;
 use tuirealm::state::{State, StateValue};
+use tuirealm::testing::render_to_string;
 
 fn make_table_data() -> tuirealm::props::Table {
     TableBuilder::default()
@@ -111,6 +110,6 @@ fn test_table_snapshot_default() {
         .headers(["Name", "Age"])
         .widths(&[20, 10])
         .table(make_table_data());
-    let rendered = common::render_to_string(&mut component, 50, 8);
+    let rendered = render_to_string(&mut component, 50, 8);
     insta::assert_snapshot!("table_default", rendered);
 }

--- a/crates/tuirealm-stdlib/tests/component_textarea.rs
+++ b/crates/tuirealm-stdlib/tests/component_textarea.rs
@@ -3,6 +3,7 @@ use tui_realm_stdlib::components::Textarea;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::component::Component;
 use tuirealm::props::{Borders, Color, Title};
+use tuirealm::ratatui::layout::Size;
 use tuirealm::ratatui::text::Span;
 use tuirealm::state::{State, StateValue};
 use tuirealm::testing::render_to_string;
@@ -100,6 +101,6 @@ fn test_textarea_snapshot_default() {
             Span::from("Second line of text"),
             Span::from("Third line of text"),
         ]);
-    let rendered = render_to_string(&mut component, 40, 7);
+    let rendered = render_to_string(&mut component, Size::new(40, 7));
     insta::assert_snapshot!("textarea_stdlib_default", rendered);
 }

--- a/crates/tuirealm-stdlib/tests/component_textarea.rs
+++ b/crates/tuirealm-stdlib/tests/component_textarea.rs
@@ -1,5 +1,3 @@
-mod common;
-
 use pretty_assertions::assert_eq;
 use tui_realm_stdlib::components::Textarea;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
@@ -7,6 +5,7 @@ use tuirealm::component::Component;
 use tuirealm::props::{Borders, Color, Title};
 use tuirealm::ratatui::text::Span;
 use tuirealm::state::{State, StateValue};
+use tuirealm::testing::render_to_string;
 
 #[test]
 fn test_textarea_initial_state() {
@@ -101,6 +100,6 @@ fn test_textarea_snapshot_default() {
             Span::from("Second line of text"),
             Span::from("Third line of text"),
         ]);
-    let rendered = common::render_to_string(&mut component, 40, 7);
+    let rendered = render_to_string(&mut component, 40, 7);
     insta::assert_snapshot!("textarea_stdlib_default", rendered);
 }

--- a/crates/tuirealm-stdlib/tests/snapshots/component_input__input_no_borders.snap
+++ b/crates/tuirealm-stdlib/tests/snapshots/component_input__input_no_borders.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tuirealm-stdlib/tests/component_input.rs
+expression: rendered
+---
+Test Text

--- a/crates/tuirealm-textarea/tests/common.rs
+++ b/crates/tuirealm-textarea/tests/common.rs
@@ -1,1 +1,0 @@
-pub use tuirealm::testing::render_to_string;

--- a/crates/tuirealm-textarea/tests/component_textarea.rs
+++ b/crates/tuirealm-textarea/tests/component_textarea.rs
@@ -1,5 +1,3 @@
-mod common;
-
 use pretty_assertions::assert_eq;
 use tui_realm_textarea::{
     TEXTAREA_CMD_DEL_LINE_BY_END, TEXTAREA_CMD_DEL_LINE_BY_HEAD, TEXTAREA_CMD_DEL_NEXT_WORD,
@@ -12,6 +10,7 @@ use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::component::Component;
 use tuirealm::props::{Borders, Color, Style, Title};
 use tuirealm::state::{State, StateValue};
+use tuirealm::testing::render_to_string;
 
 #[test]
 fn test_textarea_initial_state_empty() {
@@ -298,7 +297,7 @@ fn test_textarea_snapshot_singleline() {
     for ch in "Hello, World!".chars() {
         component.perform(Cmd::Type(ch));
     }
-    let rendered = common::render_to_string(&mut component, 40, 8);
+    let rendered = render_to_string(&mut component, 40, 8);
     insta::assert_snapshot!("textarea_crate_singleline", rendered);
 }
 
@@ -318,7 +317,7 @@ fn test_textarea_snapshot_multiline() {
     for ch in "Line 3".chars() {
         component.perform(Cmd::Type(ch));
     }
-    let rendered = common::render_to_string(&mut component, 40, 8);
+    let rendered = render_to_string(&mut component, 40, 8);
     insta::assert_snapshot!("textarea_crate_multiline", rendered);
 }
 
@@ -327,6 +326,6 @@ fn test_textarea_snapshot_empty() {
     let mut component = TextArea::default()
         .borders(Borders::default())
         .title(Title::from("Empty"));
-    let rendered = common::render_to_string(&mut component, 40, 8);
+    let rendered = render_to_string(&mut component, 40, 8);
     insta::assert_snapshot!("textarea_crate_empty", rendered);
 }

--- a/crates/tuirealm-textarea/tests/component_textarea.rs
+++ b/crates/tuirealm-textarea/tests/component_textarea.rs
@@ -9,6 +9,7 @@ use tui_realm_textarea::{
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::component::Component;
 use tuirealm::props::{Borders, Color, Style, Title};
+use tuirealm::ratatui::layout::Size;
 use tuirealm::state::{State, StateValue};
 use tuirealm::testing::render_to_string;
 
@@ -297,7 +298,7 @@ fn test_textarea_snapshot_singleline() {
     for ch in "Hello, World!".chars() {
         component.perform(Cmd::Type(ch));
     }
-    let rendered = render_to_string(&mut component, 40, 8);
+    let rendered = render_to_string(&mut component, Size::new(40, 8));
     insta::assert_snapshot!("textarea_crate_singleline", rendered);
 }
 
@@ -317,7 +318,7 @@ fn test_textarea_snapshot_multiline() {
     for ch in "Line 3".chars() {
         component.perform(Cmd::Type(ch));
     }
-    let rendered = render_to_string(&mut component, 40, 8);
+    let rendered = render_to_string(&mut component, Size::new(40, 8));
     insta::assert_snapshot!("textarea_crate_multiline", rendered);
 }
 
@@ -326,6 +327,6 @@ fn test_textarea_snapshot_empty() {
     let mut component = TextArea::default()
         .borders(Borders::default())
         .title(Title::from("Empty"));
-    let rendered = render_to_string(&mut component, 40, 8);
+    let rendered = render_to_string(&mut component, Size::new(40, 8));
     insta::assert_snapshot!("textarea_crate_empty", rendered);
 }

--- a/crates/tuirealm-treeview/tests/common.rs
+++ b/crates/tuirealm-treeview/tests/common.rs
@@ -1,1 +1,0 @@
-pub use tuirealm::testing::render_to_string;

--- a/crates/tuirealm-treeview/tests/component_treeview.rs
+++ b/crates/tuirealm-treeview/tests/component_treeview.rs
@@ -1,5 +1,3 @@
-mod common;
-
 use pretty_assertions::assert_eq;
 use tui_realm_treeview::mock::mock_tree;
 use tui_realm_treeview::{TREE_CMD_CLOSE, TREE_CMD_OPEN, TreeView};
@@ -7,6 +5,7 @@ use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::component::Component;
 use tuirealm::props::{Borders, Color, Style, Title};
 use tuirealm::state::{State, StateValue};
+use tuirealm::testing::render_to_string;
 
 #[test]
 fn test_treeview_initial_state() {
@@ -115,7 +114,7 @@ fn test_treeview_snapshot_default() {
         .indent_size(3)
         .with_tree(mock_tree())
         .initial_node("/");
-    let rendered = common::render_to_string(&mut component, 40, 15);
+    let rendered = render_to_string(&mut component, 40, 15);
     insta::assert_snapshot!("treeview_default", rendered);
 }
 
@@ -128,6 +127,6 @@ fn test_treeview_snapshot_collapsed() {
         .with_tree(mock_tree())
         .initial_node("/");
     component.perform(Cmd::Custom(TREE_CMD_CLOSE));
-    let rendered = common::render_to_string(&mut component, 40, 15);
+    let rendered = render_to_string(&mut component, 40, 15);
     insta::assert_snapshot!("treeview_collapsed", rendered);
 }

--- a/crates/tuirealm-treeview/tests/component_treeview.rs
+++ b/crates/tuirealm-treeview/tests/component_treeview.rs
@@ -4,6 +4,7 @@ use tui_realm_treeview::{TREE_CMD_CLOSE, TREE_CMD_OPEN, TreeView};
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::component::Component;
 use tuirealm::props::{Borders, Color, Style, Title};
+use tuirealm::ratatui::layout::Size;
 use tuirealm::state::{State, StateValue};
 use tuirealm::testing::render_to_string;
 
@@ -114,7 +115,7 @@ fn test_treeview_snapshot_default() {
         .indent_size(3)
         .with_tree(mock_tree())
         .initial_node("/");
-    let rendered = render_to_string(&mut component, 40, 15);
+    let rendered = render_to_string(&mut component, Size::new(40, 15));
     insta::assert_snapshot!("treeview_default", rendered);
 }
 
@@ -127,6 +128,6 @@ fn test_treeview_snapshot_collapsed() {
         .with_tree(mock_tree())
         .initial_node("/");
     component.perform(Cmd::Custom(TREE_CMD_CLOSE));
-    let rendered = render_to_string(&mut component, 40, 15);
+    let rendered = render_to_string(&mut component, Size::new(40, 15));
     insta::assert_snapshot!("treeview_collapsed", rendered);
 }

--- a/crates/tuirealm/src/terminal/adapter/test.rs
+++ b/crates/tuirealm/src/terminal/adapter/test.rs
@@ -3,6 +3,7 @@
 
 use ratatui::Terminal;
 use ratatui::backend::TestBackend;
+use ratatui::layout::Size;
 
 use crate::ratatui::TerminalOptions;
 use crate::terminal::{TerminalAdapter, TerminalError, TerminalResult};
@@ -17,18 +18,14 @@ pub struct TestTerminalAdapter {
 impl TestTerminalAdapter {
     /// Create a new [`TestTerminalAdapter`] instance with default ratatui Terminal options and the provided
     /// height and width.
-    pub fn new(width: u16, height: u16) -> TerminalResult<Self> {
-        Self::new_with_options(width, height, TerminalOptions::default())
+    pub fn new(size: Size) -> TerminalResult<Self> {
+        Self::new_with_options(size, TerminalOptions::default())
     }
 
     /// Create a new [`TestTerminalAdapter`] instance with custom ratatui Terminal options, and the provided
     /// sizes.
-    pub fn new_with_options(
-        width: u16,
-        height: u16,
-        options: TerminalOptions,
-    ) -> TerminalResult<Self> {
-        let backend = TestBackend::new(width, height);
+    pub fn new_with_options(size: Size, options: TerminalOptions) -> TerminalResult<Self> {
+        let backend = TestBackend::new(size.width, size.height);
         let terminal = Terminal::with_options(backend, options)
             .map_err(|_| TerminalError::Other("Failed creating terminal"))?;
 

--- a/crates/tuirealm/src/testing.rs
+++ b/crates/tuirealm/src/testing.rs
@@ -7,18 +7,19 @@
 //! # Example
 //!
 //! ```no_run
-//! use tuirealm::component::Component;
-//! use tuirealm::testing::render_to_string;
-//!
+//! # use tuirealm::component::Component;
+//! # use tuirealm::testing::render_to_string;
+//! # use tuirealm::ratatui::layout::Size;
+//! #
 //! fn assert_component_snapshot(component: &mut dyn Component) {
-//!     let rendered = render_to_string(component, 40, 10);
+//!     let rendered = render_to_string(component, Size::new(40, 10));
 //!     insta::assert_snapshot!(rendered);
 //! }
 //! ```
 
 use crate::component::Component;
 use crate::ratatui::buffer::Buffer;
-use crate::ratatui::layout::Rect;
+use crate::ratatui::layout::Size;
 use crate::terminal::{TerminalAdapter, TestTerminalAdapter};
 
 /// Convert a ratatui [`Buffer`] to a string, one line per row,
@@ -56,20 +57,17 @@ pub fn buffer_to_string(buffer: &Buffer) -> String {
 /// # Arguments
 ///
 /// * `component` — the component to render.
-/// * `width` — width of the virtual terminal in columns.
-/// * `height` — height of the virtual terminal in rows.
+/// * `size` — width & height of the virtual terminal.
 ///
 /// # Panics
 ///
 /// Panics if the [`TestTerminalAdapter`] cannot be created or if the
 /// draw call fails.
-pub fn render_to_string(component: &mut dyn Component, width: u16, height: u16) -> String {
-    let mut adapter =
-        TestTerminalAdapter::new(width, height).expect("failed to create TestTerminalAdapter");
-    let area = Rect::new(0, 0, width, height);
+pub fn render_to_string(component: &mut dyn Component, size: Size) -> String {
+    let mut adapter = TestTerminalAdapter::new(size).expect("failed to create TestTerminalAdapter");
     let completed = adapter
         .raw_mut()
-        .draw(|f| component.view(f, area))
+        .draw(|f| component.view(f, f.area()))
         .expect("failed to draw component");
     buffer_to_string(completed.buffer)
 }


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

Re https://github.com/veeso/tui-realm-stdlib/issues/62

## Description

This PR adds a additional snapshot test for `Input` when there is no border applied.
Also does:
- remove all `testing/common.rs` files as they are now no longer necessary.
- refactor `width, height` to take a `size` instead, which should make it more concise on a glance (without intellisense)

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
