### PR TITLE
Add a ability to have different highlight style when unfocused

### DIFF
--- a/crates/tuirealm-stdlib/examples/table.rs
+++ b/crates/tuirealm-stdlib/examples/table.rs
@@ -9,7 +9,7 @@ use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::component::{AppComponent, Component};
 use tuirealm::event::{Event, Key, KeyEvent, NoUserEvent};
 use tuirealm::props::{
-    BorderType, Borders, Color, HorizontalAlignment, Style, TableBuilder, Title,
+    BorderType, Borders, Color, HorizontalAlignment, Style, TableBuilder, TextModifiers, Title,
 };
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
 use tuirealm::ratatui::text::Line;
@@ -129,7 +129,12 @@ impl Default for TableAlfa {
                 .inactive(Style::new().fg(Color::Gray))
                 .title(Title::from("Keybindings").alignment(HorizontalAlignment::Center))
                 .scroll(true)
-                .highlight_style(Style::new().fg(Color::LightYellow))
+                .highlight_style(
+                    Style::new()
+                        .fg(Color::LightYellow)
+                        .add_modifier(TextModifiers::REVERSED),
+                )
+                .highlight_style_inactive(Style::new().remove_modifier(TextModifiers::REVERSED))
                 .highlight_str("🚀")
                 .rewind(true)
                 .step(4)

--- a/crates/tuirealm-stdlib/src/components/checkbox.rs
+++ b/crates/tuirealm-stdlib/src/components/checkbox.rs
@@ -170,11 +170,17 @@ impl Checkbox {
         self
     }
 
-    /// Set a custom highlight style that is patched ontop of the normal style.
+    /// Set a custom highlight style that is patched on-top of the normal style.
     ///
     /// By default the highlight style is just `Style::new().add_modifier(Modifier::REVERSED)`.
     pub fn highlight_style(mut self, s: Style) -> Self {
         self.attr(Attribute::HighlightStyle, AttrValue::Style(s));
+        self
+    }
+
+    /// Set a custom highlight style that is patched on-top of the highlight style when unfocused.
+    pub fn highlight_style_inactive(mut self, s: Style) -> Self {
+        self.attr(Attribute::HighlightStyleUnfocused, AttrValue::Style(s));
         self
     }
 
@@ -245,11 +251,11 @@ impl Component for Checkbox {
             .collect();
         let mut widget: Tabs = Tabs::new(choices)
             .select(self.states.choice)
-            .style(self.common.style);
-
-        if self.common.is_active() {
-            widget = widget.highlight_style(self.common_hg.get_style(self.common.style));
-        }
+            .style(self.common.style)
+            .highlight_style(
+                self.common_hg
+                    .get_style_focus(self.common.style, self.common.is_active()),
+            );
 
         if let Some(block) = self.common.get_block() {
             widget = widget.block(block);

--- a/crates/tuirealm-stdlib/src/components/list.rs
+++ b/crates/tuirealm-stdlib/src/components/list.rs
@@ -176,11 +176,17 @@ impl List {
         self
     }
 
-    /// Set a custom highlight style that is patched ontop of the normal style.
+    /// Set a custom highlight style that is patched on-top of the normal style.
     ///
     /// By default the highlight style is just `Style::new().add_modifier(Modifier::REVERSED)`.
     pub fn highlight_style(mut self, s: Style) -> Self {
         self.attr(Attribute::HighlightStyle, AttrValue::Style(s));
+        self
+    }
+
+    /// Set a custom highlight style that is patched on-top of the highlight style when unfocused.
+    pub fn highlight_style_inactive(mut self, s: Style) -> Self {
+        self.attr(Attribute::HighlightStyleUnfocused, AttrValue::Style(s));
         self
     }
 
@@ -255,11 +261,11 @@ impl Component for List {
         // Make the widget
         let mut widget = TuiList::new(list_items)
             .style(self.common.style)
-            .direction(tuirealm::ratatui::widgets::ListDirection::TopToBottom);
-
-        if self.common.is_active() {
-            widget = widget.highlight_style(self.common_hg.get_style(self.common.style));
-        }
+            .direction(tuirealm::ratatui::widgets::ListDirection::TopToBottom)
+            .highlight_style(
+                self.common_hg
+                    .get_style_focus(self.common.style, self.common.is_active()),
+            );
 
         if let Some(block) = self.common.get_block() {
             widget = widget.block(block);

--- a/crates/tuirealm-stdlib/src/components/radio.rs
+++ b/crates/tuirealm-stdlib/src/components/radio.rs
@@ -149,11 +149,17 @@ impl Radio {
         self
     }
 
-    /// Set a custom highlight style that is patched ontop of the normal style.
+    /// Set a custom highlight style that is patched on-top of the normal style.
     ///
     /// By default the highlight style is just `Style::new().add_modifier(Modifier::REVERSED)`.
     pub fn highlight_style(mut self, s: Style) -> Self {
         self.attr(Attribute::HighlightStyle, AttrValue::Style(s));
+        self
+    }
+
+    /// Set a custom highlight style that is patched on-top of the highlight style when unfocused.
+    pub fn highlight_style_inactive(mut self, s: Style) -> Self {
+        self.attr(Attribute::HighlightStyleUnfocused, AttrValue::Style(s));
         self
     }
 
@@ -218,15 +224,11 @@ impl Component for Radio {
 
         let mut widget = Tabs::new(choices)
             .select(self.states.choice)
-            .style(self.common.style);
-
-        if self.common.is_active() {
-            widget = widget.highlight_style(self.common_hg.get_style(self.common.style));
-        } else {
-            // for some reason, it seems like "Tabs" has a default "REVERSED" set for the highlight style
-            // at least as of ratatui-widgets 0.30
-            widget = widget.highlight_style(Style::default());
-        }
+            .style(self.common.style)
+            .highlight_style(
+                self.common_hg
+                    .get_style_focus(self.common.style, self.common.is_active()),
+            );
 
         if let Some(block) = self.common.get_block() {
             widget = widget.block(block);

--- a/crates/tuirealm-stdlib/src/components/select.rs
+++ b/crates/tuirealm-stdlib/src/components/select.rs
@@ -169,11 +169,17 @@ impl Select {
         self
     }
 
-    /// Set a custom highlight style that is patched ontop of the normal style.
+    /// Set a custom highlight style that is patched on-top of the normal style.
     ///
     /// By default the highlight style is just `Style::new().add_modifier(Modifier::REVERSED)`.
     pub fn highlight_style(mut self, s: Style) -> Self {
         self.attr(Attribute::HighlightStyle, AttrValue::Style(s));
+        self
+    }
+
+    /// Set a custom highlight style that is patched on-top of the highlight style when unfocused.
+    pub fn highlight_style_inactive(mut self, s: Style) -> Self {
+        self.attr(Attribute::HighlightStyleUnfocused, AttrValue::Style(s));
         self
     }
 
@@ -229,11 +235,11 @@ impl Select {
         // Make list
         let mut widget = List::new(choices)
             .direction(ListDirection::TopToBottom)
-            .style(self.common.style);
-
-        if self.common.is_active() {
-            widget = widget.highlight_style(self.common_hg.get_style(self.common.style));
-        }
+            .style(self.common.style)
+            .highlight_style(
+                self.common_hg
+                    .get_style_focus(self.common.style, self.common.is_active()),
+            );
 
         if let Some(symbol) = self.common_hg.get_symbol() {
             widget = widget.highlight_symbol(symbol);

--- a/crates/tuirealm-stdlib/src/components/table.rs
+++ b/crates/tuirealm-stdlib/src/components/table.rs
@@ -174,11 +174,17 @@ impl Table {
         self
     }
 
-    /// Set a custom highlight style that is patched ontop of the normal style.
+    /// Set a custom highlight style that is patched on-top of the normal style.
     ///
     /// By default the highlight style is just `Style::new().add_modifier(Modifier::REVERSED)`.
     pub fn highlight_style(mut self, s: Style) -> Self {
         self.attr(Attribute::HighlightStyle, AttrValue::Style(s));
+        self
+    }
+
+    /// Set a custom highlight style that is patched on-top of the highlight style when unfocused.
+    pub fn highlight_style_inactive(mut self, s: Style) -> Self {
+        self.attr(Attribute::HighlightStyleUnfocused, AttrValue::Style(s));
         self
     }
 
@@ -346,11 +352,12 @@ impl Component for Table {
         let rows: Vec<Row> = self.make_rows(row_height);
         let widths: Vec<Constraint> = self.layout();
 
-        let mut widget = TuiTable::new(rows, &widths).style(self.common.style);
-
-        if self.common.is_active() {
-            widget = widget.row_highlight_style(self.common_hg.get_style(self.common.style));
-        }
+        let mut widget = TuiTable::new(rows, &widths)
+            .style(self.common.style)
+            .row_highlight_style(
+                self.common_hg
+                    .get_style_focus(self.common.style, self.common.is_active()),
+            );
 
         if let Some(block) = self.common.get_block() {
             widget = widget.block(block);

--- a/crates/tuirealm-stdlib/src/prop_ext.rs
+++ b/crates/tuirealm-stdlib/src/prop_ext.rs
@@ -150,6 +150,8 @@ impl CommonProps {
 pub struct CommonHighlight {
     /// The main style to patch [`CommonProps::style`] with for the currently active element.
     pub style: Style,
+    /// A Style to patch on-top of [`style`](Self::style) when unfocused.
+    pub style_unfocused: Style,
     /// The symbol to use to indicate the currently selected element.
     pub symbol: LineStatic,
 }
@@ -158,6 +160,7 @@ impl Default for CommonHighlight {
     fn default() -> Self {
         Self {
             style: Style::default().add_modifier(TextModifiers::REVERSED),
+            style_unfocused: Style::default(),
             symbol: LineStatic::default(),
         }
     }
@@ -168,6 +171,9 @@ impl CommonHighlight {
     pub fn set(&mut self, attr: Attribute, value: AttrValue) -> Option<AttrValue> {
         match (attr, value) {
             (Attribute::HighlightStyle, AttrValue::Style(val)) => self.style = val,
+            (Attribute::HighlightStyleUnfocused, AttrValue::Style(val)) => {
+                self.style_unfocused = val
+            }
             (Attribute::HighlightedStr, AttrValue::TextLine(val)) => self.symbol = val,
 
             // other
@@ -181,6 +187,7 @@ impl CommonHighlight {
     pub fn get<'a>(&'a self, attr: Attribute) -> Option<AttrValueRef<'a>> {
         match attr {
             Attribute::HighlightStyle => Some(AttrValueRef::Style(self.style)),
+            Attribute::HighlightStyleUnfocused => Some(AttrValueRef::Style(self.style_unfocused)),
             Attribute::HighlightedStr => Some(AttrValueRef::TextLine(&self.symbol)),
 
             // other
@@ -194,6 +201,7 @@ impl CommonHighlight {
         self.get(attr).map(QueryResult::Borrowed)
     }
 
+    /// Get the set highlight symbol as its own `Line` instance, but referencing the existing data.
     pub fn get_symbol(&self) -> Option<Line<'_>> {
         if self.symbol.spans.is_empty() {
             None
@@ -202,9 +210,22 @@ impl CommonHighlight {
         }
     }
 
+    /// Get the patched highlight style.
     #[inline]
     pub fn get_style(&self, normal_style: Style) -> Style {
         normal_style.patch(self.style)
+    }
+
+    /// Get the patched highlight style with focused or unfocused style.
+    #[inline]
+    pub fn get_style_focus(&self, normal_style: Style, focus: bool) -> Style {
+        let style = normal_style.patch(self.style);
+
+        if focus {
+            style
+        } else {
+            style.patch(self.style_unfocused)
+        }
     }
 }
 
@@ -482,6 +503,13 @@ mod tests {
         );
         assert_eq!(
             props
+                .get(Attribute::HighlightStyleUnfocused)
+                .unwrap()
+                .unwrap_style(),
+            Style::new()
+        );
+        assert_eq!(
+            props
                 .get(Attribute::HighlightedStr)
                 .unwrap()
                 .unwrap_textline(),
@@ -508,6 +536,20 @@ mod tests {
             Style::new()
                 .fg(Color::Blue)
                 .add_modifier(TextModifiers::DIM)
+        );
+
+        // style unfocused via highlight style attribute
+        props.set(
+            Attribute::HighlightStyleUnfocused,
+            AttrValue::Style(Style::new().remove_modifier(TextModifiers::DIM)),
+        );
+
+        assert_eq!(
+            props
+                .get(Attribute::HighlightStyleUnfocused)
+                .unwrap()
+                .unwrap_style(),
+            Style::new().remove_modifier(TextModifiers::DIM)
         );
 
         // symbol via highlight symbol attribute

--- a/crates/tuirealm-treeview/src/lib.rs
+++ b/crates/tuirealm-treeview/src/lib.rs
@@ -333,11 +333,17 @@ impl<V: NodeValue> TreeView<V> {
         self
     }
 
-    /// Set a custom highlight style that is patched ontop of the normal style.
+    /// Set a custom highlight style that is patched on-top of the normal style.
     ///
     /// By default the highlight style is just `Style::new().add_modifier(Modifier::REVERSED)`.
     pub fn highlight_style(mut self, s: Style) -> Self {
         self.attr(Attribute::HighlightStyle, AttrValue::Style(s));
+        self
+    }
+
+    /// Set a custom highlight style that is patched on-top of the highlight style when unfocused.
+    pub fn highlight_style_inactive(mut self, s: Style) -> Self {
+        self.attr(Attribute::HighlightStyleUnfocused, AttrValue::Style(s));
         self
     }
 
@@ -434,7 +440,10 @@ impl<V: NodeValue> Component for TreeView<V> {
         let mut tree = TreeWidget::new(self.tree())
             .indent_size(indent_size.into())
             .style(self.common.style)
-            .highlight_style(self.common_hg.get_style(self.common.style));
+            .highlight_style(
+                self.common_hg
+                    .get_style_focus(self.common.style, self.common.is_active()),
+            );
 
         if let Some(block) = block {
             tree = tree.block(block);

--- a/crates/tuirealm/src/core/props/mod.rs
+++ b/crates/tuirealm/src/core/props/mod.rs
@@ -80,6 +80,8 @@ pub enum Attribute {
     HighlightedStr,
     /// Style to patch [`Style`](Self::Style) with to apply on the highlighted element.
     HighlightStyle,
+    /// Style to patch on-top of [`HighlightStyle`](Self::HighlightStyle) to modify for unfocused state.
+    HighlightStyleUnfocused,
     /// Maximum input length for input fields
     InputLength,
     /// Input type for input fields


### PR DESCRIPTION
## Description

This PR adds a way to modify the highlight style when the components is not "active", for example to remove the modifier `REVERSED` but allow the color to stay.
The `table` example has been modified to showcase the usage.
Though due to this change, the highlight style drawing is now always active by default, regardless of if focused or not, unless overwritten. Aside from that, there should be no breaking changes.

Only now that 4.0.0 has been released, have i come around to actually update `termusic` to tuirealm 4.0.0, and there i found a usability regression: Highlights (modifiers & colors) were gone if the component was not focused anymore, but the symbol as still there, which is harder to see than still having color.

PS: more PRs of this kind may come, so i would recommend to not release a version immediately.

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
