### PR TITLE
Fix `Table` not respecting Row's Line style

### DIFF
--- a/crates/tuirealm-stdlib/examples/table.rs
+++ b/crates/tuirealm-stdlib/examples/table.rs
@@ -115,6 +115,9 @@ struct TableAlfa {
     component: Table,
 }
 
+/// Define the style once and re-use it. Saves on some characters and lines.
+const STYLE_BOLD: Style = Style::new().bold();
+
 impl Default for TableAlfa {
     fn default() -> Self {
         Self {
@@ -144,31 +147,31 @@ impl Default for TableAlfa {
                 .widths(&[30, 20, 50])
                 .table(
                     TableBuilder::default()
-                        .add_col(Line::from("KeyCode::Down"))
+                        .add_col(Line::styled("KeyCode::Down", STYLE_BOLD))
                         .add_col(Line::from("OnKey"))
                         .add_col(Line::from("Move cursor down"))
                         .add_row()
-                        .add_col(Line::from("KeyCode::Up"))
+                        .add_col(Line::styled("KeyCode::Up", STYLE_BOLD))
                         .add_col(Line::from("OnKey"))
                         .add_col(Line::from("Move cursor up"))
                         .add_row()
-                        .add_col(Line::from("KeyCode::PageDown"))
+                        .add_col(Line::styled("KeyCode::PageDown", STYLE_BOLD))
                         .add_col(Line::from("OnKey"))
                         .add_col(Line::from("Move cursor down by 8"))
                         .add_row()
-                        .add_col(Line::from("KeyCode::PageUp"))
+                        .add_col(Line::styled("KeyCode::PageUp", STYLE_BOLD))
                         .add_col(Line::from("OnKey"))
                         .add_col(Line::from("Move cursor up by 8"))
                         .add_row()
-                        .add_col(Line::from("KeyCode::End"))
+                        .add_col(Line::styled("KeyCode::End", STYLE_BOLD))
                         .add_col(Line::from("OnKey"))
                         .add_col(Line::from("Move cursor to last item"))
                         .add_row()
-                        .add_col(Line::from("KeyCode::Home"))
+                        .add_col(Line::styled("KeyCode::Home", STYLE_BOLD))
                         .add_col(Line::from("OnKey"))
                         .add_col(Line::from("Move cursor to first item"))
                         .add_row()
-                        .add_col(Line::from("KeyCode::Char(_)"))
+                        .add_col(Line::styled("KeyCode::Char(_)", STYLE_BOLD))
                         .add_col(Line::from("OnKey"))
                         .add_col(Line::from("Return pressed key"))
                         .build(),

--- a/crates/tuirealm-stdlib/src/components/table.rs
+++ b/crates/tuirealm-stdlib/src/components/table.rs
@@ -10,13 +10,12 @@ use tuirealm::props::{
 };
 use tuirealm::ratatui::Frame;
 use tuirealm::ratatui::layout::{Constraint, Rect};
-use tuirealm::ratatui::text::Line;
 use tuirealm::ratatui::widgets::{Cell, Row, Table as TuiTable, TableState};
 use tuirealm::state::{State, StateValue};
 
 use super::props::TABLE_COLUMN_SPACING;
 use crate::prop_ext::{CommonHighlight, CommonProps};
-use crate::utils;
+use crate::utils::borrow_clone_line;
 
 // -- States
 
@@ -321,15 +320,7 @@ impl Table {
             .map(|row| {
                 let columns: Vec<Cell> = row
                     .iter()
-                    .map(|col| {
-                        let line = Line::from(
-                            col.spans
-                                .iter()
-                                .map(utils::borrow_clone_span)
-                                .collect::<Vec<_>>(),
-                        );
-                        Cell::from(line)
-                    })
+                    .map(|col| Cell::from(borrow_clone_line(col)))
                     .collect();
                 Row::new(columns).height(row_height)
             })
@@ -532,6 +523,7 @@ mod tests {
 
     use pretty_assertions::assert_eq;
     use tuirealm::props::{HorizontalAlignment, TableBuilder};
+    use tuirealm::ratatui::text::Line;
 
     use super::*;
 


### PR DESCRIPTION
~~Depend on #219~~

## Description

I just noticed that a `Table`'s row `Line` does not keep the set style (on the `Line` directly) when drawing.
Also modifies the `table` example to apply some styling to a column.

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
