### PR TITLE
Fix current build errors & warnings

### DIFF
--- a/crates/tuirealm-derive/tests/component_derive.rs
+++ b/crates/tuirealm-derive/tests/component_derive.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code)] // practically just compile tests
 
 use tuirealm::command::{Cmd, CmdResult};
-use tuirealm::component::Component;
 use tuirealm::props::{AttrValue, Attribute, QueryResult};
 use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::Rect;
@@ -10,7 +9,7 @@ use tuirealm_derive::Component;
 
 struct Stub;
 
-impl Component for Stub {
+impl tuirealm::component::Component for Stub {
     fn view(&mut self, _frame: &mut Frame, _area: Rect) {}
 
     fn query(&self, _attr: Attribute) -> Option<QueryResult<'_>> {

--- a/crates/tuirealm/src/terminal/event_listener.rs
+++ b/crates/tuirealm/src/terminal/event_listener.rs
@@ -24,11 +24,13 @@ pub use test::TestEventListener;
 
 #[allow(unused_imports)] // used in the event listeners
 use crate::event::Event;
-use crate::listener::PortError;
 
 /// Convert [`io::Error`](std::io::Error) to a [`PortError`], with correct Intermittent & Permanent Mapping
-fn io_err_to_port_err(err: std::io::Error) -> PortError {
+#[cfg(any(feature = "crossterm", feature = "termion"))]
+fn io_err_to_port_err(err: std::io::Error) -> crate::listener::PortError {
     use std::io::ErrorKind;
+
+    use crate::listener::PortError;
 
     match err.kind() {
         ErrorKind::Interrupted
@@ -43,13 +45,14 @@ fn io_err_to_port_err(err: std::io::Error) -> PortError {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, any(feature = "crossterm", feature = "termion")))]
 mod tests {
     use std::io::{Error as ioError, ErrorKind};
 
     use pretty_assertions::assert_eq;
 
     use super::*;
+    use crate::listener::PortError;
 
     #[test]
     fn should_map_to_intermittend() {


### PR DESCRIPTION
## Description

This PR fixes tests not compiling due to duplicate name import. Also fixes a "dead code" warning.

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
