### PR TITLE
docs(tuirealm): fix stale API in guides, sync zh-cn translations

### DIFF
--- a/crates/tuirealm/docs/en/advanced.md
+++ b/crates/tuirealm/docs/en/advanced.md
@@ -57,21 +57,21 @@ So what is a subscription actually, and how we can create them?
 The subscription is defined as:
 
 ```rust
-pub struct Sub<ComponentId, UserEvent>(SubEventClause<UserEvent>, Arc<SubClause<ComponentId>>)
+pub struct Sub<ComponentId, UserEvent>(EventClause<UserEvent>, Arc<SubClause<ComponentId>>)
 where
     ComponentId: Eq + PartialEq + Clone + Hash,
     UserEvent: Eq + PartialEq + Clone;
 ```
 
 It takes 2 parameters:
-- `SubEventClause<UserEvent>`: The **Event Clause**, which determines what type of event to forward. This practically mirrors `Event`'s Variants directly.
+- `EventClause<UserEvent>`: The **Event Clause**, which determines what type of event to forward. This practically mirrors `Event`'s Variants directly.
 - `SubClause<ComponentId>`: The actual *ruleset* to determine, well, *when* to forward a given Event to the target Component.
 
-**`SubClause`** has many variants to allow a broad range of possibilities, for example it has `Always`, which will always forward a event, no specific rules; it has `IsMounted`, which is like `Always`, only that it only forwards to **Id** if there is a component mounted to it; finally there are logical combinators like `And`, `Or` and `Not`. There are some other variants, which should be self-describing. More on that in a later section.
+**`SubClause`** has many variants to allow a broad range of possibilities, for example it has `Always`, which will always forward an event, no specific rules; it has `IsMounted`, which is like `Always`, only that it only forwards to **Id** if there is a component mounted to it; finally there are logical combinators like `And`, `Or` and `Not`. There are some other variants, which should be self-describing. More on that in a later section.
 
 So when an event is received, if a component, **that is not active**, satisfies the *event clause* and the *sub clause*, then the event will be forwarded to that component too.
 
-> ❗ In order to forward an event, both the `SubEventClause` and the `SubClause` must be satisfied
+> ❗ In order to forward an event, both the `EventClause` and the `SubClause` must be satisfied
 
 Note that if a given Component is active, it will never get the event twice through being focused and through a subscription it may also have.
 
@@ -88,25 +88,25 @@ app.mount(
     Id::Clock,
     Box::new(
         Clock::new(SystemTime::now())
-            .alignment(Alignment::Center)
+            .alignment(HorizontalAlignment::Center)
     ),
-    vec![Sub::new(SubEventClause::Tick, SubClause::Always)]
+    vec![Sub::new(EventClause::Tick, SubClause::Always)]
 );
 ```
 
 Or you can create new subscriptions whenever you want:
 
 ```rust
-app.subscribe(&Id::Clock, Sub::new(SubEventClause::Tick, SubClause::Always));
+app.subscribe(&Id::Clock, Sub::new(EventClause::Tick, SubClause::Always));
 ```
 
 And if you need to remove a subscription you can unsubscribe simply with:
 
 ```rust
-app.unsubscribe(&Id::Clock, SubEventClause::Tick);
+app.unsubscribe(&Id::Clock, EventClause::Tick);
 ```
 
-> ❗ If you have multiple rules for a given `SubEventClause`, `unsubscribe` will remove *all* subscriptions matching that clause.
+> ❗ If you have multiple rules for a given `EventClause`, `unsubscribe` will remove *all* subscriptions matching that clause.
 
 ### Event clauses in detail
 
@@ -274,12 +274,12 @@ Once we've defined what the component should look like, we can start defining th
 - `Borders(Borders)`: will define the border properties for the component
 - `Content(Payload(Vec(String)))`: will define the possible options for the radio group
 - `Title(Title)`: will define the box title
-- `Value(Payload(One(Usize)))`: will work as a prop, but will update the state too, for the current selected option.
+- `Value(Payload(Single(Usize)))`: will work as a prop, but will update the state too, for the current selected option.
 
 ```rust
 pub struct Radio {
     props: Props,
-    state: RadioState
+    states: RadioState,
 }
 
 impl Radio {
@@ -297,7 +297,7 @@ impl Component for Radio {
     // ...
 
     fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
-        self.props.get_as_ref(attr)
+        self.props.get_for_query(attr)
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {
@@ -310,11 +310,11 @@ impl Component for Radio {
                     .into_iter()
                     .map(|x| x.unwrap_str())
                     .collect();
-                self.state.set_choices(choices);
+                self.states.set_choices(choices);
             }
             Attribute::Value => {
-                let index = value.unwrap_payload().unwrap_one().unwrap_usize();
-                self.state.select(index);
+                let index = value.unwrap_payload().unwrap_single().unwrap_usize();
+                self.states.select(index);
             }
             attr => {
                 self.props.set(attr, value);
@@ -379,7 +379,7 @@ impl Component for Radio {
     // ...
 
     fn state(&self) -> State {
-        State::One(StateValue::Usize(self.states.choice))
+        State::Single(StateValue::Usize(self.states.choice))
     }
 
     // ...
@@ -439,11 +439,11 @@ impl Component for Radio {
         }
 
         // Make choices
-        let choices: Vec<Spans> = self
-            .state
+        let choices: Vec<Line> = self
+            .states
             .choices
             .iter()
-            .map(|x| Spans::from(x))
+            .map(|x| Line::from(x.as_str()))
             .collect();
 
         // Fetch all other style properties
@@ -467,7 +467,7 @@ impl Component for Radio {
             .fg(foreground)
             .bg(background);
 
-        let highlight_style = style.patch(Style::default().bg(highlight_bg));
+        let highlight_style = normal_style.patch(Style::default().bg(highlight_bg));
 
         // assemble the Block (borders)
         let borders = self
@@ -475,7 +475,12 @@ impl Component for Radio {
             .get(Attribute::Borders)
             .and_then(AttrValue::as_borders)
             .unwrap_or_default();
-        let title = self.props.get(Attribute::Title).map(|x| x.unwrap_title());
+        let title = self
+            .props
+            .get(Attribute::Title)
+            .and_then(AttrValue::as_title)
+            .cloned()
+            .unwrap_or_default();
         let focus = self
             .props
             .get(Attribute::Focus)
@@ -485,13 +490,17 @@ impl Component for Radio {
         let block = Block::default()
             .title_top(title.content)
             .borders(borders.sides)
-            .border_style(if focus { borders.style() } else { Style::default().fg(Color::DarkGrey) });
+            .border_style(if focus {
+                borders.style()
+            } else {
+                Style::default().fg(Color::DarkGray)
+            });
 
         // Finally, use a ratatui widget to draw the contents
         let tabs = Tabs::new(choices)
             .block(block)
-            .select(self.state.choice)
-            .style(style)
+            .select(self.states.choice)
+            .style(normal_style)
             .highlight_style(highlight_style);
         render.render_widget(tabs, area);
     }

--- a/crates/tuirealm/docs/en/get-started.md
+++ b/crates/tuirealm/docs/en/get-started.md
@@ -127,7 +127,7 @@ In practice a component is a trait, with these methods to be implmented:
 ```rust
 pub trait Component {
     fn view(&mut self, frame: &mut Frame, area: Rect);
-    fn query(&self, attr: Attribute) -> Option<AttrValue>;
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>>;
     fn attr(&mut self, attr: Attribute, value: AttrValue);
     fn state(&self) -> State;
     fn perform(&mut self, cmd: Cmd) -> CmdResult;
@@ -427,7 +427,7 @@ As we can quickly see, the tick method has the following workflow:
 
 1. The event listener is fetched according to the provided `PollStrategy`
 
-    > ❗The poll strategy tells how to poll the event listener. For example you can only fetch one event per cycle, or multiple; various Strategies are available. For a fully event driven application `BlockingUpTo` is recommended.
+    > ❗The poll strategy tells how to poll the event listener. For example you can only fetch one event per cycle, or multiple; various Strategies are available. For a fully event driven application `Once` is recommended.
 
 2. All the incoming events are immediately forwarded to the current *active* component in the *view*, which may return some *messages*
 3. All the incoming events are sent to all the components subscribed to that event, which satisfied the clauses described in the subscription. They, as usual, will may return some *messages*
@@ -537,6 +537,7 @@ So we've said we have two Counters, one tracking alphabetic characters and one d
 With that said, let's start to implement the counter:
 
 ```rust
+#[derive(Default)]
 struct Counter {
     props: Props,
     states: OwnStates,
@@ -566,11 +567,11 @@ Then, we'll implement easy-to-use Builder methods for our Component:
 impl Counter {
     pub fn label<S>(mut self, label: S) -> Self
     where
-        S: AsRef<str>,
+        S: Into<LineStatic>,
     {
         self.attr(
             Attribute::Title,
-            AttrValue::Title((label.as_ref().to_string(), Alignment::Center)),
+            AttrValue::Title(Title::from(label).alignment(HorizontalAlignment::Center)),
         );
         self
     }
@@ -589,6 +590,11 @@ impl Counter {
         self.attr(Attribute::Background, AttrValue::Color(c));
         self
     }
+
+    pub fn borders(mut self, b: Borders) -> Self {
+        self.attr(Attribute::Borders, AttrValue::Borders(b));
+        self
+    }
 }
 ```
 
@@ -598,59 +604,65 @@ Finally we can implement `Component` for `Counter`
 impl Component for Counter {
     fn view(&mut self, frame: &mut Frame, area: Rect) {
         // Check if the component is meant to be displayed or hidden
-        if !self.props.get_or(Attribute::Display, AttrValue::Flag(true)).unwrap_flag() {
+        if matches!(
+            self.props.get(Attribute::Display),
+            Some(AttrValue::Flag(false))
+        ) {
             return;
         }
 
         // Get the text we want to display
-        let count_str = self.states.counter.to_string();
+        let text = self.states.counter.to_string();
 
-        // Get other properties to apply
+        // Get other properties to apply, falling back to defaults if unset
         let foreground = self
             .props
-            .get_or(Attribute::Foreground, AttrValue::Color(Color::Reset))
-            .unwrap_color();
+            .get(Attribute::Foreground)
+            .and_then(AttrValue::as_color)
+            .unwrap_or(Color::Reset);
         let background = self
             .props
-            .get_or(Attribute::Background, AttrValue::Color(Color::Reset))
-            .unwrap_color();
-        let style = Style::default()
-            .fg(foreground)
-            .bg(background);
-
+            .get(Attribute::Background)
+            .and_then(AttrValue::as_color)
+            .unwrap_or(Color::Reset);
         let title = self
             .props
-            .get_or(
-                Attribute::Title,
-                AttrValue::Title(Title::default()),
-            )
-            .unwrap_title();
+            .get(Attribute::Title)
+            .and_then(AttrValue::as_title)
+            .cloned()
+            .unwrap_or_default();
         let borders = self
             .props
-            .get_or(Attribute::Borders, AttrValue::Borders(Borders::default()))
-            .unwrap_borders();
+            .get(Attribute::Borders)
+            .and_then(AttrValue::as_borders)
+            .unwrap_or_default();
         // we also want to draw the block border differently depending if the component is focused or not
         let focus = self
             .props
-            .get_or(Attribute::Focus, AttrValue::Flag(false))
-            .unwrap_flag();
+            .get(Attribute::Focus)
+            .and_then(AttrValue::as_flag)
+            .unwrap_or(false);
 
         let block = Block::default()
             .title_top(title.content)
             .borders(borders.sides)
-            .border_style(if focus { borders.style() } else { Style::default().fg(Color::DarkGrey) });
+            .border_style(if focus {
+                borders.style()
+            } else {
+                Style::default().fg(Color::DarkGray)
+            });
 
         frame.render_widget(
-            Paragraph::new(count_str)
+            Paragraph::new(text)
                 .block(block)
-                .style(style)
-                .alignment(alignment),
+                .style(Style::default().fg(foreground).bg(background))
+                .alignment(HorizontalAlignment::Center),
             area,
         );
     }
 
     fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
-        self.props.get_as_ref(attr)
+        self.props.get_for_query(attr)
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {
@@ -658,7 +670,7 @@ impl Component for Counter {
     }
 
     fn state(&self) -> State {
-        State::One(StateValue::Isize(self.states.counter))
+        State::Single(StateValue::Isize(self.states.counter))
     }
 
     fn perform(&mut self, cmd: Cmd) -> CmdResult {
@@ -675,10 +687,11 @@ impl Component for Counter {
 
 This is one big code dump, so lets break it down:
 
-- in `view` we fetch all properties that can be set and apply them to be drawn
-- in `query` and `attr` just pass them right through to `Props` to get / set the properties
-- in `state` return the current counter `times` value
-- in `perform`, on Command `Submit` we increment the counter and return a `Changed` value and ignore all other commands
+- in `view` we fetch all properties that can be set and apply them to be drawn. `Props::get` returns `Option<&AttrValue>`; the `AttrValue::as_*` helpers convert it into the concrete type we want, and we fall back to a default if the attribute hasn't been set.
+- in `query` we hand back a `QueryResult` via `Props::get_for_query`, which the view uses to read attributes without cloning
+- `attr` just forwards the value through to `Props` to update a property
+- `state` returns the current counter value wrapped in `State::Single`
+- `perform` increments the counter and returns a `Changed` result on `Cmd::Submit`; any other command is rejected with `CmdResult::Invalid`
 
 With that our **Component** is ready, we could now implement our two **Components**, but we also need some other types like **Messages**, so lets go and do those first.
 
@@ -713,8 +726,11 @@ So for our application, as we did for `Msg`, let's define `Id` with a Enum:
 pub enum Id {
     DigitCounter,
     LetterCounter,
+    Label,
 }
 ```
+
+> ❗ We also include a `Label` id which we'll use to display the last message received from the counters. The `Label` itself comes from [`tui-realm-stdlib`](https://github.com/veeso/tui-realm/tree/main/crates/tuirealm-stdlib) so we don't need to implement one here.
 
 ### Implementing the two counter components
 
@@ -772,7 +788,7 @@ impl AppComponent<Msg, NoUserEvent> for LetterCounter {
         };
         // perform
         match self.perform(cmd) {
-            CmdResult::Changed(State::One(StateValue::Isize(c))) => {
+            CmdResult::Changed(State::Single(StateValue::Isize(c))) => {
                 Some(Msg::LetterCounterChanged(c))
             }
             _ => None,
@@ -810,18 +826,20 @@ impl Model {
         self
             .terminal
             .draw(|f| {
-                let [letter, digit] = Layout::default()
+                let [letter, digit, label] = Layout::default()
                     .direction(Direction::Vertical)
                     .margin(1)
                     .constraints(
                         [
                             Constraint::Length(3), // Letter Counter
                             Constraint::Length(3), // Digit Counter
+                            Constraint::Length(1), // Label
                         ]
                     )
-                    .areas(f.size());
+                    .areas(f.area());
                 self.app.view(&Id::LetterCounter, f, letter);
                 self.app.view(&Id::DigitCounter, f, digit);
+                self.app.view(&Id::Label, f, label);
             }).expect("App to draw without error");
     }
 }
@@ -896,10 +914,11 @@ We're almost done, lets just quickly create a helper method to create the **Appl
 fn init_app() -> Application<Id, Msg, NoUserEvent> {
     // Setup application
     // NOTE: NoUserEvent is a shorthand to tell tui-realm we're not going to use any custom user event
-    // NOTE: the event listener is configured to use the default crossterm input listener
+    // NOTE: the event listener is configured to use the default crossterm input listener,
+    //       polling every 20ms and collecting up to 3 events per poll
     let mut app: Application<Id, Msg, NoUserEvent> = Application::init(
         EventListenerCfg::default()
-            .crossterm_input_listener(Duration::from_millis(20)),
+            .crossterm_input_listener(Duration::from_millis(20), 3),
     );
 }
 ```
@@ -908,7 +927,7 @@ The app requires the configuration for the `EventListener` which will poll `Port
 
 > ❗ Here we could also define other Ports or setup the `Tick` producer with `tick_interval()`
 
-Then we can mount the two components into the view:
+Then we can mount the two counters and the label into the view:
 
 ```rust
 app.mount(
@@ -921,11 +940,22 @@ app.mount(
     Box::new(DigitCounter::new(5)),
     Vec::default()
 )?;
+app.mount(
+    Id::Label,
+    Box::new(
+        Label::default()
+            .text("Waiting for a Msg...")
+            .alignment(HorizontalAlignment::Left)
+            .foreground(Color::LightYellow)
+            .modifiers(TextModifiers::BOLD),
+    ),
+    Vec::default(),
+)?;
 ```
 
-> ❗ The two empty vectors are the subscriptions related to the component. (In this case none)
+> ❗ The empty vectors are the subscriptions related to each component. (In this case none)
 
-Then we initilize focus:
+Then we initialize focus:
 
 ```rust
 app.active(&Id::LetterCounter)?;
@@ -948,7 +978,7 @@ impl Model {
     fn init_app() -> Result<Application<Id, Msg, NoUserEvent>, Box<dyn Error>> { 
         let mut app: Application<Id, Msg, NoUserEvent> = Application::init(
             EventListenerCfg::default()
-                .crossterm_input_listener(Duration::from_millis(20)),
+                .crossterm_input_listener(Duration::from_millis(20), 3),
         );
 
         app.mount(
@@ -960,6 +990,17 @@ impl Model {
             Id::DigitCounter,
             Box::new(DigitCounter::new(5)),
             Vec::default()
+        )?;
+        app.mount(
+            Id::Label,
+            Box::new(
+                Label::default()
+                    .text("Waiting for a Msg...")
+                    .alignment(HorizontalAlignment::Left)
+                    .foreground(Color::LightYellow)
+                    .modifiers(TextModifiers::BOLD),
+            ),
+            Vec::default(),
         )?;
 
         app.active(&Id::LetterCounter)?;
@@ -986,7 +1027,7 @@ model.view();
 
 while !model.quit {
     // Tick
-    match model.app.tick(PollStrategy::BlockingUpTo(1)) {
+    match model.app.tick(PollStrategy::Once(Duration::from_millis(10))) {
         Err(err) => {
             // Handle error...
         }
@@ -999,16 +1040,19 @@ while !model.quit {
                 }
             }
         }
+        _ => {}
     }
     // Redraw
     if model.redraw {
-        model.view(&mut app);
+        model.view();
         model.redraw = false;
     }
 }
 ```
 
-On each cycle we call `tick()` on our application, with strategy `BlockingUpTo` with a max collection of events of `1`. If there is a message, we ask the Model to process the messages. After processing, we redraw, only if the Model has decided it needs to be re-drawn.
+On each cycle we call `tick()` on our application, with strategy `Once` and a 10ms timeout, meaning we poll once per cycle waiting at most 10ms for an event. If there is a message, we ask the Model to process the messages. After processing, we redraw, but only if the Model has decided it needs to be re-drawn.
+
+> ❗ Other `PollStrategy` variants exist (`TryFor`, `UpTo`, `BlockCollectUpTo`) which block for longer or collect more events per tick — pick the one that fits your application's responsiveness needs.
 
 Once `quit` becomes true, the application terminates.
 All backends provided by `tui-realm` itself, will automatically clean-up terminal modes on `Drop`.

--- a/crates/tuirealm/docs/en/migrating-4.0.md
+++ b/crates/tuirealm/docs/en/migrating-4.0.md
@@ -1,5 +1,7 @@
 # Migrating from tui-realm 3.x
 
+📍<u>**English**</u> | <a href="../zh-cn/migrating-4.0.md">简体中文</a>
+
 - [Migrating from tui-realm 3.x](#migrating-from-tui-realm-3x)
   - [Introduction](#introduction)
 

--- a/crates/tuirealm/docs/zh-cn/advanced.md
+++ b/crates/tuirealm/docs/zh-cn/advanced.md
@@ -1,21 +1,21 @@
-📍<u>**简体中文**</u> | <a href="../en/advanced.md">English</a>
-
 # 高级概念
+
+<a href="../en/advanced.md">English</a> | 📍<u>**简体中文**</u>
 
 - [高级概念](#高级概念)
   - [简介](#简介)
-  - [订阅 (Subscriptions)](#订阅 (Subscriptions))
+  - [订阅 (Subscriptions)](#订阅-subscriptions)
     - [处理订阅](#处理订阅)
-    - [事件子句 (Event clauses) 详解](#事件子句 (Event clauses) 详解)
-    - [订阅子句 (Sub clauses) 详解](#订阅子句 (Sub clauses) 详解)
+    - [事件子句 (Event clauses) 详解](#事件子句-event-clauses-详解)
+    - [订阅子句 (Sub clauses) 详解](#订阅子句-sub-clauses-详解)
     - [订阅锁](#订阅锁)
   - [Tick 事件](#tick-事件)
-  - [端口](#端口)
+  - [端口 (Ports)](#端口-ports)
   - [实现新组件](#实现新组件)
     - [组件应该是什么样子](#组件应该是什么样子)
     - [定义组件属性](#定义组件属性)
     - [定义组件状态](#定义组件状态)
-    - [定义 Cmd API](#定义-cmd-api)
+    - [定义 Command API](#定义-command-api)
     - [渲染组件](#渲染组件)
   - [属性注入器](#属性注入器)
   - [下一步](#下一步)
@@ -24,201 +24,187 @@
 
 ## 简介
 
-本指南将向您介绍 tui-realm 的所有高级概念，这些概念在[入门指南](get-started.md)中未涵盖。尽管 tui-realm 相当简单，但它也可以变得非常强大，这得益于我们将在本文档中介绍的所有这些功能。
+本指南将介绍 `tui-realm` 的所有高级概念，这些内容未在 [入门指南](get-started.md) 中涉及。
+尽管 `tui-realm` 相当简洁，但得益于本文档涵盖的这些特性，它也可以非常强大。
 
-您将学习到：
+你将学习到：
 
-- 如何处理订阅 (Subscriptions)，使某些组件在特定情况下监听特定事件
-- 什么是 `Event::Tick`
-- 如何通过 `Ports` 使用自定义事件源
-- 如何实现新组件
+- 如何处理 **Subscriptions**，使某些组件在特定条件下监听特定事件，即使未获得焦点。
+- 如何通过 `Ports` 使用自定义事件源。
+- 相比 [入门指南](get-started.md)，更详细地了解如何设计可复用的自定义组件。
 
 ---
 
 ## 订阅 (Subscriptions)
 
-> 订阅是一个规则集，它告诉**应用程序**基于某些规则将事件转发给其他组件，即使它们不处于活动状态。
+> 订阅是一个规则集，它告诉 **Application** 即使组件未处于活动状态也要将事件转发给它们。
 
-正如我们在 tui-realm 的基本概念中已经介绍的，应用负责将事件从端口转发到组件。
-默认情况下，事件仅转发给当前活动组件，但这可能相当烦人：
+正如我们在 `tui-realm` 基础概念中已经介绍的，*Application* 负责将事件从 *Ports* 转发到 *Components*。
+默认情况下，事件仅转发给当前活动组件，但这可能带来一些麻烦：
 
-- 首先，我们可能需要一个组件始终监听传入事件。想象一些轮询远程服务器的加载器。它们不能仅在获得焦点时更新，它们可能需要在*事件监听器*每次接收到来自*端口*的事件时更新。没有*订阅*，这将是不可能的。
-- 有时这只是"太无聊"和范围的问题：在示例中我有两个计数器，它们都监听 `<ESC>` 键来退出应用并返回 `AppClose` 消息。但是告诉应用是否应该终止是它们的责任吗？我的意思是，它们只是计数器，所以它们不应该知道是否关闭应用，对吧？除此之外，为每个组件编写 `<ESC>` 的情况来返回 `AppClose` 也非常烦人。有一个不可见的组件始终监听 `<ESC>` 来返回 `AppClose` 会舒服得多。
+- 首先，我们可能需要一个组件始终监听特定的传入事件。设想某些 *Components* 需要从远程服务器获取数据。
+  它们不能仅在获得焦点时更新，很可能需要在每次 *Port* 产生事件并被 *Event listener* 接收时都更新。
+  没有 *Subscriptions*，这很难实现。
+- 有时这只是重复和范围问题：在 [入门指南](get-started.md#我们的第一个应用) 的示例中我们有两个 counter，
+  它们都在监听 `<ESC>` 键以退出应用，返回 `AppClose` 消息。
+  但告诉应用是否应该终止真的是它们的职责吗？
+  毕竟它们只是计数器，所以它们不应该知道是否关闭应用对吧？
+  除此之外，为每个组件编写 `<ESC>` 匹配以返回 `AppClose` 也非常麻烦。
+  有一个始终监听 `<ESC>` 并返回 `AppClose` 的不可见组件会舒服得多。
 
-那么订阅实际上是什么，我们如何创建它们？
+那么订阅究竟是什么，我们如何创建它？
 
 订阅定义为：
 
 ```rust
-pub struct Sub<UserEvent>(EventClause<UserEvent>, SubClause)
+pub struct Sub<ComponentId, UserEvent>(EventClause<UserEvent>, Arc<SubClause<ComponentId>>)
 where
+    ComponentId: Eq + PartialEq + Clone + Hash,
     UserEvent: Eq + PartialEq + Clone;
 ```
 
-所以它是一个元组结构，接受一个 `EventClause` 和一个 `SubClause`，让我们深入了解：
+它接受 2 个参数：
 
-- **事件子句**是传入事件必须满足的匹配子句。正如我们之前所说，应用必须知道是否将某个*事件*转发给某个组件。所以它必须检查的第一件事是它是否正在监听那种事件。
+- `EventClause<UserEvent>`：**事件子句**，决定要转发哪种类型的事件。这实际上直接镜像了 `Event` 的变体。
+- `SubClause<ComponentId>`：实际的 *规则集*，决定 *何时* 将给定事件转发给目标 Component。
 
-    事件子句声明如下：
+**`SubClause`** 有许多变体以允许广泛的可能性，例如它有 `Always`，将总是转发事件，没有特定规则；它有 `IsMounted`，与 `Always` 类似，但仅在该 **Id** 挂载有组件时才转发；最后还有 `And`、`Or` 和 `Not` 这样的逻辑组合器。还有一些其他应该见名知意的变体。我们会在后文详细介绍。
 
-    ```rust
-    pub enum EventClause<UserEvent>
-    where
-        UserEvent: Eq + PartialEq + Clone,
-    {
-        /// 无论何种事件都转发
-        Any,
-        /// 检查是否按下了某个键
-        Keyboard(KeyEvent),
-        /// 检查窗口是否已调整大小
-        WindowResize,
-        /// 在 tick 时转发事件
-        Tick,
-        /// 在此特定用户事件时转发事件。
-        /// 用户事件的匹配方式取决于其 partialEq 实现
-        User(UserEvent),
-    }
-    ```
+所以当接收到事件时，如果一个 **非活动** 的组件同时满足 *event clause* 和 *sub clause*，则该事件也将转发给它。
 
-- **订阅子句**是必须由与订阅关联的组件满足的附加条件，以便转发事件：
+> ❗ 要转发事件，必须同时满足 `EventClause` 和 `SubClause`
 
-    ```rust
-    pub enum SubClause {
-        /// 始终将事件转发给组件
-        Always,
-        /// 如果目标组件具有提供的属性和提供的值，则转发事件
-        /// 如果组件上不存在该属性，结果始终为 `false`。
-        HasAttrValue(Attribute, AttrValue),
-        /// 如果目标组件具有提供的状态，则转发事件
-        HasState(State),
-        /// 如果内部子句为 `false`，则转发事件
-        Not(Box<SubClause>),
-        /// 如果两个内部子句都为 `true`，则转发事件
-        And(Box<SubClause>, Box<SubClause>),
-        /// 如果至少一个内部子句为 `true`，则转发事件
-        Or(Box<SubClause>, Box<SubClause>),
-    }
-    ```
-
-因此，当接收到事件时，如果一个**不活动**的组件满足事件子句和订阅子句，那么事件也将转发给该组件。
-
-> ❗ 为了转发事件，必须同时满足 `EventClause` 和 `SubClause`
+注意，如果一个组件是活动的，它不会因同时获得焦点和订阅而收到两次该事件。
 
 让我们详细看看如何处理订阅以及如何使用子句。
 
 ### 处理订阅
 
-您可以在组件挂载时和任何时候创建订阅。
+你可以在组件挂载时创建订阅，也可以在之后动态创建。
 
-要在 `mount` 时订阅组件，只需向 `mount()` 提供 `Sub` 向量：
+要在 `mount` 时订阅组件，向 `mount()` 提供 `Sub` 的向量即可：
 
 ```rust
 app.mount(
     Id::Clock,
     Box::new(
         Clock::new(SystemTime::now())
-            .alignment(Alignment::Center)
-            .background(Color::Reset)
-            .foreground(Color::Cyan)
-            .modifiers(TextModifiers::BOLD)
+            .alignment(HorizontalAlignment::Center)
     ),
-    vec![Sub::new(SubEventClause::Tick, SubClause::Always)]
+    vec![Sub::new(EventClause::Tick, SubClause::Always)]
 );
 ```
 
-或者您可以在任何时候创建新订阅：
+也可以随时创建新订阅：
 
 ```rust
-app.subscribe(&Id::Clock, Sub::new(SubEventClause::Tick, SubClause::Always));
+app.subscribe(&Id::Clock, Sub::new(EventClause::Tick, SubClause::Always));
 ```
 
-如果您需要删除订阅，可以简单地取消订阅：
+如果需要删除订阅，可以简单地取消订阅：
 
 ```rust
-app.unsubscribe(&Id::Clock, SubEventClause::Tick);
+app.unsubscribe(&Id::Clock, EventClause::Tick);
 ```
+
+> ❗ 如果一个 `EventClause` 有多个规则，`unsubscribe` 会删除 *所有* 匹配该子句的订阅。
 
 ### 事件子句 (Event clauses) 详解
 
-事件子句用于定义应为哪种事件设置订阅。
-一旦应用检查是否要转发事件，它必须首先检查事件子句并验证其是否满足与传入事件的边界。事件子句有：
+Event clauses 用于定义订阅应针对哪种事件生效。
+一旦 application 检查是否转发事件，它必须首先检查 event clause 并验证它是否满足与传入事件的条件。事件子句包括：
 
-- `Any`：事件子句被满足，无论是什么类型的事件。一切都取决于 `SubClause` 的结果。
-- `Keyboard(KeyEvent)`：为了满足子句，传入事件必须是 `Keyboard` 类型，并且 `KeyEvent` 必须完全相同。
-- `WindowResize`：为了满足子句，传入事件必须是 `WindowResize` 类型，无论窗口大小如何。
-- `Tick`：为了满足子句，传入事件必须是 `Tick` 类型。
-- `User(UserEvent)`：为了被满足，传入事件必须是 `User` 类型。`UserEvent` 的值必须匹配，根据为此类型实现 `PartialEq` 的方式。
+- `Any`：该事件子句总被满足，不论事件类型是什么。之后一切取决于 `SubClause` 的结果。
+- `Keyboard(KeyEvent)`：要满足该子句，传入事件必须是 `Keyboard` 类型，并且 `KeyEvent` 必须完全一致。
+- `WindowResize`：要满足该子句，传入事件必须是 `WindowResize` 类型，不论窗口尺寸为何。
+- `Tick`：要满足该子句，传入事件必须是 `Tick` 类型。
+- `User(UserEvent)`：要满足，传入事件必须是 `User` 类型。`UserEvent` 的值必须匹配，依据该类型 `PartialEq` 的实现。
+- `Discriminant(UserEvent)`：要满足，传入事件必须是 `User` 类型。然后 `UserEvent` 的 `std::mem::discriminant` 必须匹配。
+
+> ❗ `Discriminant` 只检查 `UserEvent` 的顶层变体，意思是像 `UserEvent::VariantA(OtherEnum::A)` 与 `UserEvent::Variant(OtherEnum::B)` 这样的 **也会匹配**。如果这不是你想要的行为，使用 `User(UserEvent)` 并实现自定义 `PartialEq`。
 
 ### 订阅子句 (Sub clauses) 详解
 
-订阅子句在事件子句满足后验证，它们定义了一些必须由**目标**组件（与订阅关联的组件）满足的子句。
-特别是订阅子句有：
+Sub clauses 在 event clause 满足后进行校验。它们定义一些必须满足才能真正转发事件的条件。
+具体来说，sub clauses 包括：
 
-- `Always`：子句始终满足
-- `HasAttrValue(Id, Attribute, AttrValue)`：如果目标组件（在 `Id` 中定义）在其 `Props` 中具有 `Attribute` 和 `AttrValue`，则满足子句。
-- `HasState(Id, State)`：如果目标组件（在 `Id` 中定义）具有等于提供状态的 `State`，则满足子句。
-- `IsMounted(Id)`：如果目标组件（在 `Id` 中定义）已挂载到视图中，则满足子句。
+- `Always`：子句总是满足。
+- `HasAttrValue(Id, Attribute, AttrValue)`：如果 **Id** 对应的 Component 具有属性 `Attribute` 且值为 `AttrValue` 则满足。
+- `HasState(Id, State)`：如果 **Id** 对应的 Component 的 `State` 等于提供的 state 则满足。
+- `IsMounted(Id)`：如果 **Id** 对应的 Component 已挂载到 View 中则满足。
 
-除了这些，还可以使用表达式组合订阅子句：
+> 如果当前订阅对应的 Component 不依赖其他 Component 已挂载，则应使用 `Always` 而非 `IsMounted(Self)`。
 
-- `Not(SubClause)`：如果内部子句不满足，则满足子句（取反结果）
-- `And(SubClause, SubClause)`：如果两个子句都满足，则满足子句
-- `Or(SubClause, SubClause)`：如果至少一个子句满足，则满足子句。
+除了这些，还可以用逻辑表达式组合 Sub clauses：
 
-使用 `And` 和 `Or`，您甚至可以创建长表达式，请记住它们是递归评估的，例如：
+- `Not(SubClause)`：内部子句 **不** 满足时满足 (逻辑 NOT)
+- `And(SubClause, SubClause)`：两个子句都满足时满足 (逻辑 AND)
+- `Or(SubClause, SubClause)`：两个子句中至少一个满足时满足 (逻辑 OR)
 
-`And(Or(A, And(B, C)), And(D, Or(E, F)))` 被评估为 `(A || (B && C)) && (D && (E || F))`
+用 `And` 和 `Or` 你可以构造更长的表达式，注意它们会递归求值，例如：
+
+`And(Or(A, And(B, C)), And(D, Or(E, F)))` 求值为 `(A || (B && C)) && (D && (E || F))`。
+
+支持短路求值。例如 `Or(A, B)` 中若 `A` 求值为 `true`，则 `B` **不会** 被求值。
+同样 `And(A, B)` 中若 `A` 求值为 `false`，则 `B` **不会** 被求值。
+
+另外，为了更好地优化内存局部性，还提供了其他变体：
+
+- `AndMany`：基本上与 `And` 相同，但允许一次处理多于 (或少于) 2 个子句 (同样支持短路)
+- `OrMany`：基本上与 `Or` 相同，但允许一次处理多于 (或少于) 2 个子句 (同样支持短路)
 
 ### 订阅锁
 
-可以暂时禁用订阅传播。
-为此，您只需要调用 `application.lock_subs()`。
+可以暂时禁用订阅的事件转发。
+为此只需调用 `Application::lock_subs()`。
 
-无论何时想要恢复事件传播，只需调用 `application.unlock_subs()`。
+想恢复事件传播时调用 `Application::unlock_subs()`。
+锁定期间产生的事件 *不会* 在解锁后被转发。
 
 ---
 
 ## Tick 事件
 
-Tick 事件是一种特殊的事件，由**应用**以指定的间隔引发。
-每当初始化**应用**时，您可以指定 tick 间隔，如以下示例所示：
+Tick 事件是一种特殊事件，由 **Application** 以指定的间隔引发。
+每次初始化 **Application** 时可以指定 tick 间隔，如下例：
 
 ```rust
-let mut app: Application<Id, Msg, NoUserEvent> = Application::init(
+let app = Application::init(
     EventListenerCfg::default()
         .tick_interval(Duration::from_secs(1)),
 );
 ```
 
-使用 `tick_interval()` 方法，我们指定 tick 间隔。
-每次 tick 间隔过去时，应用运行时将抛出一个 `Event::Tick`，它将在 `tick()` 时转发给当前活动组件和所有订阅了 `Tick` 事件的组件。
+通过 `tick_interval()` 方法指定 tick 间隔。
+每次 tick 间隔过去时，application 运行时会产生一个 `Event::Tick`，在 `tick()` 中被转发给当前活动组件以及所有订阅了 `Tick` 事件的组件。
 
-Tick 事件的目的是基于某个间隔调度操作。
+Tick 事件的用途是基于某个间隔安排动作。例如让 spinner 一致地步进。
 
 ---
 
-## 端口
+## 端口 (Ports)
 
-端口基本上是**事件生产者**，由应用*事件监听器*处理。
-通常，tui-realm 应用只会消费输入事件或 tick 事件，但如果我们需要*更多*事件怎么办？
+Ports 基本上是 **事件生产者**，由 application 的 *Event listener* 处理。
+简单的 `tui-realm` 应用只会消费核心提供的事件，但如果我们需要 *更多* 事件呢？
 
-例如，我们可能需要一个工作器来获取远程服务器的数据。端口允许您创建自动化的工作器，这些工作器将产生事件，如果您正确设置了一切，您的模型和组件将被更新。
+比如我们可能需要一个 worker 从远程服务器拉取数据。你不希望 TUI 在数据拉取完成前阻塞 (不处理任何事件) 对吧？
+Ports 允许你创建产生事件的 worker，只要你正确设置了它们，model 和组件都会得到更新。
 
-现在让我们看看如何设置*端口*：
+让我们看看如何设置自定义 *Port*：
 
-1. 首先我们需要为我们的应用定义 `UserEvent` 类型：
+1. 首先为应用定义 `UserEvent` 类型：
 
     ```rust
-    #[derive(PartialEq, Clone, PartialOrd)]
+    #[derive(PartialEq, Clone)]
     pub enum UserEvent {
         GotData(Data)
-        // ... 如果您需要，其他事件
+        // ... 如果需要其他事件
     }
 
     impl Eq for UserEvent {}
     ```
 
-2. 实现*端口*，我命名为 `MyHttpClient`
+2. 实现 *Port*，我把它命名为 `MyHttpClient`
 
     ```rust
     pub struct MyHttpClient {
@@ -226,69 +212,76 @@ Tick 事件的目的是基于某个间隔调度操作。
     }
     ```
 
-    现在我们需要为*端口*实现 `Poll` trait。
-    Poll trait 告诉应用事件监听器如何在*端口*上轮询事件：
+    现在我们需要为 *Port* 实现 `Poll` trait。
+    如果你用过 async rust，这个 trait 与 `std::future::Future` 很类似。
+    Poll trait 告诉 application event listener 如何在 *port* 上轮询事件：
 
     ```rust
     impl Poll<UserEvent> for MyHttpClient {
-        fn poll(&mut self) -> ListenerResult<Option<Event<UserEvent>>> {
-            // ... 做点什么 ...
+        fn poll(&mut self) -> PortResult<Option<Event<UserEvent>>> {
+            // ... 做一些事情 ...
             Ok(Some(Event::User(UserEvent::GotData(data))))
         }
     }
     ```
 
-3. 应用中的端口设置
+3. 将 Port 加入 Application
 
     ```rust
     let mut app: Application<Id, Msg, UserEvent> = Application::init(
         EventListenerCfg::default()
-            .default_input_listener(Duration::from_millis(10))
+            /* ...其他 ports，例如 "crossterm_input_listener" */
             .port(
-                Box::new(MyHttpClient::new(/* ... */)),
+                Box::new(MyHttpClient::new()),
                 Duration::from_millis(100),
             ),
     );
     ```
 
-    在事件监听器构造函数中，您可以定义任意数量的端口。当您声明一个端口时，您需要传递一个包含实现*Poll* trait 的类型的 box 和一个间隔。
-    间隔定义了每次轮询端口之间的间隔。
+    在 event listener 构造器上可以定义任意数量的 ports。声明一个 port 时需要传入一个装有实现了 *Poll* trait 的类型的 box 以及一个间隔。
+    间隔定义了每次对该 port 轮询之间的时间差。
+
+`tui-realm` 中的 Ports 也可以被称为 `Actor Pattern`。你可以在 [Actors with Tokio](https://ryhl.io/blog/actors-with-tokio/) 博文中阅读更多关于 rust 中此模式的内容。
+
+`tui-realm` 也支持异步 ports (目前仅通过 `tokio`)，可通过 `async-ports` feature 启用。
+
+如果你的应用已经使用 async，建议优先使用 async ports 而非同步 ports。
 
 ---
 
 ## 实现新组件
 
-在 tui-realm 中实现新组件实际上相当简单，但要求您至少对**tui-rs widgets**有基本的了解。
+在 tui-realm 中实现组件非常简单。这个例子会实现一个比 [入门指南](get-started.md#component) 中更复杂的 Component，需要了解 *Component* 和 *AppComponent* 的区别以及至少一点 *ratatui widgets* 的知识。
 
-除了 tui-rs 知识，您还应该记住*Component*和*Component*之间的区别，以免实现糟糕的组件。
-
-说了这些，让我们看看如何实现一个组件。对于这个示例，我将实现 stdlib 中 `Radio` 组件的简化版本。
+说完这些，让我们看看如何实现一个更复杂的组件。这个例子我们会实现 stdlib 中 `Radio` 组件的一个简化版。
 
 ### 组件应该是什么样子
 
-我们需要定义的第一件事是组件应该是什么样子。
-在这种情况下，组件是一个包含选项列表的框，您可以选择一个，这是用户的选择。
-用户将能够在不同的选择之间移动并提交一个。
+我们需要定义的第一件事是组件的外观 (即显示的输出)。
+这里组件应是一个横向列出所有选项的方框。为此我们使用 ratatui widget `Tabs`。
+
+接下来定义组件的交互：
+我们希望用户能左右移动来选择选项，并能提交当前选中的选项。
 
 ### 定义组件属性
 
-一旦我们定义了组件的样子，我们就可以开始定义组件属性：
+定义好外观后，我们开始定义要暴露的组件属性：
 
-- `Background(Color)`：将定义组件的背景颜色
-- `Borders(Borders)`：将定义组件的边框属性
-- `Foreground(Color)`：将定义组件的前景颜色
-- `Content(Payload(Vec(String)))`：将定义单选组的可能选项
-- `Title(Title)`：将定义框标题
-- `Value(Payload(One(Usize)))`：将作为属性工作，但也会更新状态，用于当前选定的选项。
+- `Foreground(Color)`：定义组件前景色
+- `Background(Color)`：定义组件背景色
+- `HighlightedColor(Color)`：定义高亮选项的背景色
+- `Borders(Borders)`：定义组件的边框属性
+- `Content(Payload(Vec(String)))`：定义 radio 组的可选项
+- `Title(Title)`：定义方框标题
+- `Value(Payload(Single(Usize)))`：作为属性工作，但也会更新当前选中项的状态。
 
 ```rust
 pub struct Radio {
     props: Props,
-    // ...
+    states: RadioState,
 }
 
 impl Radio {
-
     // 构造函数...
 
     pub fn foreground(mut self, fg: Color) -> Self {
@@ -296,32 +289,31 @@ impl Radio {
         self
     }
 
-    // ...
+    // 其他属性的 builder 函数...
 }
 
 impl Component for Radio {
-
     // ...
 
     fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
-        self.props.get_as_ref(attr)
+        self.props.get_for_query(attr)
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {
         match attr {
             Attribute::Content => {
-                // 重置选择
+                // 覆盖 choices，如果可能则保留索引
                 let choices: Vec<String> = value
                     .unwrap_payload()
                     .unwrap_vec()
-                    .iter()
-                    .map(|x| x.clone().unwrap_str())
+                    .into_iter()
+                    .map(|x| x.unwrap_str())
                     .collect();
-                self.states.set_choices(&choices);
+                self.states.set_choices(choices);
             }
             Attribute::Value => {
-                self.states
-                    .select(value.unwrap_payload().unwrap_one().unwrap_usize());
+                let index = value.unwrap_payload().unwrap_single().unwrap_usize();
+                self.states.select(index);
             }
             attr => {
                 self.props.set(attr, value);
@@ -330,107 +322,98 @@ impl Component for Radio {
     }
 
     // ...
-
 }
 ```
 
 ### 定义组件状态
 
-由于此组件可以是交互式的，并且用户必须能够选择某个选项，我们必须实现一些状态。
-组件状态必须跟踪当前选定的项。出于实际原因，我们还使用可用选择作为状态。
+由于该组件是交互式的，用户必须能选择某个选项，所以我们要实现一些状态。
+组件状态必须跟踪当前选中项。为方便起见，也把可用选项当作状态存储。
 
 ```rust
-struct OwnStates {
-    choice: usize,        // 选定的选项
-    choices: Vec<String>, // 可用选择
+struct RadioState {
+    choice: usize,        // 选中的选项
+    choices: Vec<String>, // 可用选项
 }
 
-impl OwnStates {
-
-    /// 将选择索引移动到下一个选择
+impl RadioState {
+    /// 将 choice 索引向前移动
     pub fn next_choice(&mut self) {
         if self.choice + 1 < self.choices.len() {
             self.choice += 1;
         }
     }
 
-
-    /// 将选择索引移动到上一个选择
+    /// 将 choice 索引向后移动
     pub fn prev_choice(&mut self) {
         if self.choice > 0 {
             self.choice -= 1;
         }
     }
 
-
-    /// 从文本跨度向量设置 OwnStates 选择
-    /// 此外重置当前选择，如果可能则保留索引，或将其设置为第一个可用值
-    pub fn set_choices(&mut self, spans: &[String]) {
-        self.choices = spans.to_vec();
-        // 如果可能则保留索引
-        if self.choice >= self.choices.len() {
-            self.choice = match self.choices.len() {
-                0 => 0,
-                l => l - 1,
-            };
-        }
-    }
-
+    /// 选择指定索引
     pub fn select(&mut self, i: usize) {
         if i < self.choices.len() {
             self.choice = i;
         }
     }
+
+    /// 从字符串向量设置 RadioState 的 choices。
+    /// 此外重置当前选择，如果可能则保留索引，否则设为第一个可用值
+    pub fn set_choices<S: Into<Vec<String>>>(&mut self, spans: S) {
+        self.choices = spans.into();
+        // 如果可能则保留索引
+        if self.choice >= self.choices.len() {
+            self.choice = self.choices.len().saturating_sub(1);
+        }
+    }
 }
 ```
 
-然后我们可以定义 `state()` 方法
+然后我们定义 `Component` 的 `state()` 方法：
 
 ```rust
 impl Component for Radio {
-
     // ...
 
     fn state(&self) -> State {
-        State::One(StateValue::Usize(self.states.choice))
+        State::Single(StateValue::Usize(self.states.choice))
     }
 
     // ...
-
 }
 ```
 
-### 定义 Cmd API
+### 定义 Command API
 
-一旦我们定义了组件状态，我们就可以开始考虑命令 API。命令 API 定义了组件在面对传入命令时的行为方式以及它应该返回什么类型的结果。
+定义好组件状态后，可以开始考虑 Command API。Command API 定义了组件对传入命令的响应行为及返回结果类型。
 
-对于此组件，我们将处理以下命令：
+对于此组件，我们处理以下命令：
 
-- 当用户向右移动时，当前选择递增
-- 当用户向左移动时，当前选择递减
-- 当用户提交时，返回当前选择
+- 用户右移时，当前 choice 递增
+- 用户左移时，当前 choice 递减
+- 用户提交时，返回当前 choice
 
 ```rust
 impl Component for Radio {
-
     // ...
 
     fn perform(&mut self, cmd: Cmd) -> CmdResult {
         match cmd {
             Cmd::Move(Direction::Right) => {
-                // 递增选择
+                // 递增 choice
                 self.states.next_choice();
-                // 返回更改的 CmdResult
+                // 改变时返回 CmdResult
                 CmdResult::Changed(self.state())
             }
             Cmd::Move(Direction::Left) => {
-                // 递减选择
+                // 递减 choice
                 self.states.prev_choice();
-                // 返回更改的 CmdResult
+                // 改变时返回 CmdResult
                 CmdResult::Changed(self.state())
             }
             Cmd::Submit => {
-                // 返回提交
+                // 返回 Submit
                 CmdResult::Submit(self.state())
             }
             _ => CmdResult::Invalid(cmd),
@@ -438,13 +421,12 @@ impl Component for Radio {
     }
 
     // ...
-
 }
 ```
 
 ### 渲染组件
 
-最后，我们可以实现组件 `view()` 方法，该方法将渲染组件：
+最后我们实现 `Component` 的 `view()` 方法用于渲染组件：
 
 ```rust
 impl Component for Radio {
@@ -453,13 +435,15 @@ impl Component for Radio {
             return;
         }
 
-        // 创建选择
-        let choices: Vec<Spans> = self
+        // 构造 choices
+        let choices: Vec<Line> = self
             .states
             .choices
             .iter()
-            .map(|x| Spans::from(x.clone()))
+            .map(|x| Line::from(x.as_str()))
             .collect();
+
+        // 获取其他样式属性
         let foreground = self
             .props
             .get(Attribute::Foreground)
@@ -470,29 +454,52 @@ impl Component for Radio {
             .get(Attribute::Background)
             .and_then(AttrValue::as_color)
             .unwrap_or(Color::Reset);
+        let highlight_bg = self
+            .props
+            .get(Attribute::HighlightedColor)
+            .and_then(AttrValue::as_color)
+            .unwrap_or(Color::Reset);
+
+        let normal_style = Style::default()
+            .fg(foreground)
+            .bg(background);
+
+        let highlight_style = normal_style.patch(Style::default().bg(highlight_bg));
+
+        // 组装 Block (边框)
         let borders = self
             .props
             .get(Attribute::Borders)
             .and_then(AttrValue::as_borders)
             .unwrap_or_default();
-        let title = self.props.get(Attribute::Title).map(|x| x.unwrap_title());
+        let title = self
+            .props
+            .get(Attribute::Title)
+            .and_then(AttrValue::as_title)
+            .cloned()
+            .unwrap_or_default();
         let focus = self
             .props
             .get(Attribute::Focus)
             .and_then(AttrValue::as_flag)
-            .unwrap_or_default();
-        let div = crate::utils::get_block(borders, title, focus, None);
-        // 创建颜色
-        let (bg, fg, block_color): (Color, Color, Color) = match focus {
-            true => (foreground, background, foreground),
-            false => (Color::Reset, foreground, Color::Reset),
-        };
-        let radio: Tabs = Tabs::new(choices)
-            .block(div)
+            .unwrap_or(false);
+
+        let block = Block::default()
+            .title_top(title.content)
+            .borders(borders.sides)
+            .border_style(if focus {
+                borders.style()
+            } else {
+                Style::default().fg(Color::DarkGray)
+            });
+
+        // 最后用 ratatui widget 绘制内容
+        let tabs = Tabs::new(choices)
+            .block(block)
             .select(self.states.choice)
-            .style(Style::default().fg(block_color))
-            .highlight_style(Style::default().fg(fg).bg(bg));
-        render.render_widget(radio, area);
+            .style(normal_style)
+            .highlight_style(highlight_style);
+        render.render_widget(tabs, area);
     }
 
     // ...
@@ -503,7 +510,7 @@ impl Component for Radio {
 
 ## 属性注入器
 
-属性注入器是 trait 对象，必须实现 `Injector` trait，可以在组件挂载时为其提供一些属性（定义为 `Attribute` 和 `AttrValue` 的元组）。
+属性注入器是 trait 对象，必须实现 `Injector` trait，在组件挂载时提供某些属性 (定义为 `Attribute` 与 `AttrValue` 的元组)。
 Injector trait 定义如下：
 
 ```rs
@@ -515,15 +522,17 @@ where
 }
 ```
 
-然后您可以使用 `add_injector()` 方法将注入器添加到您的应用中。
+然后可以用 `add_injector()` 方法把注入器加入到应用中。
 
-无论何时将新组件挂载到视图中，都会为应用中定义的每个注入器调用 `inject()` 方法，提供挂载组件的 id 作为参数。
+每当你挂载一个新组件到 view 时，会为应用中定义的每个注入器调用 `inject()` 方法，并以挂载组件的 id 作为参数。
 
 ---
 
 ## 下一步
 
-如果您来自 tui-realm 0.x 并希望迁移到 tui-realm 1.x，有一个指南解释了[如何从 tui-realm 0.x 迁移到 1.x](migrating-legacy.md)。
-否则，我认为您现在就可以开始实现您的 tui-realm 应用了 😉。
+这是 `tui-realm` 当前可用指南的结尾，但建议继续阅读：
 
-如果您有任何问题，请随时打开带有 `question` 标签的问题，我会尽快回答您 🙂。
+- [`tuirealm`](https://docs.rs/tuirealm/latest/tuirealm/) 的文档
+- [`tui-realm-stdlib`](https://docs.rs/tui-realm-stdlib/latest/tui_realm_stdlib/) 的文档
+
+如果有任何问题，欢迎开带 `question` 标签的 issue，我会尽快回复 🙂。

--- a/crates/tuirealm/docs/zh-cn/get-started.md
+++ b/crates/tuirealm/docs/zh-cn/get-started.md
@@ -1,162 +1,164 @@
-📍<u>**简体中文**</u> | <a href="../en/get-started.md">English</a>
-
 # 快速入门 🏁
+
+<a href="../en/get-started.md">English</a> | 📍<u>**简体中文**</u>
 
 - [快速入门 🏁](#快速入门-)
   - [Realm 简介](#realm-简介)
   - [核心概念](#核心概念)
-  - [原型组件 (Component) 与 组件 (Component)](#原型组件 (Component) 与 组件 (Component))
-    - [原型组件](#原型组件)
-    - [组件](#组件)
-    - [属性 (Properties) 与状态 (States)](#属性 (Properties) 与状态 (States))
-    - [事件 (Events) 与命令 (Commands)](#事件 (Events) 与命令 (Commands))
-  - [应用、模型和视图](#应用模型和视图)
-    - [视图 (View)](#视图 (View))
-      - [焦点](#焦点)
-    - [模型 (Model)](#模型 (Model))
-    - [应用](#应用)
-  - [生命周期（或 "tick"）](#生命周期或-tick)
+  - [Component 与 AppComponent](#component-与-appcomponent)
+    - [Component](#component)
+    - [AppComponent](#appcomponent)
+    - [属性 (Properties) 与状态 (States)](#属性-properties-与状态-states)
+    - [事件 (Events) 与命令 (Commands)](#事件-events-与命令-commands)
+  - [Application、Model 和 View](#applicationmodel-和-view)
+    - [View](#view)
+      - [焦点 (Focus)](#焦点-focus)
+    - [Model](#model)
+    - [Application](#application)
+  - [生命周期 (或 "tick")](#生命周期-或-tick)
   - [我们的第一个应用](#我们的第一个应用)
-    - [实现计数器](#实现计数器)
+    - [实现 Counter](#实现-counter)
     - [定义消息类型](#定义消息类型)
     - [定义组件标识符](#定义组件标识符)
     - [实现两个计数器组件](#实现两个计数器组件)
-    - [实现模型](#实现模型)
-    - [应用设置和主循环](#应用设置和主循环)
+    - [实现 Model](#实现-model)
+    - [应用设置与主循环](#应用设置与主循环)
   - [下一步](#下一步)
 
 ---
 
 ## Realm 简介
 
-您将学习到：
+你将学习到：
 
 - tui-realm 的核心概念
-- 如何从零开始编写 tui-realm 应用
+- 如何从零开始编写一个 tui-realm 应用
 - tui-realm 的亮点特性
 
-tui-realm 是一个 ratatui **框架**，提供了实现有状态应用的简便方法。
-首先，让我们看看 tui-realm 的主要特性以及为什么在构建终端用户界面时应选择此框架：
+`tui-realm` 是一个 ratatui **框架**，提供了实现有状态 (stateful) 应用的简便方法。
+首先，让我们看看 tui-realm 的主要特性以及为什么在构建终端用户界面时应该选择此框架：
 
 - ⌨️ **事件驱动**
 
-    tui-realm 采用 Elm 架构的 `Event -> Msg` 模式。**事件**由称为 `Port` 的实体 (entities) 产生，这些实体作为事件监听器（如 stdin 读取器或 HTTP 客户端）工作，产生事件。这些事件随后被转发到**组件**，组件将产生一个**消息**。消息将根据其变体在您的应用模型中引起特定行为。
-    相当简单，您的应用中的所有内容都将围绕此逻辑工作，因此实现任何功能都非常容易。
+    `tui-realm` 采用源自 Elm 的 `Event -> Msg` 模式。**事件 (Events)** 由称为 `Port` 的实体产生，它们作为事件监听器工作 (例如 stdin 读取器或 HTTP 客户端)，产生事件。这些事件随后被转发到 **Components**，组件会产生一个 **Message**。消息随后会根据其变体在应用 model 中引起特定行为。
 
 - ⚛️ 基于 **React** 和 **Elm**
 
-    tui-realm 基于 [React](https://reactjs.org/) 和 [Elm](https://elm-lang.org/)。这两种方法有些不同，但我决定从每种方法中取其精华，将它们结合到 **Realm** 中。从 React 中我采用了**组件**概念。在 realm 中，每个组件代表一个图形实例，可能包含一些子组件；每个组件都有一个**状态**和一些**属性**。
-    从 Elm 中我基本上采用了 Realm 中实现的每个其他概念。我真的很喜欢 Elm 作为一门语言，特别是 **TEA**（The Elm Architecture）。
-    实际上，与 Elm 一样，在 realm 中应用的生命周期是 `Event -> Msg -> Update -> View -> Event -> ...`
+    `tui-realm` 采纳了 [React](https://reactjs.org/) 和 [Elm](https://elm-lang.org/) 的部分元素。这两者的方法不同，但我决定从中各取精华，将它们结合到 **Realm** 中。从 React 中我采用了 **Component** 概念。在 realm 中，每个组件代表一个图形实例，可能包含一些子组件；每个组件都有一个 **State** 和一些 **Properties**。
+    从 Elm 中我基本采用了 Realm 中实现的其余所有概念。我真的很喜欢 Elm 作为一门语言，特别是 **TEA** (`The Elm Architecture`)。
+    与 Elm 一样，realm 中应用的生命周期是 `-> Event -> Msg -> Update -> View ->`。
 
 - 🍲 **样板代码**
 
-    tui-realm 在开始时可能看起来很难使用，但过一段时间后您会开始意识到您正在实现的代码只是从先前组件复制的样板代码。
+    `tui-realm` 开始使用时可能看起来很难，但使用一段时间后你会开始意识到，你正在实现的代码只是从先前组件复制过来的样板代码。
 
 - 🚀 快速设置
 
-    自从最新的 tui-realm API（1.x）以来，tui-realm 变得非常容易学习和设置，这得益于新的 `Application` 数据类型、事件监听器和 `Terminal` 辅助工具。
+    得益于 `Application`、`EventListener`、终端后端以及 stdlib，上手非常容易。
 
-- 🎯 单一的**焦点**和**状态**管理
+- 🎯 单一的 **焦点** 和 **状态** 管理
 
-    在 realm 中，您不必自己管理焦点和状态，一切都由**视图**自动管理，所有组件都挂载在视图中。使用 realm，您不再需要担心应用状态和焦点了。
+    在 realm 中，你不必自己管理焦点和状态，一切都由 **View** 自动管理，所有组件都挂载在 View 中。使用 realm，你再也不必担心应用状态和焦点了。
 
 - 🙂 易于学习
 
-    得益于向用户公开的少量数据类型和指南，即使您以前从未使用过 tui 或 Elm，学习 tui-realm 也非常容易。
+    得益于指南、示例和简单直接的类型，即使你以前从未使用过 tui、React 或 Elm，学习 tui-realm 也非常容易。
 
 - 🤖 适应任何用例
 
-    正如您将通过本指南学到的，tui-realm 公开了一些高级概念来创建自己的事件监听器、处理自己的事件以及实现复杂的组件。
+    正如你将在本指南中学到的，`tui-realm` 公开了一些高级概念，用于创建你自己的事件监听器、处理自己的事件以及实现复杂的组件。
 
 ---
 
 ## 核心概念
 
-现在让我们看看 tui-realm 的核心概念。在简介中您可能已经读到了一些**粗体**的概念，但现在让我们详细看看它们。核心概念非常重要，幸运的是它们易于理解且数量不多：
+在简介中你可能已经读到了一些 **加粗** 的概念，但现在让我们详细了解它们。核心概念非常重要，幸运的是它们易于理解，而且数量不多：
 
-- **Component**：原型组件代表一个可复用的 UI 组件，可以具有一些用于渲染或处理命令的**属性**。如果需要，它还可以有自己的**状态**。实际上，它是一个 trait，公开了一些方法来渲染和处理属性、状态和事件。我们将在下一章中详细讨论。
-- **Component**：组件是 原型组件的包装器，代表您应用中的单个组件。它直接接收事件并为应用消费者生成消息。在底层，它依赖其 原型组件进行属性/状态管理和渲染。
-- **State**：状态代表组件的当前状态（例如，文本输入框中的当前文本）。状态取决于用户（或其他来源）如何与组件交互（例如，用户按下 'a'，字符被推送到文本输入框）。
-- **Attribute**：属性描述组件中的单个属性。属性不应依赖于组件状态，而应仅在组件初始化时由用户配置。通常，原型组件公开许多要配置的属性，而使用 原型组件 的组件根据用户需求设置它们。
-- **Event**：事件是一个**原始**实体，主要描述由用户引起的事件（如按键操作），但也可能由外部源生成（我们将在"高级概念"中讨论这些）。
-- **Message**（通常称为 `Msg`）：消息是由组件在接收到**事件**后生成的逻辑事件。
+- **Component**：Component 代表一个可复用的 UI 组件，可以拥有一些用于渲染或处理命令的 **属性**。如果需要，它还可以拥有自己的 **状态**。实际上，它是一个 trait，公开了一些用于渲染和处理属性、状态和事件的方法。我们将在下一章中详细讨论。
+- **AppComponent**：AppComponent 是 **Component** 的包装器，代表你应用中的单个组件。它直接接收事件并为应用消费者生成消息。在底层，它依赖其 Component 进行属性/状态管理和渲染。
+- **State**：状态代表组件的当前状态 (例如，文本输入框中的当前文本)。状态取决于用户 (或其他来源) 如何与组件交互 (例如，用户按下 'a'，字符被推送到文本输入框)。
+- **Attribute**：属性描述组件中的单个属性 (property)。属性不应依赖于组件状态，而应仅在组件初始化时由用户配置。通常，一个组件会公开许多可配置的属性，而使用该 Component 的 AppComponent 会根据用户的需要设置它们。
+- **Event**：事件是一个 **原始** 实体，描述发生了某些事情，例如用户输入或其他来源 (我们将在 "高级概念" 中讨论后者)。
+- **Message** (通常称为 `Msg`)：消息是由 AppComponents 在响应 `Event` 时生成的逻辑事件，由 `Model` 消费。
+    事件是 *原始* 的 (例如按键操作)，而消息是面向应用的。消息随后由 **更新例程 (Update routine)** 消费。
 
-    事件是*原始*的（如按键操作），而消息是面向应用的。消息随后由**更新例程**消费。我认为一个例子可以更好地解释：假设我们有一个弹出窗口组件，当按下 `ESC` 时，它必须报告给应用以隐藏它。那么事件将是 `Key::Esc`，它将消费它，并返回一个 `PopupClose` 消息。消息完全由用户通过模板类型定义，但我们将在本指南后面看到这一点。
-
-- **Command**（通常称为 `Cmd`）：是由**组件**在接收到**事件**时生成的实体。组件使用它来操作其**Component**。我们将在后面看到为什么需要这两个实体。
-- **View**：视图是存储所有组件的地方。视图基本上有三个任务：
-  
-  - **管理组件的挂载/卸载**：组件在创建时挂载到视图中。视图防止挂载重复的组件，并在您尝试操作不存在的组件时发出警告。
-  - **管理焦点**：视图保证一次只有一个组件处于活动状态。活动组件启用了一个专用属性（我们将在后面看到），所有事件都将转发给它。视图跟踪所有先前活动的组件，因此如果当前活动组件失去焦点，如果没有其他组件要激活，则先前活动的组件将变为活动状态。
-  - **提供操作组件的 API**：一旦组件挂载到视图中，它们必须以安全的方式对外部可访问。这得益于视图公开的桥接方法。由于每个组件必须唯一标识才能被访问，您需要为组件定义一些 ID。
-- **Model**：模型是您为应用定义的结构，用于实现**更新例程**。
-- **Subscription** 或 *Sub*：订阅是一个规则集，它告诉**应用**基于某些规则将事件转发给其他组件，即使它们不处于活动状态。我们将在高级概念中讨论订阅。
-- **Port**：Port 是一个事件监听器，它将使用名为 `Poll` 的 trait 来获取传入事件。Port 定义了要调用的 trait 和每次调用之间必须经过的时间间隔。事件随后被转发给订阅的组件。输入监听器是一个 port，但您也可以实现例如 HTTP 客户端来获取一些数据。无论如何，我们将在高级概念中看到 ports，因为它们不太常用。
-- **Event Listener**：这是一个线程，它轮询 ports 以读取传入事件。事件随后报告给**应用**。
-- **Application**：应用是围绕*视图*、*订阅* 和 *事件监听器* 的统一包装器。它公开了到视图的桥接、一些*订阅*的简写；但它的主要功能是 `tick()`。正如我们将在后面看到的，tick 是所有框架魔法发生的地方。
-- **Update routine**：更新例程是一个函数，必须由**模型**实现，是*Update trait*的一部分。这个函数既简单又重要。它以可变引用形式接收*模型*、可变引用形式的*视图*和传入的**消息**。基于*消息*的值，它会在模型或视图上引起特定行为。如果您问的话，它只是一个*match case*，并且可以返回一个*消息*，这将导致例程被应用递归调用。稍后，当我们看到示例时，您会看到这有多酷。
+- **Command** (通常称为 `Cmd`)：是由 **AppComponent** 在接收到 **Event** 时生成的实体。AppComponent 使用它来操作其 **Component**。
+- **View**：View 是所有组件存储的地方。View 基本上有三个任务：
+  - **管理 AppComponent 的挂载/卸载**：AppComponent 在创建时挂载到 View 中。View 会防止挂载重复的 AppComponent (基于相同的 `Id`)，并在你尝试操作未挂载的 AppComponent 时发出警告。
+  - **管理焦点**：View 保证一次只有一个 AppComponent 处于活动状态。活动的 AppComponent 启用了一个专用属性 (我们将在后面看到)，所有事件都会转发给它 (以及所有 *已订阅* 的 AppComponent)。View 跟踪所有先前持有焦点的 AppComponent，因此如果当前活动的 AppComponent 失去焦点，则前一个活动的 AppComponent 会在没有其他可激活的 AppComponent 时重新变为活动状态。
+  - **提供操作 AppComponent 的 API**：一旦 AppComponent 挂载到 View 中，它们必须以安全的方式对外部可访问。这得益于 View 公开的桥接方法。由于每个 AppComponent 必须被唯一标识才能访问，你需要为 AppComponent 定义一些 **ID**。
+- **Model**：Model 是你为应用定义的结构，用于实现 **更新例程**。
+- **更新例程 (Update routine)**：更新例程是必须由 **Model** 实现的函数。这个函数既简单又重要。它只接受 2 个参数：自身的可变引用和要处理的 **Message**。基于 *Message*，它会在 Model 或 View 上触发特定行为。该例程也可以返回一个 *Message*，这将导致 application 使用给定的 *Message* 再次调用此例程。稍后，当我们看到示例时，你会发现这有多酷。
+- **Subscription** (通常称为 *Sub*)：订阅是一个规则集，它告诉 **application** 也将特定事件转发给其他 AppComponent，即使它们不处于焦点。我们将在高级概念中讨论订阅。
+- **Port**：Port 是一个事件监听器，它将使用名为 `Poll` 的 trait 来获取传入事件。Port 定义了要调用的 trait 和每次调用之间必须经过的时间间隔。事件随后会被转发给订阅的 AppComponent。输入监听器就是一个 port，但你也可以实现例如 HTTP 客户端来获取数据。Port 会在高级概念中详细介绍。
+- **Event Listener**：这是一个线程，它轮询 **Ports** 以读取传入事件。**Events** 随后报告给 **Application**。
+- **Application**：Application 是 **View**、**Subscriptions** 和 **Event Listener** 的超级包装器。它公开了到 View 的桥接、一些 *subscriptions* 的简写；但它的主要函数是 `tick()`。正如我们稍后会看到的，`tick` 是所有框架魔法发生的地方。
 
 ---
 
-## 原型组件 (Component) 与 组件 (Component)
+## Component 与 AppComponent
 
-我们已经大致说过这两个实体是什么，但现在该在实践中看看它们了。
-我们应该记住的第一件事是，它们都是**Traits**，并且根据设计，一个*Component*也是一个*Component*。
-让我们详细看看它们的定义：
+即使读过上面的描述，你可能还是会问自己 "这两者有什么区别，为什么两者都是必需的？"。
+这主要是由于 Event 的设计方式允许自定义 `UserEvent`s，以及 Rust 的工作方式。如果这两个 trait 合二为一，那么像 stdlib 这样的库仍然需要实现一个部分的 `on` 更新函数，只能依赖 `tui-realm` 核心提供的 Event 变体。它们还可能需要在每个 Component 上加一个实际上没用的泛型，因为无法依赖 `UserEvent`s，会增加额外的冗余。
+分开的 trait 也带来了良好的关注点分离，并允许修改事物传递给底层 Component 的方式。
 
-### 原型组件
+另外请记住，**AppComponent** 始终是一个 **Component**，但一个 **Component** 只 *可能* 是一个 **AppComponent**。
 
-原型组件旨在*通用*（但不要太过）和*可重用*，但同时具有*单一职责*。
+让我们详细了解它们的定义：
+
+### Component
+
+Component 旨在对事件保持 *agnostic* (不可知)，并可在其他地方 *复用* (甚至在不同的项目中)。
+
 例如：
 
-- ✅ 显示单行文本的 Label 是一个好的 原型组件。
-- ✅ 像 HTML 中的 `<input>` 这样的 Input 组件是一个好的 原型组件。即使它可以处理许多输入类型，它仍然具有单一职责，是通用的且可重用的。
-- ❌ 可以同时处理文本、单选按钮和复选框的输入是一个糟糕的 原型组件。它太通用了。
-- ❌ 接收服务器远程地址的输入是一个糟糕的 原型组件。它不通用。
+- ✅ 显示单行文本的 Label 是一个好的 Component。
+- ✅ 像 HTML 中的 `<input>` 这样的 Input 组件是一个好的 Component。即使它可以处理许多输入类型，它仍然只有一个职责，是通用的且可复用的。
+- ❌ 同时处理文本、单选按钮和复选框的 input 是一个糟糕的 Component。它太过宽泛。
+- ❌ 接收服务器远程地址的 input 是一个糟糕的 Component。它不够通用。
 
-这些只是指南，但只是为了让您了解 原型组件是什么。
+这些只是一些指南，但只是为了让你了解什么是 Component。
 
-原型组件还处理**状态**和**属性**，这些完全基于您的需求由用户定义。有时您甚至可能有没有任何状态的组件（例如标签）。
+Component 还会处理 **States** 和 **Props**，它们完全由用户根据你的需求定义。有时你甚至可能有一个不处理任何状态的 Component (例如 Label)。
 
-实际上，原型组件是一个 trait，需要实现以下方法：
+实际上，Component 是一个 trait，需要实现以下方法：
 
 ```rust
 pub trait Component {
     fn view(&mut self, frame: &mut Frame, area: Rect);
-    fn query(&self, attr: Attribute) -> Option<AttrValue>;
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>>;
     fn attr(&mut self, attr: Attribute, value: AttrValue);
     fn state(&self) -> State;
     fn perform(&mut self, cmd: Cmd) -> CmdResult;
 }
 ```
 
-trait 要求您实现：
+trait 要求你实现：
 
-- *view*：在提供区域中渲染组件的方法。您必须使用 `ratatui` widgets 根据组件的属性和状态来渲染组件。
-- *query*：返回组件属性中某个属性的值。
-- *attr*：为组件属性分配某个属性。
-- *state*：获取当前组件状态。如果没有状态，则返回 `State::None`。
-- *perform*：对组件执行提供的**命令**。此方法由**组件**调用，我们将在后面看到。命令应更改组件状态。一旦操作处理完毕，它必须将 `CmdResult` 返回给**组件**。
+- *view*：在提供的区域中渲染组件的方法。你必须使用 `ratatui` widgets 根据组件的属性和状态来渲染组件。
+- *query*：返回组件属性中某个 attribute 的值。
+- *attr*：给组件属性赋一个某 attribute 的值。
+- *state*：获取当前组件的状态。如果没有状态，则返回 `State::None`。
+- *perform*：对组件执行提供的 **command**。此方法由 **AppComponent** 调用 (我们稍后会看到)。该命令应该改变组件状态。处理完动作后，必须将 `CmdResult` 返回给 **AppComponent**。
 
-### 组件
+### AppComponent
 
-所以，显然 原型组件定义了我们需要处理属性、状态和渲染的所有内容。那么为什么我们还没有完成，还需要一个组件 trait 呢？
+所以，显然 Component 已经定义了我们处理属性、状态和渲染所需的一切。那么为什么我们还需要一个 AppComponent trait？
 
-1. Component 必须是**通用的**：原型组件在库中分发（例如 `tui-realm-stdlib`），因此它们不能消费 `Event` 或产生 `Message`。
-2. 由于第 1 点，我们需要一个能够产生 `Msg` 并消费 `Event` 的实体。这两个实体完全或部分由用户定义，这意味着它们对于每个 realm 应用都是不同的。这意味着组件必须适应应用。
-3. **不可能满足所有人的需求**：我在 tui-realm 0.x 中尝试过，但这根本不可能。在某个时刻，我只是开始在其他属性中添加属性，但最终我不得不从头开始重新实现 stdlib 组件，只是为了获得一些不同的逻辑。原型组件很好，因为它们通用，但不要太过；它们必须对我们表现得像傻瓜一样。组件正是我们应用想要的。我们想要一个文本输入，但我们希望当我们输入 'a' 时它会改变颜色。您可以使用组件做到这一点，但不能使用 原型组件。哦，我几乎忘记了泛化 原型组件 最糟糕的事情：**键绑定**。
+1. AppComponent 必须对 **Event** 保持 agnostic：Component 可能会在库中分发 (例如 `tui-realm-stdlib`)，因此它们不能消费 `Event` 或产生 `Message`。
+2. 由于第 1 点，我们需要一个能消费 **Event** 并产生 **Messages** 的实体。这两个实体完全或部分由用户定义，意味着它们对每个 realm 应用都不同。这意味着 AppComponent 必须适配具体的应用。
+3. **不可能让一个 Component 满足所有人的需求**：我在 `tui-realm` 0.x 中尝试过，但这根本不可能。在某一时刻我开始在已有属性上加更多属性，但最终不得不从头重新实现 stdlib 组件，只是为了得到一些不同的逻辑。Component 很好，因为它们是通用的，但不要太通用；它们对我们来说必须像笨小孩一样。Component 正是我们想要的应用基础。举例来说，我们有一个 Input，并希望它根据输入的内容改变颜色；一个应用可能想在输入 `a` 时改变颜色，另一个应用可能想在输入 `the` 时改变颜色。这对给定的 Input 可以通过大量选项或校验来实现，但这种逻辑更适合放在 **AppComponent** 而不是 **Component** 中。哦，我差点忘了将 Component 一般化最糟糕的部分：**键绑定**。
 
-这么说，什么是组件？
+说到这里，AppComponent 到底是什么？
 
-组件是 原型组件 的应用特定唯一实现。让我们以表单为例，假设第一个字段是接收用户名的文本输入。如果我们用 HTML 来思考，它肯定是一个 `<input type="text" />` 对吧？您的网页中的许多其他组件也是如此。因此，文本输入将是 tui-realm 中的 `Component`。但*那个*用户名输入字段将是您的**用户名文本输入**。`UsernameInput` 将包装一个 `Input` 原型组件，但基于传入事件，它将以不同方式操作 原型组件，并且如果与例如 `EmailInput` 相比，将产生不同的**消息**。
+AppComponent 是一个 Component 的应用特定唯一实现。以表单为例，假设第一个字段是一个接收用户名的文本输入。如果用 HTML 来想，它肯定是一个 `<input type="text" />` 对吧？仅凭这个定义，该 input 对输入的具体文本是通用的，它可能有一些校验，但最终在提交时没有意义。但我们希望它是我们的 username 输入，并在提交时生成合适的 **Message**。因此该文本输入将是 tui-realm 中的 `Component`。但 *那个* "username" 输入字段将是 *你* 的 **用户名文本输入**。`UsernameInput` *AppComponent* 将包装一个 `Input` *Component*，但基于传入事件，它会以不同方式操作该 Component，并且与例如 `EmailInput` 相比会产生不同的 **Messages**。
 
-所以，让我说明从现在开始您必须记住的最重要的事情：**组件是唯一的 ❗** 在您的应用中。您**永远不应多次使用相同的组件**。
+所以，从现在起必须牢记最重要的一点：**AppComponent 在你的应用中是唯一的 ❗**。你 **绝不应该盲目地多次使用同一个 AppComponent**。
 
-现在让我们看看组件在实践中是什么：
+现在让我们看看 AppComponent 在实际中是什么样的：
 
 ```rust
-pub trait Component<Msg, UserEvent>: Component
+pub trait AppComponent<Msg, UserEvent>: Component
 where
     Msg: PartialEq,
     UserEvent: Eq + PartialEq + Clone,
@@ -165,23 +167,26 @@ where
 }
 ```
 
-相当简单吧？是的，我的意图是让它们尽可能轻量，因为您必须为视图中的每个组件实现一个。正如您可能注意到的，Component 需要实现 `Component`，所以实际上我们也会有类似这样的东西：
+很简单吧？是的，我有意让它们尽可能轻量，因为你必须为 view 中的每个组件实现一个。正如你可能注意到的，**AppComponent** 还要求实现 **Component**，所以实际上我们也会看到类似这样的东西：
 
 ```rust
 pub struct UsernameInput {
-    component: Input, // 其中 Input 实现了 `Component`
+    component: Input, // Input 实现了 `Component`
 }
 
-impl Component for UsernameInput { ... }
+impl Component for UsernameInput { /* 透传到 "self.component" */ }
+impl AppComponent for UsernameInput { ... }
 ```
 
-您可能注意到的另一件事，可能会吓到你们中的一些人，是 Component 采用的两个泛型类型。
-让我们看看这两种类型是什么：
+由于每个 **AppComponent** 都需要实现 **Component**，并且透传调用非常常见，可以使用 `#[derive(Component)]` 来代替。
 
-- `Msg`：定义您的应用将在**更新例程**中处理的**消息**类型。实际上，在 tui-realm 中，消息不是在库中定义的，而是由用户定义的。我们将在后面的"第一个应用的制作"中详细讨论这一点。对于 Message 的唯一要求是它必须实现 `PartialEq`，因为您必须能够在**更新**中匹配它。
-- `UserEvent`：用户事件定义了您的应用可以处理的自定义事件。正如我们之前所说，tui-realm 通常会发送有关用户输入或终端事件的事件，加上一个称为 `Tick` 的特殊事件（但我们将在后面讨论）。除了这些之外，我们已经看到还有其他称为 `Port` 的特殊实体，它们可能从其他源返回事件。由于 tui-realm 需要知道这些事件是什么，您需要提供您的 ports 将产生的类型。
+你可能注意到的另一件事、也可能会让一些人感到担心的是 AppComponent 的两个泛型类型。
+让我们看看这两个类型是什么：
 
-    如果我们看一下 `Event` 枚举，一切都会变得清晰。
+- `Msg` (也称为 **Message**)：定义你的应用将在 **更新例程** 中处理的 **Message** 类型。实际上，在 `tui-realm` 中，消息不是在库中定义的，而是由用户定义的。我们将在后面的 [我们的第一个应用](#我们的第一个应用) 中详细讨论。Message 的唯一要求是它必须实现 `PartialEq`，因为你必须能在 **更新例程** 中匹配它。
+- `UserEvent`：用户事件定义了你的应用可以处理的自定义事件。正如我们之前所说，`tui-realm` 通常会发送关于用户输入或终端事件的事件，加上一个称为 `Tick` 的特殊事件 (我们稍后会讨论它)。除了这些常见事件，自定义 **Port** 可能返回来自其他来源的事件，这些事件不符合常见事件的类型。由于 `tui-realm` 需要知道这些事件是什么，你需要提供你的 ports 将产生的类型 (更多内容请参见 [高级指南](./advanced.md))。
+
+    如果我们看一下 `Event` 枚举，一切就都清晰了：
 
     ```rust
     pub enum Event<UserEvent>
@@ -192,7 +197,7 @@ impl Component for UsernameInput { ... }
         Keyboard(KeyEvent),
         /// 终端窗口调整大小后引发的事件
         WindowResize(u16, u16),
-        /// UI tick 事件（应可配置）
+        /// UI tick 事件 (应可配置)
         Tick,
         /// 未处理的事件；空事件
         None,
@@ -202,48 +207,50 @@ impl Component for UsernameInput { ... }
     }
     ```
 
-    如您所见，`Event` 有一个称为 `User` 的特殊变体，它接受一个特殊类型 `UserEvent`，确实可以用于使用用户定义的事件。
+    如你所见，`Event` 有一个称为 `User` 的特殊变体，它接受一个特殊类型 `UserEvent`，确实可以用于使用用户定义的事件。
 
-    > ❗如果您的应用没有任何 `UserEvent`，您可以通过传递 `Event<NoUserEvent>` 来声明事件，这是一个空枚举
+    > ❗ 如果你的应用中没有任何 `UserEvent`，可以声明事件时使用 `Event<NoUserEvent>`，这是 `tui-realm` 提供的。
+
+从现在开始使用 "**Component**" 可能也意味着实现了 **AppComponent**，除非另有说明。
 
 ### 属性 (Properties) 与状态 (States)
 
 所有组件都由属性描述，并且通常也由状态描述。但它们之间有什么区别？
 
-基本上**属性**描述组件如何渲染以及它应该如何行为。
+基本上 **Properties** 描述组件如何渲染以及它应该如何行为。
 
-例如，属性是**样式**、**颜色**或一些属性，如"这个列表应该滚动吗？"。
+例如，属性是 **样式**、**颜色** 或一些属性比如 "这个列表应该滚动吗？"。
 属性始终存在于组件中。
 
-另一方面，状态是可选的，并且*通常*仅由用户可以与之交互的组件使用。
-状态不会描述样式或组件的行为方式，而是组件的当前状态。状态通常也会在用户执行某个**命令**后更改。
+另一方面，States 是可选的，*通常* 仅由用户可以与之交互的组件使用。
+状态不会描述样式或组件的行为方式，而是组件的当前状态。状态通常也会在用户执行某个 **Command** 之后发生变化。
 
-让我们看看如何区分组件上的属性和状态，假设这个组件是一个*复选框*：
+让我们看看如何在一个组件上区分属性和状态，假设这个组件是一个 *Checkbox*：
 
-- 复选框的前景和背景是**属性**（在交互时不改变）
-- 复选框选项是**属性**
-- 当前选定的选项是**状态**。（它们在用户交互时改变）
-- 当前高亮项是**状态**。
+- checkbox 的前景色和背景色是 **Properties** (交互时不变)
+- checkbox 选项是 **Properties**
+- 当前选中的选项是 **States** (它们在用户交互时改变)
+- 当前高亮的项目是 **State**
 
 ### 事件 (Events) 与命令 (Commands)
 
-我们已经几乎看到了组件背后的所有方面，但我们仍然需要讨论一个重要概念，即 `Event` 和 `Cmd` 之间的区别。
+我们几乎已经看到了关于组件的所有方面，但仍然需要讨论一个重要概念，即 **Events** 和 **Commands** 之间的区别。
 
-如果我们看一下**组件** trait，我们会看到 `on()` 方法具有以下签名：
+如果我们看一下 **AppComponent** trait，可以看到 `on()` 方法的签名如下：
 
 ```rust
-fn on(&mut self, ev: Event<UserEvent>) -> Option<Msg>;
+fn on(&mut self, ev: &Event<UserEvent>) -> Option<Msg>;
 ```
 
-并且我们知道 `Component::on()` 将调用其**Component** 的 `perform()` 方法，以更新其状态。perform 方法具有以下签名：
+我们知道 `AppComponent::on()` 会调用其 **Component** 的 `perform()` 方法，以更新其状态。perform 方法的签名如下：
 
 ```rust
 fn perform(&mut self, cmd: Cmd) -> CmdResult;
 ```
 
-如您所见，**组件**消费一个 `Event` 并产生一个 `Msg`，而由组件调用的 原型组件 消费一个 `Cmd` 并产生一个 `CmdResult`。
+如你所见，**AppComponent** 消费一个 `Event` 并产生一个 `Msg`，而底层 Component 则消费一个 `Cmd` 并产生一个 `CmdResult`。
 
-如果我们看一下两种类型声明，我们会发现在范围方面存在差异，让我们看一下：
+如果我们看一下两个类型声明，就会发现它们在作用域上存在差异：
 
 ```rust
 pub enum Event<UserEvent>
@@ -254,7 +261,7 @@ where
     Keyboard(KeyEvent),
     /// 终端窗口调整大小后引发的事件
     WindowResize(u16, u16),
-    /// UI tick 事件（应可配置）
+    /// UI tick 事件 (应可配置)
     Tick,
     /// 未处理的事件；空事件
     None,
@@ -264,15 +271,15 @@ where
 }
 
 pub enum Cmd {
-    /// 描述用户"输入"了一个字符
+    /// 描述用户 "输入" 了一个字符
     Type(char),
-    /// 描述"光标"移动或其他类型的移动
+    /// 描述 "光标" 移动或其他类型的移动
     Move(Direction),
-    /// `Move` 的扩展，定义滚动。步长应在属性中定义（如果有）。
+    /// `Move` 的扩展，定义滚动。步长应在属性中定义 (如有)。
     Scroll(Direction),
     /// 用户提交字段
     Submit,
-    /// 用户"删除"了某些内容
+    /// 用户 "删除" 了某些内容
     Delete,
     /// 用户切换了某些内容
     Toggle,
@@ -280,292 +287,781 @@ pub enum Cmd {
     Change,
     /// 用户定义的时间量已过，组件应更新
     Tick,
-    /// 用户定义的命令类型。您不会在 stdlib 中找到这些类型的命令，但可以在自己的组件中使用它们。
+    /// 用户定义的命令类型。你不会在 stdlib 中找到这种命令，但可以在自己的组件中使用。
     Custom(&'static str),
-    /// `None` 不会做任何事情
+    /// `None` 什么也不做
     None,
 }
 ```
 
-在某些方面，它们看起来相似，但有些东西立即变得清晰：
+从某些方面来看它们相似，但有一点立刻变得清晰：
 
-- Event 严格绑定到"硬件"，它接收键事件、终端事件或其他源的事件。
-- Cmd 完全独立于硬件和终端，它完全是关于 UI 逻辑的。我们仍然有 `KeyEvent`，但我们也有 `Type`、`Move`、`Submit`、自定义事件（但没有泛型）等等。
+- Event 严格绑定到 "硬件"，它接收键事件、终端事件或其他来源的事件。
+- Cmd 完全独立于硬件和终端，全部是关于 UI 逻辑的。我们仍然有 `KeyEvent`，但还有 `Type`、`Move`、`Submit`、自定义事件 (不带泛型) 等等。
 
----
+原因很简单：**AppComponent** 必须独立于具体应用。你可以在库中创建组件并在 GitHub、crates.io 或任何地方分发，它仍必须能够工作。如果它们以 event 作为参数，这不可能实现，因为 event 带有泛型，而泛型依赖于具体应用。
 
-## 应用、模型和视图
+还有一个原因：想象我们有一个带列表的组件可以滚动查看不同元素，可以用键上下滚动。如果我想创建一个组件库而只有事件，就不可能使用不同的键绑定。想一想，对于组件，我期望在 `perform()` 收到 `Cmd::Scroll(Direction::Up)` 时列表向上滚动，然后我可以实现我的 `AppComponent` 在按下 `W` 时发送 `Cmd::Scroll(Direction::Up)`，而另一个组件在按 `<UP>` 时发送相同命令。由于这种机制，`tui-realm` 的组件也完全独立于键绑定，这在 tui-realm 0.x 中曾经是一个麻烦。
 
-现在我们已经了解了组件是什么，让我们看看如何将它们组合在一起以创建我们的应用。
-正如我们在核心概念中看到的，应用由三个主要部分组成：
+所以每当你实现一个 **Component** 时，必须记住你应该让它独立于具体应用，因此必须定义其 **Command API** 并定义它会产生什么样的 **CmdResult**。然后你的组件必须在任何类型的事件下生成该 API 接受的 `Cmd`，并处理 `CmdResult`，最终根据 `CmdResult` 的值返回合适的 **Message**。
 
-- **模型**：代表应用状态的结构。
-- **视图**：存储所有组件并管理焦点的地方。
-- **应用**：包装视图、订阅和事件监听器的实体。
-
-让我们详细看看每一个。
-
-### 视图 (View)
-
-视图是存储所有组件的地方。视图基本上有三个任务：
-
-- **管理组件的挂载/卸载**：组件在创建时挂载到视图中。视图防止挂载重复的组件，并在您尝试操作不存在的组件时发出警告。
-- **管理焦点**：视图保证一次只有一个组件处于活动状态。活动组件启用了一个专用属性（我们将在后面看到），所有事件都将转发给它。视图跟踪所有先前活动的组件，因此如果当前活动组件失去焦点，如果没有其他组件要激活，则先前活动的组件将变为活动状态。
-- **提供操作组件的 API**：一旦组件挂载到视图中，它们必须以安全的方式对外部可访问。这得益于视图公开的桥接方法。由于每个组件必须唯一标识才能被访问，您需要为组件定义一些 ID。
-
-#### 焦点
-
-焦点是视图的一个重要方面。视图保证一次只有一个组件处于活动状态。活动组件是启用了一个称为 `Attribute::Focus` 的专用属性的组件。此属性用于以不同方式渲染活动组件（例如，更改边框颜色）。
-
-视图还跟踪所有先前活动的组件，因此如果当前活动组件失去焦点，如果没有其他组件要激活，则先前活动的组件将变为活动状态。
-
-### 模型 (Model)
-
-模型是您为应用定义的结构，用于实现**更新例程**。模型代表应用状态，并且通常包含应用需要跟踪的所有数据。
-
-模型必须实现 `Update` trait，该 trait 要求实现 `update()` 方法。此方法以可变引用形式接收模型、可变引用形式的视图和传入的消息。基于消息的值，它会在模型或视图上引起特定行为。
-
-### 应用
-
-应用是围绕*视图*、*订阅*和*事件监听器*的超级包装器。它公开了到视图的桥接、一些*订阅*的简写；但它的主要功能是 `tick()`。
-
-`tick()` 方法是所有框架魔法发生的地方。它执行以下操作：
-
-1. 从事件监听器获取传入事件
-2. 将事件转发给订阅的组件
-3. 调用组件的 `on()` 方法，该方法产生消息
-4. 调用模型的 `update()` 方法，传入消息
-5. 重复直到应用退出
+我们终于开始定义 `tui-realm` 的生命周期了。这一段流程被描述为 `Event -> (Cmd -> CmdResult) -> Msg`。
 
 ---
 
-## 生命周期（或 "tick"）
+## Application、Model 和 View
 
-tui-realm 应用的生命周期基于称为 "tick" 的概念。tick 是应用处理传入事件、更新模型和重新渲染视图的周期。
+现在我们已经定义了 Component 是什么，我们终于可以开始讨论如何把这些组件组合起来创建一个 **Application** 了。
 
-生命周期如下：
+为了把所有东西组合起来，我们会使用之前简要介绍过的三个实体：
 
-1. **事件**：事件由事件监听器从 ports 读取。事件随后被转发给订阅的组件。
-2. **消息**：组件消费事件并产生消息。消息随后传递给模型的更新例程。
-3. **更新**：模型的更新例程消费消息并更新模型状态或视图。
-4. **视图**：视图根据当前模型状态和组件状态重新渲染。
-5. **重复**：循环重复，直到应用退出。
+- **Application**
+- **Model**
+- **View**
+
+首先，从组件开始，我们需要讨论的第一个就是 **View**。
+
+### View
+
+View 基本上是所有 (App)Component 的容器。所有属于同一个 "view" (就 UI 而言) 的组件都必须 *挂载* 到同一个 **View** 中。
+View 中的每个组件 **必须** 由一个 **Identifier** (通常称 *Id*) 唯一标识，identifier 是你必须定义的一种类型，通常是 Enum，但也可以是其他东西，比如 (静态) 字符串。
+
+组件一旦挂载，就无法再被直接访问。View 会将其存储为泛型 `AppComponent` 并暴露一个桥接接口，通过 **Identifier** 查询来操作 view 中的所有组件。
+
+组件会一直存在于 view 中，直到你卸载它。组件一旦被卸载，就无法再使用，并会被丢弃。
+
+然而 View 不只是组件的列表，它在 UI 开发中也扮演着基本角色。例如，**View** 还处理焦点和事件转发。让我们在下一章中讨论。
+
+#### 焦点 (Focus)
+
+每当你与 UI 中的组件交互时，必须始终有一种方式来决定由哪个组件处理该交互。如果我按下一个键，View 必须能正确地将这些 **Event** 转发给获得焦点的 **AppComponent**。
+焦点只是 View 跟踪的一个状态。在任何时刻，View 必须知道当前哪个组件处于 *活动* 状态，以及如果该组件被卸载该怎么办。
+
+在 `tui-realm` 中，我决定了以下关于焦点的规则：
+
+1. 一次只有一个组件可以拥有焦点
+2. 所有事件都将被转发给当前拥有焦点的组件。
+3. 组件只能通过 `active()` 方法获得焦点。
+4. 如果一个组件获得焦点，其 `Attribute::Focus` 属性变为 `AttrValue::Flag(true)`
+5. 如果一个组件失去焦点，其 `Attribute::Focus` 属性变为 `AttrValue::Flag(false)`
+6. 每次一个组件获得焦点时，先前活动的组件会失去焦点并被追加到一个 `Stack` (称为 *焦点栈*) 中，其中保存所有先前拥有焦点的组件。
+7. 如果拥有焦点的组件被 **卸载**，**焦点栈** 中最近且仍处于挂载状态的组件会变为活动。
+8. 如果拥有焦点的组件通过 `blur()` 方法被禁用，**焦点栈** 中最近的组件会变为活动，但被 *blur 的* 组件不会被推入 **焦点栈** (`blur` 也可以理解为 `focus_previous_component`)。
+
+下表展示了焦点的工作方式：
+
+| 动作        | Focus | 焦点栈      | Components |
+|-------------|-------|-------------|------------|
+| Active A    | A     |             | A, B, C    |
+| Active B    | B     | A           | A, B, C    |
+| Active C    | C     | B, A        | A, B, C    |
+| Blur        | B     | A           | A, B, C    |
+| Active C    | C     | B, A        | A, B, C    |
+| Active A    | A     | C, B        | A, B, C    |
+| Umount A    | C     | B           | B, C       |
+| Mount D     | C     | B           | B, C, D    |
+| Umount B    | C     |             | C, D       |
+| Blur(err)   | C     |             | C, D       |
+
+### Model
+
+Model 是一个完全由实现 `tui-realm` 应用的用户定义的 struct。它唯一必需的两个方法是 **更新例程** 和 **绘制例程**。
+
+我们很快会在讨论 *application* 时详细看到这一点，但目前我们只需要知道什么是 **更新例程**，它通过 `update` 函数实现：
+
+```rust
+/// 处理来自 view 的消息并更新当前状态。
+/// 此函数可能返回一个 Message，
+/// 因此必要时应递归调用此函数
+fn update(&mut self, msg: Option<Msg>) -> Option<Msg>;
+```
+
+update 方法接收 model (self) 的可变引用以及来自组件的可能传入消息，该消息是某类事件的处理结果。
+在 update 内部，我们会匹配 msg 以在 model 或 view 上执行某些操作，并在必要时返回 `None` 或另一个消息。正如我们将看到的，如果返回 `Some(Msg)`，我们可以以最后产生的消息作为参数重新调用此例程。
+
+### Application
+
+最后我们准备讨论 tui-realm 的核心结构：**Application**。让我们看看它负责哪些任务：
+
+- 它包含 **View** 并提供使用组件 *identifier* 对其进行操作的方法。
+- 它处理 **Subscriptions**。正如我们之前看到的，*subscriptions* 是一种特殊规则，告诉 application 如果满足某些条件则将事件转发给其他组件，即便该组件没有焦点。
+- 它从 **Ports** 读取传入事件。
+
+从它的定义可以看到，Application 是所有这些实体的容器：
+
+```rust
+pub struct Application<ComponentId, Msg, UserEvent>
+where
+    ComponentId: Eq + PartialEq + Clone + Hash,
+    Msg: PartialEq,
+    UserEvent: Eq + PartialEq + Clone + Send + 'static,
+{
+    listener: EventListener<UserEvent>,
+    subs: Vec<Subscription<ComponentId, UserEvent>>,
+    view: View<ComponentId, Msg, UserEvent>,
+}
+```
+
+所以 application 就是 `tui-realm` 应用所需的所有实体的沙盒 (这就是它被称为 **Application** 的原因)。
+
+最酷的是，整个 application 可以通过一个单独的方法来运行！这个方法叫做 `tick()`，正如我们将在下一章看到的，它执行完成一次 `Event -> Component(s) -> Msg` 循环所需的所有工作：
+
+```rust
+pub fn tick(&mut self, strategy: PollStrategy) -> ApplicationResult<Vec<Msg>> {
+    // 轮询事件监听器
+    let events = self.poll(strategy)?;
+    // 转发给活动元素
+    let mut messages: Vec<Msg> = events
+        .iter()
+        .map(|x| self.forward_to_active_component(x.clone()))
+        .flatten()
+        .collect();
+    // 转发给订阅并扩展向量
+    messages.extend(self.forward_to_subscriptions(events));
+    Ok(messages)
+}
+```
+
+我们可以迅速看到，tick 方法的工作流程如下：
+
+1. 根据提供的 `PollStrategy` 获取事件监听器
+
+    > ❗ poll strategy 告诉如何轮询事件监听器。例如你可以每次循环只获取一个事件，或多个；有多种策略可用。对于完全事件驱动的应用，推荐使用 `Once`。
+
+2. 所有传入事件立即被转发给 view 中当前的 *活动* 组件，该组件可能返回一些 *messages*
+3. 所有传入事件被发送给所有订阅该事件并满足订阅中描述的条件的组件，它们一如既往也可能返回一些 *messages*
+4. 返回消息
+
+除了 `tick()` 例程，application 还提供许多其他功能，我们稍后会在示例中看到，也别忘了查看文档。
+
+---
+
+## 生命周期 (或 "tick")
+
+我们终于准备好把这一切组合起来，看看应用的整个生命周期。
+一旦应用设置完毕，我们应用的循环将是以下这样：
+
+```mermaid
+---
+title: Lifecycle
+---
+flowchart TD
+    %% Define nodes first, as otherwise they may end up in the wrong subgraph.
+    Loop["Loop Start"]
+    Match{"Has Messages?"}
+    Update["Update::update"]
+    Redraw{"Redraw necessary?"}
+    View["Model::view"]
+    ViewComponent["Component::view"]
+    LoopEnd["End of Loop"]
+
+    subgraph Application::tick
+        Poll["Poll for events"]
+        Focused["Process focused Component"]
+        FocusedRet["Return from Focused processing"]
+        Subscriptions["Process subscriptions"]
+        SubscriptionsRet["Return from Subscriptions processing"]
+    end
+
+    subgraph comp [AppComponent]
+        AppComponent["AppComponent::on"]
+        Component["Component::perform"]
+    end
+
+    %% Do edges after defining all nodes and their subgraph positions, otherwise they may
+    %% end up in the wrong subgraph for whatever reason.
+
+    %% Main loop
+    Loop --> Poll
+    Match -->|has messages| Update
+    Match -->|has no messages| LoopEnd
+    Update --> Redraw
+    Redraw -->|yes| View
+    Redraw -->|no| LoopEnd
+    View --> ViewComponent
+    ViewComponent --> LoopEnd
+    LoopEnd --> Loop
+
+    %% Application::tick links
+    Poll ==>|has Events| Focused
+    Poll ==>|has no Events| Match
+    Focused ==> AppComponent
+    FocusedRet ==> Subscriptions
+    Subscriptions ==> AppComponent
+    SubscriptionsRet ==>|"Vec&lt;Msg>"| Match
+
+    %% Slightly links those paths to make it easier to follow.
+    %% And to indicate to mermaid to lay them out better.
+    Focused-..->FocusedRet
+    Subscriptions-..->SubscriptionsRet
+
+    %% Component links
+    AppComponent -->|Cmd| Component
+    Component -->|CmdResult| AppComponent
+    AppComponent ==>|Msg| FocusedRet & SubscriptionsRet
+```
+
+<!--可在 https://mermaid.live 方便地编辑-->
+
+在上面的图中我们可以看到什么时候执行什么的流程。共有 3 种类型的线：细线、粗线和虚线。虚线用于帮助理解流程，粗线表示由 **Application** 自动调用，细线则是用户需要实现的部分。
+
+在图中，我们可以看到之前讨论过的所有实体，它们通过两种箭头连接：*黑色* 箭头定义你必须实现的流程，而 *红色* 箭头则是由 application 已经实现并隐式调用的部分。
+
+所以 `tui-realm` 的生命周期包括：
+
+1. 在 **Application** 上调用 `tick()` 例程
+   1. 轮询 Ports 获取传入事件
+   2. 将事件转发给 view 中的活动组件
+   3. 查询订阅以判断是否应将事件转发给其他组件，然后转发这些事件
+   4. 将传入的 messages 返回给调用者
+2. 对于 `tick` 的每条消息 (以及 `update` 可能返回的每条消息)，在 **Model** 上调用 **`update()` 例程**
+3. 通过 `update()` 方法更新 model
+4. 调用 `view()` 函数渲染 UI
+
+这个简单的 4 步循环被称为一次 **Tick**，因为它事实上定义了每次 UI 刷新之间的间隔。
+现在我们知道了 `tui-realm` 应用是如何工作的，让我们看看如何实现一个。
 
 ---
 
 ## 我们的第一个应用
 
-现在我们已经了解了 tui-realm 的核心概念，让我们创建我们的第一个应用。我们将创建一个简单的计数器应用，其中有两个计数器：一个可以通过按 `+` 和 `-` 递增和递减，另一个可以通过按 `w` 和 `s` 递增和递减。
+我们终于准备好搭建一个 `tui-realm` 应用了。在这个例子中我们从一个非常简单的开始。
+我们要实现的应用非常简单：有两个 **计数器**，一个跟踪用户按下字母字符的次数，另一个跟踪用户按下数字字符的次数。它们只在激活时才跟踪事件。按 `<TAB>` 在两个计数器之间切换活动组件，按 `<ESC>` 时应用终止。
 
-### 实现计数器
+> 这个例子的结果类似于 [demo 示例](/examples/demo/demo.rs)。
 
-首先，让我们定义我们的消息类型。消息类型是枚举，将代表我们的应用可以处理的所有可能消息。
+### 实现 Counter
+
+我们说过有两个计数器，一个跟踪字母字符，一个跟踪数字字符，所以我们发现了一个潜在的 **Component**：**Counter**。Counter 只有一个状态，用来记录作为数字的 "times"，并在每次发送某种命令时增量。
+说完这些，让我们开始实现 counter：
+
+```rust
+#[derive(Default)]
+struct Counter {
+    props: Props,
+    states: OwnStates,
+}
+```
+
+和许多其他 component 一样，我们需要 `props` 来存储颜色和文本样式等属性。
+我们还有 `states`，因为我们需要跟踪要显示的 `times`。
+因为我们有状态，所以还需要声明它们：
+
+```rust
+#[derive(Default)]
+struct OwnStates {
+    counter: isize,
+}
+
+impl OwnStates {
+    fn incr(&mut self) {
+        self.counter += 1;
+    }
+}
+```
+
+然后我们为 Component 实现便于使用的 Builder 方法：
+
+```rust
+impl Counter {
+    pub fn label<S>(mut self, label: S) -> Self
+    where
+        S: Into<LineStatic>,
+    {
+        self.attr(
+            Attribute::Title,
+            AttrValue::Title(Title::from(label).alignment(HorizontalAlignment::Center)),
+        );
+        self
+    }
+
+    pub fn value(mut self, n: isize) -> Self {
+        self.attr(Attribute::Value, AttrValue::Number(n));
+        self
+    }
+
+    pub fn foreground(mut self, c: Color) -> Self {
+        self.attr(Attribute::Foreground, AttrValue::Color(c));
+        self
+    }
+
+    pub fn background(mut self, c: Color) -> Self {
+        self.attr(Attribute::Background, AttrValue::Color(c));
+        self
+    }
+
+    pub fn borders(mut self, b: Borders) -> Self {
+        self.attr(Attribute::Borders, AttrValue::Borders(b));
+        self
+    }
+}
+```
+
+最后我们可以为 `Counter` 实现 `Component`：
+
+```rust
+impl Component for Counter {
+    fn view(&mut self, frame: &mut Frame, area: Rect) {
+        // 检查组件是否应显示
+        if matches!(
+            self.props.get(Attribute::Display),
+            Some(AttrValue::Flag(false))
+        ) {
+            return;
+        }
+
+        // 获取要显示的文本
+        let text = self.states.counter.to_string();
+
+        // 获取其他要应用的属性，未设置时回退到默认值
+        let foreground = self
+            .props
+            .get(Attribute::Foreground)
+            .and_then(AttrValue::as_color)
+            .unwrap_or(Color::Reset);
+        let background = self
+            .props
+            .get(Attribute::Background)
+            .and_then(AttrValue::as_color)
+            .unwrap_or(Color::Reset);
+        let title = self
+            .props
+            .get(Attribute::Title)
+            .and_then(AttrValue::as_title)
+            .cloned()
+            .unwrap_or_default();
+        let borders = self
+            .props
+            .get(Attribute::Borders)
+            .and_then(AttrValue::as_borders)
+            .unwrap_or_default();
+        // 我们也希望根据组件是否被聚焦来区分边框渲染
+        let focus = self
+            .props
+            .get(Attribute::Focus)
+            .and_then(AttrValue::as_flag)
+            .unwrap_or(false);
+
+        let block = Block::default()
+            .title_top(title.content)
+            .borders(borders.sides)
+            .border_style(if focus {
+                borders.style()
+            } else {
+                Style::default().fg(Color::DarkGray)
+            });
+
+        frame.render_widget(
+            Paragraph::new(text)
+                .block(block)
+                .style(Style::default().fg(foreground).bg(background))
+                .alignment(HorizontalAlignment::Center),
+            area,
+        );
+    }
+
+    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
+        self.props.get_for_query(attr)
+    }
+
+    fn attr(&mut self, attr: Attribute, value: AttrValue) {
+        self.props.set(attr, value);
+    }
+
+    fn state(&self) -> State {
+        State::Single(StateValue::Isize(self.states.counter))
+    }
+
+    fn perform(&mut self, cmd: Cmd) -> CmdResult {
+        match cmd {
+            Cmd::Submit => {
+                self.states.incr();
+                CmdResult::Changed(self.state())
+            }
+            _ => CmdResult::Invalid(cmd),
+        }
+    }
+}
+```
+
+这是一整段代码，让我们分解它：
+
+- 在 `view` 中我们获取所有可以设置的属性并将其应用到绘制中。`Props::get` 返回 `Option<&AttrValue>`；`AttrValue::as_*` 辅助方法将其转换成我们想要的具体类型，如果属性未设置则回退到默认值。
+- 在 `query` 中我们通过 `Props::get_for_query` 返回一个 `QueryResult`，view 用它来读取属性而无需克隆
+- `attr` 只是把值透传到 `Props` 去更新属性
+- `state` 返回当前 counter 值，包装在 `State::Single` 中
+- `perform` 在 `Cmd::Submit` 时增量 counter 并返回 `Changed` 结果；其他命令返回 `CmdResult::Invalid`
+
+到这里 **Component** 就准备好了，但我们还需要其他类型如 **Messages**，所以先去做那些。
 
 ### 定义消息类型
 
+在实现两个 `AppComponent` 之前，我们首先需要定义应用要处理的消息。
+因此对于我们的应用，我们定义一个枚举 `Msg`：
+
 ```rust
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum Msg {
+    /// 停止应用
     AppClose,
-    CounterIncrement(usize),
-    CounterDecrement(usize),
+    /// 数字计数器已更改为给定值
+    DigitCounterChanged(isize),
+    /// 在 "Digit" 计数器上请求失焦
+    DigitCounterBlur,
+    /// 字母计数器已更改为给定值
+    LetterCounterChanged(isize),
+    /// 在 "Letter" 计数器上请求失焦
+    LetterCounterBlur,
 }
 ```
-
-这里我们定义了三种消息：
-
-- `AppClose`：关闭应用
-- `CounterIncrement(usize)`：递增指定 ID 的计数器
-- `CounterDecrement(usize)`：递减指定 ID 的计数器
 
 ### 定义组件标识符
 
-接下来，我们需要为我们的计数器定义标识符。由于每个组件必须唯一标识，我们将为每个计数器定义一个 ID。
+我们还需要为组件定义 **Identifier**，view 将用它们来查询已挂载的组件。
+因此对于我们的应用，与 `Msg` 一样，用一个枚举定义 `Id`：
 
 ```rust
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone, Hash)]
 pub enum Id {
-    Counter1,
-    Counter2,
+    DigitCounter,
+    LetterCounter,
+    Label,
 }
 ```
 
+> ❗ 我们还包含了一个 `Label` id，用于显示从计数器收到的最新消息。`Label` 本身来自 [`tui-realm-stdlib`](https://github.com/veeso/tui-realm/tree/main/crates/tuirealm-stdlib)，所以我们不需要自己实现。
+
 ### 实现两个计数器组件
 
-现在我们将实现两个计数器组件。每个计数器组件将包装一个 `Input` 原型组件，但基于传入事件，它将产生不同的消息。
+我们会有两种计数器，我们称它们为 `LetterCounter` 和 `DigitCounter`。让我们实现它们！
+
+首先我们定义 `LetterCounter`，内含 Component。因为我们不需要为 `Component` trait 写什么特别的行为，可以简单地 derive `Component`，它会自动将所有 `Component` 调用透传到底层 `Component`。想了解更多请参阅 [tuirealm_derive](../../../tuirealm-derive/)。
 
 ```rust
-pub struct Counter {
-    component: Input,
-    id: Id,
+#[derive(Component)]
+pub struct LetterCounter {
+    component: Counter,
 }
+```
 
-impl Counter {
-    pub fn new(id: Id) -> Self {
-        let mut component = Input::default()
-            .foreground(Color::Yellow)
-            .background(Color::Black)
-            .placeholder("0");
-        
-        component.attr(Attribute::Title, AttrValue::Title("Counter".into()));
-        
-        Self { component, id }
+然后我们为 letter counter 实现构造函数，它接收初始值并使用 component 构造器构造一个 `Counter`：
+
+```rust
+impl LetterCounter {
+    pub fn new(initial_value: isize) -> Self {
+        Self {
+            component: Counter::default()
+                .background(Color::Reset)
+                .borders(
+                    Borders::default().color(Color::LightGreen),
+                )
+                .foreground(Color::LightGreen)
+                .label("Letter counter")
+                .value(initial_value),
+        }
     }
 }
+```
 
-impl AppComponent<Msg, NoUserEvent> for Counter {
+最后我们为 `LetterCounter` 实现 `AppComponent` trait。这里我们首先把传入的 `Event` 转换为 `Cmd`，然后在 Component 上调用 `perform()` 获取 `CmdResult`，以产生一个 `Msg`。
+当事件是 `Esc` 或 `Tab` 时，我们直接返回 `Msg` 以关闭应用或切换焦点。
+
+```rust
+impl AppComponent<Msg, NoUserEvent> for LetterCounter {
     fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
-        match ev {
-            Event::Keyboard(KeyEvent { code: KeyCode::Char('+'), .. }) => {
-                Some(Msg::CounterIncrement(self.id as usize))
-            }
-            Event::Keyboard(KeyEvent { code: KeyCode::Char('-'), .. }) => {
-                Some(Msg::CounterDecrement(self.id as usize))
-            }
-            Event::Keyboard(KeyEvent { code: KeyCode::Char('w'), .. }) if self.id == Id::Counter2 => {
-                Some(Msg::CounterIncrement(self.id as usize))
-            }
-            Event::Keyboard(KeyEvent { code: KeyCode::Char('s'), .. }) if self.id == Id::Counter2 => {
-                Some(Msg::CounterDecrement(self.id as usize))
-            }
-            Event::Keyboard(KeyEvent { code: KeyCode::Esc, .. }) => {
-                Some(Msg::AppClose)
+        // 获取命令
+        let cmd = match ev {
+            Event::Keyboard(KeyEvent {
+                code: Key::Char(ch),
+                modifiers: KeyModifiers::NONE,
+            }) if ch.is_alphabetic() => Cmd::Submit,
+            Event::Keyboard(KeyEvent {
+                code: Key::Tab,
+                modifiers: KeyModifiers::NONE,
+            }) => return Some(Msg::LetterCounterBlur), // 返回失焦
+            Event::Keyboard(KeyEvent {
+                code: Key::Esc,
+                modifiers: KeyModifiers::NONE,
+            }) => return Some(Msg::AppClose),
+            _ => Cmd::None,
+        };
+        // perform
+        match self.perform(cmd) {
+            CmdResult::Changed(State::Single(StateValue::Isize(c))) => {
+                Some(Msg::LetterCounterChanged(c))
             }
             _ => None,
         }
     }
 }
-
-impl Component for Counter {
-    fn view(&mut self, frame: &mut Frame, area: Rect) {
-        self.component.view(frame, area);
-    }
-    
-    fn query<'a>(&'a self, attr: Attribute) -> Option<QueryResult<'a>> {
-        self.component.query(attr)
-    }
-    
-    fn attr(&mut self, attr: Attribute, value: AttrValue) {
-        self.component.attr(attr, value);
-    }
-    
-    fn state(&self) -> State {
-        self.component.state()
-    }
-    
-    fn perform(&mut self, cmd: Cmd) -> CmdResult {
-        self.component.perform(cmd)
-    }
-}
 ```
 
-### 实现模型
+我们对 `DigitCounter` 做同样的事情，但在 `on()` 中用 `is_ascii_digit` 代替 `is_alphabetic`。
 
-现在我们将实现我们的模型。模型将包含两个计数器的当前值。
+### 实现 Model
+
+现在我们有了组件，几乎完成了。终于可以实现 `Model` 了。我为这个例子做了一个非常简单的 model：
 
 ```rust
 pub struct Model {
-    counter1: i32,
-    counter2: i32,
-}
-
-impl Default for Model {
-    fn default() -> Self {
-        Self {
-            counter1: 0,
-            counter2: 0,
-        }
-    }
-}
-
-impl Update<Msg, NoUserEvent, ()> for Model {
-    fn update(&mut self, msg: Option<Msg>, view: &mut View<Msg, NoUserEvent, ()>) -> Option<Msg> {
-        match msg {
-            Some(Msg::AppClose) => {
-                // 退出应用
-                std::process::exit(0);
-            }
-            Some(Msg::CounterIncrement(id)) => {
-                if id == Id::Counter1 as usize {
-                    self.counter1 += 1;
-                    if let Some(mut counter) = view.data::<Counter>(Id::Counter1) {
-                        counter.attr(Attribute::Value, AttrValue::String(self.counter1.to_string()));
-                    }
-                } else if id == Id::Counter2 as usize {
-                    self.counter2 += 1;
-                    if let Some(mut counter) = view.data::<Counter>(Id::Counter2) {
-                        counter.attr(Attribute::Value, AttrValue::String(self.counter2.to_string()));
-                    }
-                }
-            }
-            Some(Msg::CounterDecrement(id)) => {
-                if id == Id::Counter1 as usize {
-                    self.counter1 -= 1;
-                    if let Some(mut counter) = view.data::<Counter>(Id::Counter1) {
-                        counter.attr(Attribute::Value, AttrValue::String(self.counter1.to_string()));
-                    }
-                } else if id == Id::Counter2 as usize {
-                    self.counter2 -= 1;
-                    if let Some(mut counter) = view.data::<Counter>(Id::Counter2) {
-                        counter.attr(Attribute::Value, AttrValue::String(self.counter2.to_string()));
-                    }
-                }
-            }
-            _ => {}
-        }
-        None
-    }
+    /// Application
+    pub app: Application<Id, Msg, NoUserEvent>,
+    /// 表示应用必须退出
+    pub quit: bool,
+    /// 指示是否需要重绘界面
+    pub redraw: bool,
+    /// 用于绘制到终端
+    pub terminal: CrosstermTerminalAdapter,
 }
 ```
 
-### 应用设置和主循环
+> ❗ 可以用其他后端代替 `CrosstermTerminalAdapter`，或者让它对 `TerminalAdapter` 泛型。
 
-最后，我们将设置我们的应用并运行主循环。
+现在我们实现 `view()` 方法，它将在更新 model 后渲染 GUI：
 
 ```rust
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // 初始化终端
-    let mut terminal = Terminal::new(CrosstermBackend::new(std::io::stdout()))?;
-    
-    // 创建模型和视图
-    let model = Model::default();
-    let mut view = View::new();
-    
-    // 创建计数器组件并挂载到视图
-    let counter1 = Counter::new(Id::Counter1);
-    let counter2 = Counter::new(Id::Counter2);
-    
-    view.mount(Id::Counter1, Box::new(counter1), None);
-    view.mount(Id::Counter2, Box::new(counter2), None);
-    
-    // 创建应用
-    let mut app = Application::new(model, view);
-    
-    // 运行主循环
-    loop {
-        terminal.draw(|f| {
-            app.view().render(f, f.size());
-        })?;
-        
-        if let Event::Keyboard(KeyEvent { code: KeyCode::Char('q'), .. }) = event::read()? {
-            break;
-        }
-        
-        app.tick()?;
+impl Model {
+    pub fn view(&mut self) {
+        self
+            .terminal
+            .draw(|f| {
+                let [letter, digit, label] = Layout::default()
+                    .direction(Direction::Vertical)
+                    .margin(1)
+                    .constraints(
+                        [
+                            Constraint::Length(3), // 字母计数器
+                            Constraint::Length(3), // 数字计数器
+                            Constraint::Length(1), // Label
+                        ]
+                    )
+                    .areas(f.area());
+                self.app.view(&Id::LetterCounter, f, letter);
+                self.app.view(&Id::DigitCounter, f, digit);
+                self.app.view(&Id::Label, f, label);
+            }).expect("App to draw without error");
     }
-    
-    Ok(())
 }
 ```
+
+> ❗ 如果你不熟悉 `draw()` 函数，请阅读 [ratatui](https://ratatui.rs/) 文档。
+
+最后我们可以实现 `Update` 函数：
+
+```rust
+impl Model {
+    pub fn update(&mut self, msg: Option<Msg>) -> Option<Msg> {
+        let msg = msg?;
+
+        // 设置重绘
+        self.redraw = true;
+        // 匹配消息
+        match msg {
+            Msg::AppClose => {
+                self.quit = true; // 终止
+                None
+            }
+            Msg::DigitCounterBlur => {
+                // 把焦点给字母计数器
+                self.app.active(&Id::LetterCounter).expect("LetterCounter to be mounted");
+                None
+            }
+            Msg::DigitCounterChanged(v) => {
+                // 更新 label
+                self
+                    .app
+                    .attr(
+                        &Id::Label,
+                        Attribute::Text,
+                        AttrValue::String(format!("DigitCounter has now value: {}", v))
+                    )
+                    .expect("Label to be mounted");
+                None
+            }
+            Msg::LetterCounterBlur => {
+                // 把焦点给数字计数器
+                self.app.active(&Id::DigitCounter).expect("DigitCounter to be mounted");
+                None
+            }
+            Msg::LetterCounterChanged(v) => {
+                // 更新 label
+                self
+                    .app
+                    .attr(
+                        &Id::Label,
+                        Attribute::Text,
+                        AttrValue::String(format!("LetterCounter has now value: {}", v))
+                    )
+                    .expect("Label to be mounted");
+                None
+            }
+        }
+    }
+}
+```
+
+如果你熟悉 Elm 的工作方式，这里最大的区别是：`tui-realm` 中的 `update` 是原地修改的，而不是返回一个新的 Model / Clone。
+
+你可能注意到 **更新例程** 是在一个 trait 内部，但 `view` 方法不要求放在 trait 中。严格来说 `update` 方法也不需要放在 trait 中。当前这允许向 `view` 传递额外数据或给它起任何名字。
+这在将来可能会改变。
+
+### 应用设置与主循环
+
+我们几乎完成了，快速创建一个辅助方法来创建 **Application**。这通常放在 `Model` 中：
+
+```rust
+fn init_app() -> Application<Id, Msg, NoUserEvent> {
+    // 设置 application
+    // 注意：NoUserEvent 是一个简写，告诉 tui-realm 我们不使用任何自定义用户事件
+    // 注意：事件监听器被配置为使用默认的 crossterm 输入监听器，
+    //       每 20ms 轮询一次，每次轮询最多收集 3 个事件
+    let mut app: Application<Id, Msg, NoUserEvent> = Application::init(
+        EventListenerCfg::default()
+            .crossterm_input_listener(Duration::from_millis(20), 3),
+    );
+}
+```
+
+app 需要 `EventListener` 的配置，由它来轮询 `Ports`。我们告诉事件监听器使用我们后端的 crossterm 输入监听器。
+
+> ❗ 这里也可以定义其他 Port，或者用 `tick_interval()` 设置 `Tick` 生产者
+
+然后把两个计数器和 label 挂载到 view：
+
+```rust
+app.mount(
+    Id::LetterCounter,
+    Box::new(LetterCounter::new(0)),
+    Vec::default()
+)?;
+app.mount(
+    Id::DigitCounter,
+    Box::new(DigitCounter::new(5)),
+    Vec::default()
+)?;
+app.mount(
+    Id::Label,
+    Box::new(
+        Label::default()
+            .text("Waiting for a Msg...")
+            .alignment(HorizontalAlignment::Left)
+            .foreground(Color::LightYellow)
+            .modifiers(TextModifiers::BOLD),
+    ),
+    Vec::default(),
+)?;
+```
+
+> ❗ 空 vector 是每个组件相关的订阅 (这里都没有)
+
+然后初始化焦点：
+
+```rust
+app.active(&Id::LetterCounter)?;
+```
+
+把这些组合到一个 `Model` 构造函数中：
+
+```rust
+impl Model {
+    // 这也可以是一个 default 实现
+    pub fn new() -> Self {
+        Self {
+            app: Self::init_app().expect("Failed to mount components"),
+            quit: false,
+            redraw: true,
+            terminal: Self::init_adapter().expect("Cannot initialize terminal"),
+        }
+    }
+
+    fn init_app() -> Result<Application<Id, Msg, NoUserEvent>, Box<dyn Error>> { 
+        let mut app: Application<Id, Msg, NoUserEvent> = Application::init(
+            EventListenerCfg::default()
+                .crossterm_input_listener(Duration::from_millis(20), 3),
+        );
+
+        app.mount(
+            Id::LetterCounter,
+            Box::new(LetterCounter::new(0)),
+            Vec::default()
+        )?;
+        app.mount(
+            Id::DigitCounter,
+            Box::new(DigitCounter::new(5)),
+            Vec::default()
+        )?;
+        app.mount(
+            Id::Label,
+            Box::new(
+                Label::default()
+                    .text("Waiting for a Msg...")
+                    .alignment(HorizontalAlignment::Left)
+                    .foreground(Color::LightYellow)
+                    .modifiers(TextModifiers::BOLD),
+            ),
+            Vec::default(),
+        )?;
+
+        app.active(&Id::LetterCounter)?;
+
+        Ok(app)
+    }
+
+    /// 创建后端并进入我们需要的所有模式
+    fn init_adapter() -> TerminalResult<CrosstermTerminalAdapter> {
+        let mut adapter = CrosstermTerminalAdapter::new()?;
+        adapter.enable_raw_mode()?;
+        adapter.enter_alternate_screen()?;
+
+        Ok(adapter)
+    }
+}
+```
+
+最后实现 **主循环**：
+
+```rust
+// 初次绘制，否则我们必须等至少一个事件之后才能绘制任何东西 (否则会保持空白)
+model.view();
+
+while !model.quit {
+    // Tick
+    match model.app.tick(PollStrategy::Once(Duration::from_millis(10))) {
+        Err(err) => {
+            // 处理错误...
+        }
+        Ok(messages) if !messages.is_empty() => {
+            for msg in messages {
+                // 在处理其他消息之前，立即处理 Model 返回的消息
+                let mut msg = Some(msg);
+                while msg.is_some() {
+                    msg = model.update(msg);
+                }
+            }
+        }
+        _ => {}
+    }
+    // 重绘
+    if model.redraw {
+        model.view();
+        model.redraw = false;
+    }
+}
+```
+
+每次循环我们在 application 上调用 `tick()`，策略为 `Once` 并带 10ms 超时，意味着每次循环轮询一次，最多等待 10ms 获取事件。如果有消息，我们让 Model 处理这些消息。处理后只有在 Model 决定需要重绘时才重绘。
+
+> ❗ 还有其他 `PollStrategy` 变体 (`TryFor`、`UpTo`、`BlockCollectUpTo`)，它们会阻塞更长时间或每次 tick 收集更多事件——选择最符合你应用响应性要求的那个。
+
+一旦 `quit` 变为 true，应用终止。
+`tui-realm` 自身提供的所有后端都会在 `Drop` 时自动清理终端模式。
 
 ---
 
 ## 下一步
 
-恭喜！您已经创建了您的第一个 tui-realm 应用。您现在可以：
+现在你知道了 `tui-realm` 的基础。还有更多高级概念可以探索。推荐继续阅读：
 
-- 探索[高级概念](advanced.md)以了解订阅、ports 和其他高级功能
-- 查看[从 tui-realm 0.x 迁移](migrating-legacy.md)指南，如果您有旧版应用
-- 开始构建您自己的应用！
-
-记住，tui-realm 旨在易于学习和使用，所以不要害怕尝试新事物。快乐编码！ 🚀
+- [高级概念](advanced.md)
+- [从 3.x 迁移到 4.0](migrating-4.0.md)
+- [ratatui: The Elm Architecture (TEA)](https://ratatui.rs/concepts/application-patterns/the-elm-architecture/)

--- a/crates/tuirealm/docs/zh-cn/migrating-4.0.md
+++ b/crates/tuirealm/docs/zh-cn/migrating-4.0.md
@@ -1,0 +1,197 @@
+# 从 tui-realm 3.x 迁移
+
+<a href="../en/migrating-4.0.md">English</a> | 📍<u>**简体中文**</u>
+
+- [从 tui-realm 3.x 迁移](#从-tui-realm-3x-迁移)
+  - [简介](#简介)
+
+---
+
+## 简介
+
+本文档是 4.0 发布之前的进行中文档，随着改动的引入逐条列出关键变更。
+
+### ratatui 0.30
+
+`ratatui` 已升级到 0.30，所有破坏性变更请阅读其 [博客文章](https://ratatui.rs/highlights/v030)。
+
+### 用 ratatui 等价类型替换 `TextSpan`
+
+原先的 `tuirealm::props::TextSpan` 已被替换为 `ratatui::text::{Span, Line, Text}`。
+
+由于有了新类型，引入了新的 `AttrValue` 和 `PropValue` 变体：`TextSpan`、`TextLine` 和 `Text`。
+
+### 把 `(String, Alignment)` 标题替换为真正的结构体
+
+原先的 `(String, Alignment)` 元组已被功能更完整的 `Title` struct 替换。
+
+由于 title 现在底层使用 `Line`，现在可以对标题中的单个字符做样式处理。
+
+### 移除 `PropPayload` 和 `State` 的 `Tup3`、`Tup4` 变体
+
+`PropPayload` 和 `State` 的 3 元与 4 元元组变体被移除，因为它们会膨胀枚举大小，而实际上几乎没人使用。
+
+如果仍需多种类型，可使用 `PropPayload::Vec`，或为更具描述性的字段使用 `PropPayload::Any` 承载自定义结构体。
+
+### 将 `PropPayload` 和 `State` 的 `Tup2` 变体重命名为 `Pair`
+
+既然其他元组变体都已移除，把 `Tup2` 重命名为 `Pair` 更具描述性。
+
+### 将 `PropPayload` 和 `State` 的 `One` 变体重命名为 `Single`
+
+由于 `Tup2` 改名为 `Pair`，并考虑到其他变体，`Single` 比 `One` 更符合命名规范。
+
+### Attribute `Alignment` 拆分为水平与垂直
+
+为与 ratatui `0.30` 把 `Alignment` 改名为 `HorizontalAlignment` 的变化保持一致，`tui-realm` 将原有的 Attribute `Alignment` 改名为 `AlignmentHorizontal`，并新增一个名为 `AlignmentVertical` 的属性对应 `VerticalAlignment`。
+
+### 移除 Dataset 相关值
+
+`Dataset` 实际上只被 `tui_realm_stdlib::components::Chart` 使用，而且即便如此也不需要存在 `Props` 中，因此可以轻松改为通过 `PropPayload::Any` 承载。
+
+### 移除 `Props::get`(旧) 和 `Props::get_or`
+
+`Props::get` 被移除，改用 `Props::get_ref`，以与 `Vec::get` 等标准库类型的返回类型保持一致。
+这也让克隆对用户更显式。
+
+`Props::get_or` 被移除，因为它依赖 `Props::get`，而无法合理地改造为使用 `Props::get_ref`。
+
+### 将 `Props::get_ref` 重命名为 `Props::get`
+
+由于旧 `Props::get` 已被移除，并为了更好地与 `Vec::get` 等标准库类型对齐，`::get_ref` 被重命名为 `::get`。
+
+### `Component::on` 的 `Event` 参数现为引用
+
+在 4.0 中，`Component::on` 的 `Event` 参数现在是引用。这让我们得以移除此前一直进行的中间克隆，现在是否克隆由用户决定。
+
+### `termion` 后端 / 适配器变更
+
+`termion` 后端适配器已重构，以更契合 `termion` 的工作方式。
+
+实际上意味着 `new` 不再存在，取而代之的是更具体的新函数：
+
+- `new_raw`
+- `new_alternate_raw`
+- `new_mouse_alternate_raw`
+- `new_mouse_raw`
+
+此外，`TerminalBridge::new_termion` 和 `init_termion` 已被移除，改用 `TerminalBridge::new_init_termion`。
+
+### 移除 `PropBoundExt`
+
+`as_any` 和 `as_any_mut` 现在直接在 `dyn PropBound` 上实现，不再需要额外导入另一个 trait。
+
+### `Poll` 返回类型变更
+
+在 4.0 中，`Poll::poll` 和 `PollAsync::poll` 的返回类型从 `ListenerResult` 改为 `PortResult`。
+由此带来的新 `PortError` 可以提供更多关于发生什么的上下文。它还支持标明错误是 Intermittent (应再次轮询) 还是 Permanent (应停止该 port)。
+
+这是因为 `ListenerError` 的变体大多是内部使用的。
+`ListenerResult` 也被改为非公开。
+
+### `poll` 使用独立的错误类型
+
+除了 [`*Poll::poll` 返回类型变更](#poll-返回类型变更)，`ApplicationError` 新增了专门的 `Poll` 变体，不再与 Listener 启动/停止错误混用。
+
+### 把 `PollStrategy::UpToNoWait` 改为 `PollStrategy::UpTo`
+
+旧的 `PollStrategy::UpTo` 被移除，由原先叫 `PollStrategy::UpToNoWait` 的替代。
+
+这样改是因为 "对每个 N 等待 TIMEOUT，如果有事件可用" 这种行为对事件驱动型 tui 应用并不实用。
+(新的 `UpTo`，即以前的 `UpToNoWait`，会 "等待 TIMEOUT 一次，收集事件，之后在有事件可用时最多再收集 N-1 个事件 (不再阻塞)")
+
+### Poll timeout 移至 `PollStrategy` 中
+
+此前保存在 `EventListener(Cfg|Builder)` 上的 timeout 被移至 `PollStrategy`。
+这样做是因为某些策略根本不使用 timeout，而另一些策略对该时长有不同的含义。
+
+### 移除 `TerminalBridge`
+
+`TerminalBridge` 包装器被移除，因为相比直接使用后端或直接使用 trait 它并没有带来任何好处。
+
+Panic handler 和 restore 现在在各后端上按需实现。
+各后端的具体说明见相应后端的 `Restore` 和 `On Panic` 小节。
+
+### 移除 `Update` trait
+
+为与 `view` 等其他 "外部" 函数保持一致，决定移除 `Update` trait，因为它从未真正作为任何地方的 bounds 被要求。
+
+这使它与之前也没有 trait 的 `view` 等函数保持一致。
+同时允许自定义 `update` 函数的调用方式，例如如果你从不返回消息用于递归处理，就可以省略。
+
+迁移非常简单，把 `impl Update for Model` 改为 `impl Model`，并可能将可见性改为 `pub fn`。
+
+### 导出清理：要求按模块限定导入
+
+`tuirealm` 和 `tui-realm-stdlib` 中根级的 re-export 已被移除。现在必须通过模块路径导入类型：
+
+```rust
+// 之前 (3.x)
+use tuirealm::{Application, Component, MockComponent, Event, State, Frame};
+
+// 之后 (4.0)
+use tuirealm::application::Application;
+use tuirealm::component::{AppComponent, Component};
+use tuirealm::event::Event;
+use tuirealm::state::State;
+use tuirealm::ratatui::Frame;
+```
+
+对于 `tui-realm-stdlib`，组件类型现在位于 `components` 下：
+
+```rust
+// 之前
+use tui_realm_stdlib::Input;
+
+// 之后
+use tui_realm_stdlib::components::Input;
+```
+
+### `MockComponent` 重命名为 `Component`
+
+`Component` trait (事件处理) 已重命名为 `AppComponent`。
+`MockComponent` trait (渲染、state、props) 已重命名为 `Component`。
+派生宏 `#[derive(MockComponent)]` 改为 `#[derive(Component)]`，以匹配新的 `Component` 名称。
+
+```rust
+// 之前 (3.x)
+use tuirealm::{MockComponent, Component};
+
+#[derive(MockComponent)]
+struct MyWidget { component: Input }
+
+impl Component<Msg, UserEvent> for MyWidget {
+    fn on(&mut self, ev: Event<UserEvent>) -> Option<Msg> { ... }
+}
+
+// 之后 (4.0)
+use tuirealm::component::{AppComponent, Component};  // traits
+
+#[derive(Component)]
+struct MyWidget { component: Input }
+
+impl AppComponent<Msg, UserEvent> for MyWidget {
+    fn on(&mut self, ev: &Event<UserEvent>) -> Option<Msg> { ... }
+}
+```
+
+### 将 `Component::query` 改为返回借用内容
+
+`Component::query` 被修改为允许并倾向于返回借用内容，但仍支持返回拥有所有权的内容。
+这让消费者可以决定何时真正需要克隆，除 `PropPayload::Any` 外几乎任何情况都不再强制克隆。
+
+### 将 `CmdResult::None` 重命名为 `CmdResult::NoChange`
+
+`CmdResult` 的 `None` 变体被重命名为 `NoChange`，让该变体的含义一眼更清晰。
+
+### 将 `Attribute::FocusStyle` 重命名为 `Attribute::UnfocusedBorderStyle`
+
+`Attribute` 的 `FocusStyle` 变体被重命名为 `UnfocusedBorderStyle`，更能一眼看出该属性的作用。
+
+### 将 `Attribute::HighlightColor` 重命名为 `Attribute::HighlightStyle`
+
+`Attribute` 的 `HighlightColor` 变体被移除，取而代之添加了 `HighlightStyle`，以完整配置样式 (含 modifiers) 而不仅是颜色。
+
+### 将 `::highlighted_*` 函数重命名为 `::highlight_*`
+
+为命名一致并与 `ratatui` 中的函数名对齐，所有 `highlighted_*` 函数 (例如 `::highlighted_str`) 改为 `highlight_*` (例如 `::highlight_str`)。


### PR DESCRIPTION
## Summary

- Fix stale API references across `get-started.md` and `advanced.md` so code samples compile against 4.0
- Retranslate `zh-cn/get-started.md` and `zh-cn/advanced.md` from the corrected English sources (prior versions had wrong concepts and non-existent APIs)
- Add `zh-cn/migrating-4.0.md` translation, cross-link en/zh

Closes #126

## Key fixes (English)

- `get_or(...).unwrap_X()` → `get(...).and_then(AttrValue::as_X).unwrap_or(default)`
- `State::One` → `State::Single`
- `PollStrategy::BlockingUpTo` → `PollStrategy::Once(Duration)`
- `crossterm_input_listener(Duration)` → `crossterm_input_listener(Duration, usize)`
- `f.size()` → `f.area()`
- `AttrValue::Title((String, Alignment))` → `AttrValue::Title(Title::from(...).alignment(...))`
- `Props::get_as_ref` → `Props::get_for_query`
- `SubEventClause` → `EventClause`
- `PropPayload::unwrap_one` → `unwrap_single`
- `Counter` now derives `Default`; `Id` gains `Label` variant so update handler targets exist
- Fixed undefined `style`/`alignment` variables, `DarkGrey` typo, broken title fetch

## Test plan

- [ ] Skim rendered `en/get-started.md` end to end
- [ ] Skim rendered `zh-cn/get-started.md` for formatting
- [ ] Verify code blocks conceptually match demo example at `crates/tuirealm/examples/demo/`
- [ ] Confirm cross-language links resolve on GitHub UI